### PR TITLE
feat(account): 회원 관련 객체를 만든다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 	implementation 'org.springframework.ai:spring-ai-pdf-document-reader'
 	implementation 'org.springframework.ai:spring-ai-tika-document-reader'
 
+	// SendGrid(Email)
+	implementation 'com.sendgrid:sendgrid-java:4.4.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/deskit/deskit/account/dto/PendingSignupResponse.java
+++ b/src/main/java/com/deskit/deskit/account/dto/PendingSignupResponse.java
@@ -1,0 +1,20 @@
+package com.deskit.deskit.account.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class PendingSignupResponse {
+
+    // provider + providerId로 된 이름
+    private String username;
+
+    // provider상 이름
+    private String name;
+
+    // provider 제공 이메일
+    private String email;
+}

--- a/src/main/java/com/deskit/deskit/account/dto/SocialSignupRequest.java
+++ b/src/main/java/com/deskit/deskit/account/dto/SocialSignupRequest.java
@@ -1,0 +1,39 @@
+package com.deskit.deskit.account.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SocialSignupRequest {
+
+    // 판매자 또는 일반회원
+    private String memberType;
+
+    // 전화번호
+    private String phoneNumber;
+
+    // 일반회원 MBTI
+    private String mbti;
+
+    // 일반회원 직업 카테고리
+    private String jobCategory;
+
+    // 판매자 사업자등록번호
+    private String businessNumber;
+
+    // 판매자 사업자명(상호명)
+    private String companyName;
+
+    // 판매자 설명
+    private String description;
+
+    // 사업계획서(Base-64 인코딩)
+    private String planFileBase64;
+
+    // 초대 토큰
+    private String inviteToken;
+
+    // 약관 동의 체크
+    private boolean isAgreed;
+}

--- a/src/main/java/com/deskit/deskit/account/dto/UserDTO.java
+++ b/src/main/java/com/deskit/deskit/account/dto/UserDTO.java
@@ -1,0 +1,21 @@
+package com.deskit.deskit.account.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class UserDTO {
+
+    private String role;
+    private String name;
+    private String username;
+
+    // Email from the social provider.
+    private String email;
+
+    // Flag to indicate social user needs extra signup data.
+    private boolean newUser;
+}

--- a/src/main/java/com/deskit/deskit/account/entity/CompanyRegistered.java
+++ b/src/main/java/com/deskit/deskit/account/entity/CompanyRegistered.java
@@ -1,0 +1,37 @@
+package com.deskit.deskit.account.entity;
+
+import com.deskit.deskit.account.enums.CompanyStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "company_registered")
+public class CompanyRegistered {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "company_id")
+    private Long companyId;
+
+    @Column(name = "company_name", nullable = false)
+    private String companyName;
+
+    @Column(name = "business_number", nullable = false)
+    private String businessNumber;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "company_status", nullable = false)
+    private CompanyStatus companyStatus;
+}

--- a/src/main/java/com/deskit/deskit/account/entity/Invitation.java
+++ b/src/main/java/com/deskit/deskit/account/entity/Invitation.java
@@ -1,0 +1,43 @@
+package com.deskit.deskit.account.entity;
+
+import com.deskit.deskit.account.enums.InvitationStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "invitation")
+public class Invitation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "invitation_id")
+    private Long invitationId;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "status", nullable = false)
+    private InvitationStatus status;
+
+    @Column(name = "token", nullable = false)
+    private String token;
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+}

--- a/src/main/java/com/deskit/deskit/account/entity/Member.java
+++ b/src/main/java/com/deskit/deskit/account/entity/Member.java
@@ -1,0 +1,59 @@
+package com.deskit.deskit.account.entity;
+
+import com.deskit.deskit.account.enums.JobCategory;
+import com.deskit.deskit.account.enums.MBTI;
+import com.deskit.deskit.account.enums.MemberStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "login_id", nullable = false)
+    private String loginId;
+
+    @Column(name = "profile")
+    private String profile;
+
+    @Column(name = "phone", nullable = false)
+    private String phone;
+
+    @Column(name = "is_agreed", nullable = false)
+    private boolean isAgreed;
+
+    @Column(name = "status", nullable = false)
+    private MemberStatus status;
+
+    @Column(name = "role", nullable = false)
+    private String role;
+
+    @Column(name = "mbti")
+    private MBTI mbti;
+
+    @Column(name = "job_category")
+    private JobCategory jobCategory;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/deskit/deskit/account/entity/Seller.java
+++ b/src/main/java/com/deskit/deskit/account/entity/Seller.java
@@ -1,0 +1,51 @@
+package com.deskit.deskit.account.entity;
+
+import com.deskit.deskit.account.enums.SellerRole;
+import com.deskit.deskit.account.enums.SellerStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "seller")
+public class Seller {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "seller_id")
+    private Long sellerId;
+
+    @Column(name = "seller_status")
+    private SellerStatus sellerStatus;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "login_id", nullable = false)
+    private String loginId;
+
+    @Column(name = "profile")
+    private String profile;
+
+    @Column(name = "phone", nullable = false)
+    private String phone;
+
+    @Column(name = "role", nullable = false)
+    private SellerRole role;
+}

--- a/src/main/java/com/deskit/deskit/account/entity/SellerGrade.java
+++ b/src/main/java/com/deskit/deskit/account/entity/SellerGrade.java
@@ -1,0 +1,45 @@
+package com.deskit.deskit.account.entity;
+
+import com.deskit.deskit.account.enums.SellerGradeEnum;
+import com.deskit.deskit.account.enums.SellerGradeStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "seller_grade")
+public class SellerGrade {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "grade_id")
+    private Long gradeId;
+
+    @Column(name = "grade")
+    private SellerGradeEnum grade;
+
+    @Column(name = "grade_status")
+    private SellerGradeStatus gradeStatus;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt;
+
+    @Column(name = "company_id")
+    private Long companyId;
+}

--- a/src/main/java/com/deskit/deskit/account/entity/SellerRegister.java
+++ b/src/main/java/com/deskit/deskit/account/entity/SellerRegister.java
@@ -1,0 +1,32 @@
+package com.deskit.deskit.account.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "seller_register")
+public class SellerRegister {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "register_id")
+    private Long registerId;
+
+    @Lob
+    @Column(name = "plan_file", columnDefinition = "LONGBLOB")
+    private byte[] planFile;
+
+    @Column(name = "seller_id")
+    private Long sellerId;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "company_name")
+    private String companyName;
+}

--- a/src/main/java/com/deskit/deskit/account/enums/CompanyStatus.java
+++ b/src/main/java/com/deskit/deskit/account/enums/CompanyStatus.java
@@ -1,0 +1,6 @@
+package com.deskit.deskit.account.enums;
+
+public enum CompanyStatus {
+    ACTIVE,
+    DELETED
+}

--- a/src/main/java/com/deskit/deskit/account/enums/InvitationStatus.java
+++ b/src/main/java/com/deskit/deskit/account/enums/InvitationStatus.java
@@ -1,0 +1,7 @@
+package com.deskit.deskit.account.enums;
+
+public enum InvitationStatus {
+    PENDING,
+    ACCEPTED,
+    EXPIRED
+}

--- a/src/main/java/com/deskit/deskit/account/enums/JobCategory.java
+++ b/src/main/java/com/deskit/deskit/account/enums/JobCategory.java
@@ -1,0 +1,10 @@
+package com.deskit.deskit.account.enums;
+
+public enum JobCategory {
+    ADMIN_PLAN_TYPE,
+    CREATIVE_TYPE,
+    EDU_RES_TYPE,
+    MED_PRO_TYPE,
+    FLEXIBLE_TYPE,
+    NONE
+}

--- a/src/main/java/com/deskit/deskit/account/enums/MBTI.java
+++ b/src/main/java/com/deskit/deskit/account/enums/MBTI.java
@@ -1,0 +1,12 @@
+package com.deskit.deskit.account.enums;
+
+public enum MBTI {
+    INTJ, INTP,
+    ENTJ, ENTP,
+    INFJ, INFP,
+    ENFJ, ENFP,
+    ISTJ, ISFJ,
+    ESTJ, ESFJ,
+    ISTP, ISFP,
+    ESTP, ESFP, NONE
+}

--- a/src/main/java/com/deskit/deskit/account/enums/MemberStatus.java
+++ b/src/main/java/com/deskit/deskit/account/enums/MemberStatus.java
@@ -1,0 +1,6 @@
+package com.deskit.deskit.account.enums;
+
+public enum MemberStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/com/deskit/deskit/account/enums/SellerGradeEnum.java
+++ b/src/main/java/com/deskit/deskit/account/enums/SellerGradeEnum.java
@@ -1,0 +1,7 @@
+package com.deskit.deskit.account.enums;
+
+public enum SellerGradeEnum {
+    A,
+    B,
+    C
+}

--- a/src/main/java/com/deskit/deskit/account/enums/SellerGradeStatus.java
+++ b/src/main/java/com/deskit/deskit/account/enums/SellerGradeStatus.java
@@ -1,0 +1,7 @@
+package com.deskit.deskit.account.enums;
+
+public enum SellerGradeStatus {
+    ACTIVE,
+    TEMP,
+    REVIEW
+}

--- a/src/main/java/com/deskit/deskit/account/enums/SellerRole.java
+++ b/src/main/java/com/deskit/deskit/account/enums/SellerRole.java
@@ -1,0 +1,6 @@
+package com.deskit.deskit.account.enums;
+
+public enum SellerRole {
+    ROLE_SELLER_OWNER,
+    ROLE_SELLER_MANAGER
+}

--- a/src/main/java/com/deskit/deskit/account/enums/SellerStatus.java
+++ b/src/main/java/com/deskit/deskit/account/enums/SellerStatus.java
@@ -1,0 +1,7 @@
+package com.deskit.deskit.account.enums;
+
+public enum SellerStatus {
+    PENDING,
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/com/deskit/deskit/common/config/CorsMvcConfig.java
+++ b/src/main/java/com/deskit/deskit/common/config/CorsMvcConfig.java
@@ -1,0 +1,17 @@
+package com.deskit.deskit.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+
+        corsRegistry.addMapping("/**")
+                .exposedHeaders("Set-Cookie")
+                .allowedOrigins("http://localhost:5173");
+    }
+}

--- a/src/main/java/com/deskit/deskit/common/config/RedisConfig.java
+++ b/src/main/java/com/deskit/deskit/common/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.deskit.deskit.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/deskit/deskit/common/util/verification/PhoneSendRequest.java
+++ b/src/main/java/com/deskit/deskit/common/util/verification/PhoneSendRequest.java
@@ -1,0 +1,12 @@
+package com.deskit.deskit.common.util.verification;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PhoneSendRequest {
+
+    // Phone number to receive verification code.
+    private String phoneNumber;
+}

--- a/src/main/java/com/deskit/deskit/common/util/verification/PhoneSendResponse.java
+++ b/src/main/java/com/deskit/deskit/common/util/verification/PhoneSendResponse.java
@@ -1,0 +1,17 @@
+package com.deskit.deskit.common.util.verification;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class PhoneSendResponse {
+
+    // Response message for the phone send request.
+    private String message;
+
+    // Development-only code echo.
+    private String code;
+}

--- a/src/main/java/com/deskit/deskit/common/util/verification/PhoneVerifyRequest.java
+++ b/src/main/java/com/deskit/deskit/common/util/verification/PhoneVerifyRequest.java
@@ -1,0 +1,15 @@
+package com.deskit.deskit.common.util.verification;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PhoneVerifyRequest {
+
+    // 전화번호
+    private String phoneNumber;
+
+    // 인증 코드(6자리)
+    private String code;
+}


### PR DESCRIPTION
## 📌 관련 이슈

- issue #5 

## 📝 작업 내용

- 회원 관련 객체(enums, entity, dto) 추가
- 이메일 전송을 위한 build.gradle 의존성 추가(SendGrid)
- 전화번호 인증에 사용될 DTO는 common/util에 추가

## 🧐 리뷰 포인트

- 추가된 객체만 확인하시면 될 것 같습니다. ^^;

