### PR TITLE
feat: 태그 카테고리/태그 엔티티 및 레포지토리 추가

### DIFF
--- a/src/main/java/com/deskit/deskit/tag/entity/Tag.java
+++ b/src/main/java/com/deskit/deskit/tag/entity/Tag.java
@@ -11,25 +11,51 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+/**
+ * Tag 엔티티
+ * - tag 테이블과 매핑되는 도메인 엔티티
+ * - BaseEntity를 상속하여 created_at / updated_at / deleted_at(소프트 삭제) 공통 컬럼을 함께 사용
+ */
 @Entity
 @Table(name = "tag")
 public class Tag extends BaseEntity {
 
+  /**
+   * PK (tag_id)
+   * - MySQL AUTO_INCREMENT에 대응하기 위해 IDENTITY 전략 사용
+   */
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "tag_id", nullable = false)
   private Long id;
 
+  /**
+   * 태그 카테고리 연관관계 (N:1)
+   * - tag.tag_category_id 컬럼으로 조인
+   * - LAZY 로딩: 실제로 tagCategory를 사용할 때 조회(불필요한 조인 방지)
+   */
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "tag_category_id", nullable = false)
   private TagCategory tagCategory;
 
+  /**
+   * 태그명 (tag_name)
+   * - 스키마 VARCHAR(50) 제약에 맞춰 length 지정
+   */
   @Column(name = "tag_name", nullable = false, length = 50)
   private String tagName;
 
+  /**
+   * JPA 기본 생성자 (필수)
+   * - 외부에서 직접 사용하지 않도록 protected
+   */
   protected Tag() {
   }
 
+  /**
+   * 태그 생성용 생성자
+   * - tagCategory / tagName을 필수 값으로 받아 초기화
+   */
   public Tag(TagCategory tagCategory, String tagName) {
     this.tagCategory = tagCategory;
     this.tagName = tagName;

--- a/src/main/java/com/deskit/deskit/tag/entity/Tag.java
+++ b/src/main/java/com/deskit/deskit/tag/entity/Tag.java
@@ -1,0 +1,49 @@
+package com.deskit.deskit.tag.entity;
+
+import com.deskit.deskit.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "tag")
+public class Tag extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "tag_id", nullable = false)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "tag_category_id", nullable = false)
+  private TagCategory tagCategory;
+
+  @Column(name = "tag_name", nullable = false, length = 50)
+  private String tagName;
+
+  protected Tag() {
+  }
+
+  public Tag(TagCategory tagCategory, String tagName) {
+    this.tagCategory = tagCategory;
+    this.tagName = tagName;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public TagCategory getTagCategory() {
+    return tagCategory;
+  }
+
+  public String getTagName() {
+    return tagName;
+  }
+}

--- a/src/main/java/com/deskit/deskit/tag/entity/TagCategory.java
+++ b/src/main/java/com/deskit/deskit/tag/entity/TagCategory.java
@@ -10,10 +10,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+/**
+ * TagCategory 엔티티
+ * - tag_category 테이블과 매핑되는 도메인 엔티티
+ * - BaseEntity를 상속하여 created_at / updated_at / deleted_at(소프트 삭제) 공통 컬럼을 함께 사용
+ */
 @Entity
 @Table(name = "tag_category")
 public class TagCategory extends BaseEntity {
 
+  /**
+   * 태그 카테고리 분류 코드 (tag_code)
+   * - DB ENUM('SPACE','TONE','SITUATION','MOOD')와 매핑
+   * - EnumType.STRING: enum 이름(SPACE 등)을 문자열로 저장/조회
+   */
   public enum TagCode {
     SPACE,
     TONE,
@@ -21,21 +31,40 @@ public class TagCategory extends BaseEntity {
     MOOD
   }
 
+  /**
+   * PK (tag_category_id)
+   * - MySQL AUTO_INCREMENT에 대응하기 위해 IDENTITY 전략 사용
+   */
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "tag_category_id", nullable = false)
   private Long id;
 
+  /**
+   * 카테고리 코드 (tag_code)
+   */
   @Enumerated(EnumType.STRING)
   @Column(name = "tag_code", nullable = false)
   private TagCode tagCode;
 
+  /**
+   * 카테고리명 (tag_category_name)
+   * - 스키마 VARCHAR(30) 제약에 맞춰 length 지정
+   */
   @Column(name = "tag_category_name", nullable = false, length = 30)
   private String tagCategoryName;
 
+  /**
+   * JPA 기본 생성자 (필수)
+   * - 외부에서 직접 사용하지 않도록 protected
+   */
   protected TagCategory() {
   }
 
+  /**
+   * 카테고리 생성용 생성자
+   * - tagCode / tagCategoryName을 필수 값으로 받아 초기화
+   */
   public TagCategory(TagCode tagCode, String tagCategoryName) {
     this.tagCode = tagCode;
     this.tagCategoryName = tagCategoryName;

--- a/src/main/java/com/deskit/deskit/tag/entity/TagCategory.java
+++ b/src/main/java/com/deskit/deskit/tag/entity/TagCategory.java
@@ -1,0 +1,55 @@
+package com.deskit.deskit.tag.entity;
+
+import com.deskit.deskit.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "tag_category")
+public class TagCategory extends BaseEntity {
+
+  public enum TagCode {
+    SPACE,
+    TONE,
+    SITUATION,
+    MOOD
+  }
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "tag_category_id", nullable = false)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "tag_code", nullable = false)
+  private TagCode tagCode;
+
+  @Column(name = "tag_category_name", nullable = false, length = 30)
+  private String tagCategoryName;
+
+  protected TagCategory() {
+  }
+
+  public TagCategory(TagCode tagCode, String tagCategoryName) {
+    this.tagCode = tagCode;
+    this.tagCategoryName = tagCategoryName;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public TagCode getTagCode() {
+    return tagCode;
+  }
+
+  public String getTagCategoryName() {
+    return tagCategoryName;
+  }
+}

--- a/src/main/java/com/deskit/deskit/tag/repository/TagCategoryRepository.java
+++ b/src/main/java/com/deskit/deskit/tag/repository/TagCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.deskit.deskit.tag.repository;
+
+import com.deskit.deskit.tag.entity.TagCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagCategoryRepository extends JpaRepository<TagCategory, Long> {
+}

--- a/src/main/java/com/deskit/deskit/tag/repository/TagRepository.java
+++ b/src/main/java/com/deskit/deskit/tag/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package com.deskit.deskit.tag.repository;
+
+import com.deskit.deskit.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}


### PR DESCRIPTION
- refs #6 

## 📝 작업 내용

- TagCategory / Tag 엔티티 추가(BaseEntity 상속, 테이블/컬럼 매핑)
- TagCategoryRepository / TagRepository 추가(JpaRepository)
- Tag → TagCategory 연관관계 LAZY 설정

## 🧐 리뷰 포인트

- TagCategory.TagCode를 내부 enum으로 둔 구성(파일 수 최소화 목적)이 팀 컨벤션에 맞는지 확인 부탁드립니다.
- Tag ↔ TagCategory 매핑(@ManyToOne LAZY, @JoinColumn name/nullable, length 설정)이 스키마와 일치하는지 확인 부탁드립니다.