### PR TITLE
feat: 상품 목록/상세 조회 응답에 태그 구조 포함

### DIFF
--- a/src/main/java/com/deskit/deskit/product/controller/ProductController.java
+++ b/src/main/java/com/deskit/deskit/product/controller/ProductController.java
@@ -1,0 +1,33 @@
+package com.deskit.deskit.product.controller;
+
+import com.deskit.deskit.product.dto.ProductResponse;
+import com.deskit.deskit.product.service.ProductService;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/products")
+public class ProductController {
+
+  private final ProductService productService;
+
+  public ProductController(ProductService productService) {
+    this.productService = productService;
+  }
+
+  @GetMapping
+  public List<ProductResponse> getProducts() {
+    return productService.getProducts();
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ProductResponse> getProduct(@PathVariable("id") Long id) {
+    return productService.getProduct(id)
+        .map(ResponseEntity::ok)
+        .orElseGet(() -> ResponseEntity.notFound().build());
+  }
+}

--- a/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
@@ -1,0 +1,126 @@
+package com.deskit.deskit.product.dto;
+
+import com.deskit.deskit.product.entity.Product;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Collections;
+import java.util.List;
+
+public class ProductResponse {
+
+  @JsonProperty("product_id")
+  private final Long productId;
+
+  @JsonProperty("seller_id")
+  private final Long sellerId;
+
+  @JsonProperty("name")
+  private final String name;
+
+  @JsonProperty("short_desc")
+  private final String shortDesc;
+
+  @JsonProperty("detail_html")
+  private final String detailHtml;
+
+  @JsonProperty("price")
+  private final Integer price;
+
+  @JsonProperty("cost_price")
+  private final Integer costPrice;
+
+  @JsonProperty("status")
+  private final Product.Status status;
+
+  @JsonProperty("stock_qty")
+  private final Integer stockQty;
+
+  @JsonProperty("safety_stock")
+  private final Integer safetyStock;
+
+  @JsonProperty("tags")
+  private final ProductTags tags;
+
+  @JsonProperty("tagsFlat")
+  private final List<String> tagsFlat;
+
+  public ProductResponse(Long productId, Long sellerId, String name, String shortDesc,
+                         String detailHtml, Integer price, Integer costPrice,
+                         Product.Status status, Integer stockQty, Integer safetyStock,
+                         ProductTags tags, List<String> tagsFlat) {
+    this.productId = productId;
+    this.sellerId = sellerId;
+    this.name = name;
+    this.shortDesc = shortDesc;
+    this.detailHtml = detailHtml;
+    this.price = price;
+    this.costPrice = costPrice;
+    this.status = status;
+    this.stockQty = stockQty;
+    this.safetyStock = safetyStock;
+    this.tags = tags == null ? ProductTags.empty() : tags;
+    this.tagsFlat = tagsFlat == null ? Collections.emptyList() : tagsFlat;
+  }
+
+  public static ProductResponse from(Product product, ProductTags tags, List<String> tagsFlat) {
+    return new ProductResponse(
+        product.getId(),
+        product.getSellerId(),
+        product.getProductName(),
+        product.getShortDesc(),
+        product.getDetailHtml(),
+        product.getPrice(),
+        product.getCostPrice(),
+        product.getStatus(),
+        product.getStockQty(),
+        product.getSafetyStock(),
+        tags,
+        tagsFlat
+    );
+  }
+
+  @JsonPropertyOrder({"space", "tone", "situation", "mood"})
+  public static class ProductTags {
+
+    @JsonProperty("space")
+    private final List<String> space;
+
+    @JsonProperty("tone")
+    private final List<String> tone;
+
+    @JsonProperty("situation")
+    private final List<String> situation;
+
+    @JsonProperty("mood")
+    private final List<String> mood;
+
+    public ProductTags(List<String> space, List<String> tone,
+                       List<String> situation, List<String> mood) {
+      this.space = space == null ? Collections.emptyList() : space;
+      this.tone = tone == null ? Collections.emptyList() : tone;
+      this.situation = situation == null ? Collections.emptyList() : situation;
+      this.mood = mood == null ? Collections.emptyList() : mood;
+    }
+
+    public static ProductTags empty() {
+      return new ProductTags(Collections.emptyList(), Collections.emptyList(),
+          Collections.emptyList(), Collections.emptyList());
+    }
+
+    public List<String> getSpace() {
+      return space;
+    }
+
+    public List<String> getTone() {
+      return tone;
+    }
+
+    public List<String> getSituation() {
+      return situation;
+    }
+
+    public List<String> getMood() {
+      return mood;
+    }
+  }
+}

--- a/src/main/java/com/deskit/deskit/product/entity/package-info.java
+++ b/src/main/java/com/deskit/deskit/product/entity/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.product.entity;

--- a/src/main/java/com/deskit/deskit/product/repository/ProductRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductRepository.java
@@ -1,7 +1,13 @@
 package com.deskit.deskit.product.repository;
 
 import com.deskit.deskit.product.entity.Product;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+  List<Product> findAllByDeletedAtIsNullOrderByIdAsc();
+
+  Optional<Product> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/deskit/deskit/product/repository/ProductRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductRepository.java
@@ -5,9 +5,28 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * Product 엔티티에 대한 DB 접근 레이어(Repository)
+ * - Spring Data JPA가 구현체를 자동 생성해줌
+ * - 기본 CRUD(save/findById/findAll/delete 등)는 JpaRepository가 제공
+ */
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+  /**
+   * deleted_at 이 NULL(= 논리삭제 안 된 데이터)인 상품만 조회
+   * 그리고 id 오름차순으로 정렬해서 리스트로 반환
+   *
+   * 메서드 이름 규칙(쿼리 메서드)로 SQL/JPQL을 자동 생성:
+   * - findAllByDeletedAtIsNull : deletedAt 컬럼이 null인 것만
+   * - OrderByIdAsc : id 기준 오름차순 정렬
+   */
   List<Product> findAllByDeletedAtIsNullOrderByIdAsc();
 
+  /**
+   * 특정 id의 상품을 조회하되, deleted_at 이 NULL인 경우만 조회
+   * 결과가 없을 수 있으니 Optional로 감쌈
+   *
+   * 예: id는 존재하지만 deleted_at이 채워져 있으면(논리삭제) -> Optional.empty()
+   */
   Optional<Product> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/deskit/deskit/product/repository/ProductTagRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductTagRepository.java
@@ -8,14 +8,33 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+/**
+ * ProductTag(상품-태그 매핑) 테이블 접근 Repository
+ * - PK가 (product_id, tag_id) 복합키라서 ID 타입이 ProductTagId(@EmbeddedId)임
+ */
 public interface ProductTagRepository extends JpaRepository<ProductTag, ProductTagId> {
 
+  /**
+   * 태그 집계를 위한 "조회 결과용 Projection 인터페이스"
+   * - 엔티티 전체를 다 가져오지 않고, 필요한 컬럼만 가볍게 조회할 때 사용
+   * - 아래 @Query에서 "as productId/tagCode/tagName" 별칭이
+   *   이 getter 이름과 매칭되면 Spring Data가 알아서 매핑해줌
+   */
   interface ProductTagRow {
-    Long getProductId();
-    TagCategory.TagCode getTagCode();
-    String getTagName();
+    Long getProductId();              // Product의 id
+    TagCategory.TagCode getTagCode(); // TagCategory의 enum 코드(SPACE/TONE/...)
+    String getTagName();              // Tag의 이름(예: "모던", "미니멀")
   }
 
+  /**
+   * 여러 상품(productIds)에 대해 "활성(논리삭제되지 않은) 태그"를 한 번에 조회
+   *
+   * 포인트:
+   * - pt.deletedAt / t.deletedAt / tc.deletedAt 이 모두 null인 데이터만(=활성)
+   * - pt.product.id in :productIds 로 한 번에 배치 조회해서 N+1 방지
+   * - order by 로 결과 정렬을 고정해서 서비스에서 tags/tagsFlat 만들 때
+   *   안정적인 순서(상품 -> 카테고리 -> 태그명)를 유지
+   */
   @Query("""
       select pt.product.id as productId,
              tc.tagCode as tagCode,

--- a/src/main/java/com/deskit/deskit/product/repository/ProductTagRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductTagRepository.java
@@ -2,7 +2,32 @@ package com.deskit.deskit.product.repository;
 
 import com.deskit.deskit.product.entity.ProductTag;
 import com.deskit.deskit.product.entity.ProductTag.ProductTagId;
+import com.deskit.deskit.tag.entity.TagCategory;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductTagRepository extends JpaRepository<ProductTag, ProductTagId> {
+
+  interface ProductTagRow {
+    Long getProductId();
+    TagCategory.TagCode getTagCode();
+    String getTagName();
+  }
+
+  @Query("""
+      select pt.product.id as productId,
+             tc.tagCode as tagCode,
+             t.tagName as tagName
+        from ProductTag pt
+        join pt.tag t
+        join t.tagCategory tc
+       where pt.deletedAt is null
+         and t.deletedAt is null
+         and tc.deletedAt is null
+         and pt.product.id in :productIds
+       order by pt.product.id, tc.tagCode, t.tagName
+      """)
+  List<ProductTagRow> findActiveTagsByProductIds(@Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/deskit/deskit/product/repository/package-info.java
+++ b/src/main/java/com/deskit/deskit/product/repository/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.product.repository;

--- a/src/main/java/com/deskit/deskit/product/service/ProductService.java
+++ b/src/main/java/com/deskit/deskit/product/service/ProductService.java
@@ -1,0 +1,144 @@
+package com.deskit.deskit.product.service;
+
+import com.deskit.deskit.product.dto.ProductResponse;
+import com.deskit.deskit.product.dto.ProductResponse.ProductTags;
+import com.deskit.deskit.product.entity.Product;
+import com.deskit.deskit.product.repository.ProductRepository;
+import com.deskit.deskit.product.repository.ProductTagRepository;
+import com.deskit.deskit.product.repository.ProductTagRepository.ProductTagRow;
+import com.deskit.deskit.tag.entity.TagCategory.TagCode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProductService {
+
+  private final ProductRepository productRepository;
+  private final ProductTagRepository productTagRepository;
+
+  public ProductService(ProductRepository productRepository,
+                        ProductTagRepository productTagRepository) {
+    this.productRepository = productRepository;
+    this.productTagRepository = productTagRepository;
+  }
+
+  public List<ProductResponse> getProducts() {
+    List<Product> products = productRepository.findAllByDeletedAtIsNullOrderByIdAsc();
+    if (products.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<Long> productIds = products.stream()
+        .map(Product::getId)
+        .collect(Collectors.toList());
+    List<ProductTagRow> rows = productTagRepository.findActiveTagsByProductIds(productIds);
+    Map<Long, TagsBundle> tagsByProductId = buildTagsByProductId(rows);
+    return products.stream()
+        .map(product -> {
+          TagsBundle bundle = tagsByProductId.get(product.getId());
+          ProductTags tags = bundle == null ? ProductTags.empty() : bundle.getTags();
+          List<String> tagsFlat = bundle == null ? Collections.emptyList() : bundle.getTagsFlat();
+          return ProductResponse.from(product, tags, tagsFlat);
+        })
+        .collect(Collectors.toList());
+  }
+
+  public Optional<ProductResponse> getProduct(Long id) {
+    Optional<Product> product = productRepository.findByIdAndDeletedAtIsNull(id);
+    if (product.isEmpty()) {
+      return Optional.empty();
+    }
+    List<ProductTagRow> rows = productTagRepository.findActiveTagsByProductIds(List.of(id));
+    Map<Long, TagsBundle> tagsByProductId = buildTagsByProductId(rows);
+    TagsBundle bundle = tagsByProductId.get(id);
+    ProductTags tags = bundle == null ? ProductTags.empty() : bundle.getTags();
+    List<String> tagsFlat = bundle == null ? Collections.emptyList() : bundle.getTagsFlat();
+    return Optional.of(ProductResponse.from(product.get(), tags, tagsFlat));
+  }
+
+  static Map<Long, TagsBundle> buildTagsByProductId(List<ProductTagRow> rows) {
+    Map<Long, TagAccumulator> accumulators = new java.util.HashMap<>();
+    for (ProductTagRow row : rows) {
+      if (row == null || row.getProductId() == null || row.getTagCode() == null) {
+        continue;
+      }
+      TagAccumulator acc = accumulators.computeIfAbsent(row.getProductId(),
+          ignored -> new TagAccumulator());
+      acc.add(row.getTagCode(), row.getTagName());
+    }
+    return accumulators.entrySet().stream()
+        .collect(Collectors.toMap(
+            Map.Entry::getKey,
+            entry -> entry.getValue().toBundle()
+        ));
+  }
+
+  static class TagsBundle {
+    private final ProductTags tags;
+    private final List<String> tagsFlat;
+
+    TagsBundle(ProductTags tags, List<String> tagsFlat) {
+      this.tags = tags;
+      this.tagsFlat = tagsFlat;
+    }
+
+    ProductTags getTags() {
+      return tags;
+    }
+
+    List<String> getTagsFlat() {
+      return tagsFlat;
+    }
+  }
+
+  private static class TagAccumulator {
+    private final Map<TagCode, LinkedHashSet<String>> byCode = new EnumMap<>(TagCode.class);
+
+    void add(TagCode code, String tagName) {
+      if (tagName == null || tagName.isBlank()) {
+        return;
+      }
+      byCode.computeIfAbsent(code, ignored -> new LinkedHashSet<>()).add(tagName);
+    }
+
+    TagsBundle toBundle() {
+      List<String> space = listFor(TagCode.SPACE);
+      List<String> tone = listFor(TagCode.TONE);
+      List<String> situation = listFor(TagCode.SITUATION);
+      List<String> mood = listFor(TagCode.MOOD);
+      ProductTags tags = new ProductTags(space, tone, situation, mood);
+      LinkedHashSet<String> flat = new LinkedHashSet<>();
+      addAll(flat, space);
+      addAll(flat, tone);
+      addAll(flat, situation);
+      addAll(flat, mood);
+      return new TagsBundle(tags, new ArrayList<>(flat));
+    }
+
+    private List<String> listFor(TagCode code) {
+      LinkedHashSet<String> values = byCode.get(code);
+      if (values == null || values.isEmpty()) {
+        return Collections.emptyList();
+      }
+      return new ArrayList<>(values);
+    }
+
+    private void addAll(LinkedHashSet<String> target, List<String> source) {
+      if (source == null || source.isEmpty()) {
+        return;
+      }
+      for (String value : source) {
+        if (value != null && !value.isBlank()) {
+          target.add(value);
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=deskit
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/testdb?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+spring.datasource.url=jdbc:mysql://localhost:3306/livecommerce?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
 spring.datasource.username=root
 spring.datasource.password=mysql1234
 

--- a/src/test/java/com/deskit/deskit/product/service/ProductTagAggregationTest.java
+++ b/src/test/java/com/deskit/deskit/product/service/ProductTagAggregationTest.java
@@ -1,0 +1,64 @@
+package com.deskit.deskit.product.service;
+
+import com.deskit.deskit.product.repository.ProductTagRepository.ProductTagRow;
+import com.deskit.deskit.tag.entity.TagCategory.TagCode;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ProductTagAggregationTest {
+
+  @Test
+  void buildTagsByProductId_buildsOrderedTagsAndFlatList() {
+    List<ProductTagRow> rows = List.of(
+        new Row(1L, TagCode.SPACE, "오피스"),
+        new Row(1L, TagCode.SPACE, "서재"),
+        new Row(1L, TagCode.TONE, "모던"),
+        new Row(1L, TagCode.TONE, "모던"),
+        new Row(1L, TagCode.SITUATION, "재택근무"),
+        new Row(1L, TagCode.MOOD, "깔끔한"),
+        new Row(2L, TagCode.MOOD, "포근한")
+    );
+
+    Map<Long, ProductService.TagsBundle> result = ProductService.buildTagsByProductId(rows);
+    ProductService.TagsBundle bundle = result.get(1L);
+
+    assertNotNull(bundle);
+    assertEquals(List.of("오피스", "서재"), bundle.getTags().getSpace());
+    assertEquals(List.of("모던"), bundle.getTags().getTone());
+    assertEquals(List.of("재택근무"), bundle.getTags().getSituation());
+    assertEquals(List.of("깔끔한"), bundle.getTags().getMood());
+    assertEquals(List.of("오피스", "서재", "모던", "재택근무", "깔끔한"),
+        bundle.getTagsFlat());
+  }
+
+  private static class Row implements ProductTagRow {
+    private final Long productId;
+    private final TagCode tagCode;
+    private final String tagName;
+
+    Row(Long productId, TagCode tagCode, String tagName) {
+      this.productId = productId;
+      this.tagCode = tagCode;
+      this.tagName = tagName;
+    }
+
+    @Override
+    public Long getProductId() {
+      return productId;
+    }
+
+    @Override
+    public TagCode getTagCode() {
+      return tagCode;
+    }
+
+    @Override
+    public String getTagName() {
+      return tagName;
+    }
+  }
+}


### PR DESCRIPTION
📝 작업 내용
	•	Product 조회 API 추가: GET /api/products, GET /api/products/{id}
	•	소프트 삭제(deleted_at IS NULL) 기준으로 상품/태그 조회 필터링
	•	ProductTagRepository에 태그 배치 조회용 projection + JPQL 추가 (N+1 방지)
	•	프론트 호환을 위해 snake_case 응답 DTO(ProductResponse) 구성 + tags, tagsFlat 조립
	•	태그 정렬/중복 제거 로직에 대한 단위 테스트 추가

🧐 리뷰 포인트
	•	태그 조회 쿼리(findActiveTagsByProductIds)의 조인/필터 조건이 의도대로인지, 정렬 기준이 적절한지 봐주세요.