### PR TITLE
feat: 상품/셋업 조회 API 및 태그 집계 추가

### DIFF
--- a/src/main/java/com/deskit/deskit/product/controller/ProductController.java
+++ b/src/main/java/com/deskit/deskit/product/controller/ProductController.java
@@ -9,25 +9,45 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Product 조회 전용 REST API 컨트롤러
+ * - /api/products: 상품 목록 조회
+ * - /api/products/{id}: 상품 단건 조회
+ *
+ * 주의:
+ * - 실제 인증/인가(Spring Security) 설정에 따라 이 엔드포인트도 로그인 리다이렉트(302)가 발생할 수 있음.
+ * - 여기서는 비즈니스 로직을 직접 처리하지 않고 ProductService에 위임해서 계층 분리를 유지함.
+ */
 @RestController
 @RequestMapping("/api/products")
 public class ProductController {
 
+  // 조회 로직(상품 + 태그 집계)을 담당하는 서비스
   private final ProductService productService;
 
+  // 생성자 주입(스프링이 ProductService 빈을 주입)
   public ProductController(ProductService productService) {
     this.productService = productService;
   }
 
+  /**
+   * 상품 목록 조회
+   * - Service에서 deletedAt is null(소프트 삭제 제외) 필터 + 태그 배치 조회 후 DTO로 변환
+   */
   @GetMapping
   public List<ProductResponse> getProducts() {
     return productService.getProducts();
   }
 
+  /**
+   * 상품 단건 조회
+   * - 존재하면 200 OK + ProductResponse
+   * - 없으면 404 Not Found
+   */
   @GetMapping("/{id}")
   public ResponseEntity<ProductResponse> getProduct(@PathVariable("id") Long id) {
     return productService.getProduct(id)
-        .map(ResponseEntity::ok)
-        .orElseGet(() -> ResponseEntity.notFound().build());
+            .map(ResponseEntity::ok)
+            .orElseGet(() -> ResponseEntity.notFound().build());
   }
 }

--- a/src/main/java/com/deskit/deskit/product/controller/package-info.java
+++ b/src/main/java/com/deskit/deskit/product/controller/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.product.controller;

--- a/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
@@ -6,9 +6,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Product 조회 API 응답 DTO
+ * - 프론트(mock 데이터)와 호환되도록 snake_case(JSON) 키를 사용 (@JsonProperty)
+ * - tags: 카테고리별(space/tone/situation/mood) 태그 리스트
+ * - tagsFlat: tags를 카테고리 순서대로 합친 1차원 리스트 (UI/필터링 편의)
+ */
 public class ProductResponse {
 
-  @JsonProperty("product_id")
+  @JsonProperty("product_id") // JSON 키를 product_id로 고정
   private final Long productId;
 
   @JsonProperty("seller_id")
@@ -44,6 +50,10 @@ public class ProductResponse {
   @JsonProperty("tagsFlat")
   private final List<String> tagsFlat;
 
+  /**
+   * 생성자에서 null-safe 처리:
+   * - tags/tagsFlat이 null로 들어오면 빈 값으로 치환해서 응답 안정성 확보
+   */
   public ProductResponse(Long productId, Long sellerId, String name, String shortDesc,
                          String detailHtml, Integer price, Integer costPrice,
                          Product.Status status, Integer stockQty, Integer safetyStock,
@@ -62,23 +72,30 @@ public class ProductResponse {
     this.tagsFlat = tagsFlat == null ? Collections.emptyList() : tagsFlat;
   }
 
+  /**
+   * 엔티티 -> DTO 변환 팩토리 메서드
+   * - 엔티티 필드명(productName 등)과 응답 필드명(name 등)을 여기서 매핑
+   */
   public static ProductResponse from(Product product, ProductTags tags, List<String> tagsFlat) {
     return new ProductResponse(
-        product.getId(),
-        product.getSellerId(),
-        product.getProductName(),
-        product.getShortDesc(),
-        product.getDetailHtml(),
-        product.getPrice(),
-        product.getCostPrice(),
-        product.getStatus(),
-        product.getStockQty(),
-        product.getSafetyStock(),
-        tags,
-        tagsFlat
+            product.getId(),
+            product.getSellerId(),
+            product.getProductName(), // 엔티티 productName -> 응답 name
+            product.getShortDesc(),
+            product.getDetailHtml(),
+            product.getPrice(),
+            product.getCostPrice(),
+            product.getStatus(),
+            product.getStockQty(),
+            product.getSafetyStock(),
+            tags,
+            tagsFlat
     );
   }
 
+  /**
+   * tags 객체의 JSON 필드 출력 순서를 고정 (보기 좋게 + 프론트 기대 순서)
+   */
   @JsonPropertyOrder({"space", "tone", "situation", "mood"})
   public static class ProductTags {
 
@@ -94,6 +111,10 @@ public class ProductResponse {
     @JsonProperty("mood")
     private final List<String> mood;
 
+    /**
+     * 카테고리별 태그 리스트를 담는 객체
+     * - null로 들어오면 빈 리스트로 치환 (null-safe)
+     */
     public ProductTags(List<String> space, List<String> tone,
                        List<String> situation, List<String> mood) {
       this.space = space == null ? Collections.emptyList() : space;
@@ -102,11 +123,13 @@ public class ProductResponse {
       this.mood = mood == null ? Collections.emptyList() : mood;
     }
 
+    /** 빈 tags 기본값 제공 */
     public static ProductTags empty() {
       return new ProductTags(Collections.emptyList(), Collections.emptyList(),
-          Collections.emptyList(), Collections.emptyList());
+              Collections.emptyList(), Collections.emptyList());
     }
 
+    // Jackson이 직렬화 시 getter를 통해 값을 읽기 때문에 getter 제공
     public List<String> getSpace() {
       return space;
     }

--- a/src/main/java/com/deskit/deskit/product/dto/package-info.java
+++ b/src/main/java/com/deskit/deskit/product/dto/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.product.dto;

--- a/src/main/java/com/deskit/deskit/product/entity/Product.java
+++ b/src/main/java/com/deskit/deskit/product/entity/Product.java
@@ -10,9 +10,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "product")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product extends BaseEntity {
 
   public enum Status {
@@ -60,9 +65,6 @@ public class Product extends BaseEntity {
   @Column(name = "safety_stock", nullable = false)
   private Integer safetyStock;
 
-  protected Product() {
-  }
-
   public Product(Long sellerId, String productName, String shortDesc, String detailHtml,
                  Integer price, Integer costPrice, Status status, Integer stockQty,
                  Integer safetyStock) {
@@ -75,45 +77,5 @@ public class Product extends BaseEntity {
     this.status = status;
     this.stockQty = stockQty;
     this.safetyStock = safetyStock;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public Long getSellerId() {
-    return sellerId;
-  }
-
-  public String getProductName() {
-    return productName;
-  }
-
-  public String getShortDesc() {
-    return shortDesc;
-  }
-
-  public String getDetailHtml() {
-    return detailHtml;
-  }
-
-  public Integer getPrice() {
-    return price;
-  }
-
-  public Integer getCostPrice() {
-    return costPrice;
-  }
-
-  public Status getStatus() {
-    return status;
-  }
-
-  public Integer getStockQty() {
-    return stockQty;
-  }
-
-  public Integer getSafetyStock() {
-    return safetyStock;
   }
 }

--- a/src/main/java/com/deskit/deskit/product/entity/ProductTag.java
+++ b/src/main/java/com/deskit/deskit/product/entity/ProductTag.java
@@ -13,12 +13,19 @@ import jakarta.persistence.Table;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "product_tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductTag {
 
   @Embeddable
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
   public static class ProductTagId implements Serializable {
 
     @Column(name = "product_id", nullable = false)
@@ -27,20 +34,9 @@ public class ProductTag {
     @Column(name = "tag_id", nullable = false)
     private Long tagId;
 
-    protected ProductTagId() {
-    }
-
     public ProductTagId(Long productId, Long tagId) {
       this.productId = productId;
       this.tagId = tagId;
-    }
-
-    public Long getProductId() {
-      return productId;
-    }
-
-    public Long getTagId() {
-      return tagId;
     }
 
     @Override
@@ -81,31 +77,8 @@ public class ProductTag {
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
-  protected ProductTag() {
-  }
-
   public ProductTag(Product product, Tag tag) {
     this.product = product;
     this.tag = tag;
-  }
-
-  public ProductTagId getId() {
-    return id;
-  }
-
-  public Product getProduct() {
-    return product;
-  }
-
-  public Tag getTag() {
-    return tag;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
-  }
-
-  public LocalDateTime getDeletedAt() {
-    return deletedAt;
   }
 }

--- a/src/main/java/com/deskit/deskit/product/service/ProductService.java
+++ b/src/main/java/com/deskit/deskit/product/service/ProductService.java
@@ -18,68 +18,97 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
-@Service
+@Service // 스프링 서비스 계층 빈 등록 (비즈니스 로직/조합 담당)
 public class ProductService {
 
-  private final ProductRepository productRepository;
-  private final ProductTagRepository productTagRepository;
+  private final ProductRepository productRepository; // Product 조회용 JPA Repository
+  private final ProductTagRepository productTagRepository; // Product-Tag 매핑 조회용 JPA Repository
 
+  // 생성자 주입: 테스트/대체 구현에 유리하고, final 필드와 잘 맞음
   public ProductService(ProductRepository productRepository,
                         ProductTagRepository productTagRepository) {
     this.productRepository = productRepository;
     this.productTagRepository = productTagRepository;
   }
 
+  // 상품 목록 조회: deleted_at IS NULL인 상품만 가져오고, 태그는 productIds로 한 번에 batch 조회 (N+1 방지)
   public List<ProductResponse> getProducts() {
     List<Product> products = productRepository.findAllByDeletedAtIsNullOrderByIdAsc();
     if (products.isEmpty()) {
       return Collections.emptyList();
     }
+
+    // 조회된 상품 id 목록 뽑아서 IN 쿼리로 태그를 한 번에 가져오기
     List<Long> productIds = products.stream()
-        .map(Product::getId)
-        .collect(Collectors.toList());
+            .map(Product::getId)
+            .collect(Collectors.toList());
+
+    // (product_id, tagCode, tagName) 형태의 projection row들
     List<ProductTagRow> rows = productTagRepository.findActiveTagsByProductIds(productIds);
+
+    // productId -> (tags, tagsFlat) 형태로 변환
     Map<Long, TagsBundle> tagsByProductId = buildTagsByProductId(rows);
+
+    // 상품 엔티티 + 태그 번들 => 프론트 호환 DTO로 조립
     return products.stream()
-        .map(product -> {
-          TagsBundle bundle = tagsByProductId.get(product.getId());
-          ProductTags tags = bundle == null ? ProductTags.empty() : bundle.getTags();
-          List<String> tagsFlat = bundle == null ? Collections.emptyList() : bundle.getTagsFlat();
-          return ProductResponse.from(product, tags, tagsFlat);
-        })
-        .collect(Collectors.toList());
+            .map(product -> {
+              TagsBundle bundle = tagsByProductId.get(product.getId());
+              ProductTags tags = bundle == null ? ProductTags.empty() : bundle.getTags();
+              List<String> tagsFlat = bundle == null ? Collections.emptyList() : bundle.getTagsFlat();
+              return ProductResponse.from(product, tags, tagsFlat);
+            })
+            .collect(Collectors.toList());
   }
 
+  // 상품 단건 조회: deleted_at IS NULL인 상품만 반환. 없으면 Optional.empty()
   public Optional<ProductResponse> getProduct(Long id) {
     Optional<Product> product = productRepository.findByIdAndDeletedAtIsNull(id);
     if (product.isEmpty()) {
       return Optional.empty();
     }
+
+    // 단건이지만 동일 로직 재사용: IN(List.of(id))로 tags batch 조회
     List<ProductTagRow> rows = productTagRepository.findActiveTagsByProductIds(List.of(id));
     Map<Long, TagsBundle> tagsByProductId = buildTagsByProductId(rows);
+
     TagsBundle bundle = tagsByProductId.get(id);
     ProductTags tags = bundle == null ? ProductTags.empty() : bundle.getTags();
     List<String> tagsFlat = bundle == null ? Collections.emptyList() : bundle.getTagsFlat();
+
     return Optional.of(ProductResponse.from(product.get(), tags, tagsFlat));
   }
 
+  // DB에서 가져온 tag row들을 productId별로 묶어서 tags/tagsFlat을 만든다
+  // - TagCode별 리스트 유지(space/tone/situation/mood)
+  // - 중복 태그 제거(LinkedHashSet) + 순서 안정적으로 유지
   static Map<Long, TagsBundle> buildTagsByProductId(List<ProductTagRow> rows) {
     Map<Long, TagAccumulator> accumulators = new java.util.HashMap<>();
+
     for (ProductTagRow row : rows) {
+      // projection이 깨졌거나 필수 값이 없으면 스킵 (방어코드)
       if (row == null || row.getProductId() == null || row.getTagCode() == null) {
         continue;
       }
+
+      // productId별 누적기 생성/재사용
       TagAccumulator acc = accumulators.computeIfAbsent(row.getProductId(),
-          ignored -> new TagAccumulator());
+              ignored -> new TagAccumulator());
+
+      // 코드별로 tagName 추가(중복 제거)
       acc.add(row.getTagCode(), row.getTagName());
     }
+
+    // 누적기 -> 최종 응답 번들로 변환
     return accumulators.entrySet().stream()
-        .collect(Collectors.toMap(
-            Map.Entry::getKey,
-            entry -> entry.getValue().toBundle()
-        ));
+            .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> entry.getValue().toBundle()
+            ));
   }
 
+  // Product 1건에 대한 태그 결과 묶음
+  // - tags: 카테고리별 리스트
+  // - tagsFlat: UI용 단일 리스트(카테고리 순서대로 합침)
   static class TagsBundle {
     private final ProductTags tags;
     private final List<String> tagsFlat;
@@ -98,6 +127,9 @@ public class ProductService {
     }
   }
 
+  // TagCode별 태그명을 누적하는 내부 헬퍼
+  // - EnumMap: enum 키에 최적화된 Map
+  // - LinkedHashSet: 중복 제거 + 입력 순서 유지
   private static class TagAccumulator {
     private final Map<TagCode, LinkedHashSet<String>> byCode = new EnumMap<>(TagCode.class);
 
@@ -108,17 +140,23 @@ public class ProductService {
       byCode.computeIfAbsent(code, ignored -> new LinkedHashSet<>()).add(tagName);
     }
 
+    // 누적된 데이터를 ProductTags + tagsFlat로 변환
     TagsBundle toBundle() {
+      // 프론트가 기대하는 키 순서( space -> tone -> situation -> mood )로 정렬
       List<String> space = listFor(TagCode.SPACE);
       List<String> tone = listFor(TagCode.TONE);
       List<String> situation = listFor(TagCode.SITUATION);
       List<String> mood = listFor(TagCode.MOOD);
+
       ProductTags tags = new ProductTags(space, tone, situation, mood);
+
+      // flat은 카테고리 순서대로 합치되 중복 제거(LinkedHashSet)
       LinkedHashSet<String> flat = new LinkedHashSet<>();
       addAll(flat, space);
       addAll(flat, tone);
       addAll(flat, situation);
       addAll(flat, mood);
+
       return new TagsBundle(tags, new ArrayList<>(flat));
     }
 

--- a/src/main/java/com/deskit/deskit/product/service/package-info.java
+++ b/src/main/java/com/deskit/deskit/product/service/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.product.service;

--- a/src/main/java/com/deskit/deskit/setup/controller/SetupController.java
+++ b/src/main/java/com/deskit/deskit/setup/controller/SetupController.java
@@ -1,0 +1,54 @@
+package com.deskit.deskit.setup.controller;
+
+import com.deskit.deskit.setup.dto.SetupResponse;
+import com.deskit.deskit.setup.service.SetupService;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Setup(셋업) 조회 전용 REST API 컨트롤러
+ * - /api/setups: 셋업 목록 조회
+ * - /api/setups/{id}: 셋업 단건 조회
+ *
+ * 포인트:
+ * - 컨트롤러는 HTTP 요청/응답만 담당하고, 조회/태그 집계 로직은 SetupService에 위임한다.
+ * - 서비스에서 deletedAt is null(소프트 삭제 제외) 필터 + 태그를 배치 조회해서 N+1을 피한다.
+ * - 보안(Spring Security) 설정에 따라 이 엔드포인트도 인증이 필요하면 302로 /login 리다이렉트될 수 있다.
+ */
+@RestController
+@RequestMapping("/api/setups")
+public class SetupController {
+
+  // 셋업 조회(셋업 + 태그 집계)를 담당하는 서비스
+  private final SetupService setupService;
+
+  // 생성자 주입
+  public SetupController(SetupService setupService) {
+    this.setupService = setupService;
+  }
+
+  /**
+   * 셋업 목록 조회
+   * - Service에서 tags/tagsFlat까지 포함한 DTO 리스트로 변환해서 반환
+   */
+  @GetMapping
+  public List<SetupResponse> getSetups() {
+    return setupService.getSetups();
+  }
+
+  /**
+   * 셋업 단건 조회
+   * - 존재하면 200 OK + SetupResponse
+   * - 없으면 404 Not Found
+   */
+  @GetMapping("/{id}")
+  public ResponseEntity<SetupResponse> getSetup(@PathVariable("id") Long id) {
+    return setupService.getSetup(id)
+            .map(ResponseEntity::ok)
+            .orElseGet(() -> ResponseEntity.notFound().build());
+  }
+}

--- a/src/main/java/com/deskit/deskit/setup/controller/package-info.java
+++ b/src/main/java/com/deskit/deskit/setup/controller/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.setup.controller;

--- a/src/main/java/com/deskit/deskit/setup/dto/SetupResponse.java
+++ b/src/main/java/com/deskit/deskit/setup/dto/SetupResponse.java
@@ -1,0 +1,128 @@
+package com.deskit.deskit.setup.dto;
+
+import com.deskit.deskit.setup.entity.Setup;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Setup 조회 API 응답 DTO
+ * - 프론트(mock 데이터)와 필드명을 맞추기 위해 snake_case(JSON)로 내려줌 (@JsonProperty)
+ * - tags: 카테고리별 리스트(space/tone/situation/mood)
+ * - tagsFlat: tags를 카테고리 순서대로 합친 단일 리스트(UI 편의용)
+ */
+public class SetupResponse {
+
+  @JsonProperty("setup_id") // JSON 키를 setup_id로 고정
+  private final Long setupId;
+
+  @JsonProperty("seller_id")
+  private final Long sellerId;
+
+  @JsonProperty("name")
+  private final String name;
+
+  @JsonProperty("short_desc")
+  private final String shortDesc;
+
+  @JsonProperty("tip_text")
+  private final String tipText;
+
+  @JsonProperty("setup_image_url")
+  private final String setupImageUrl;
+
+  @JsonProperty("tags")
+  private final SetupTags tags;
+
+  @JsonProperty("tagsFlat")
+  private final List<String> tagsFlat;
+
+  /**
+   * 생성자에서 null-safe 처리:
+   * - tags/tagsFlat이 null로 들어오면 빈 값으로 치환하여 응답 안정성을 높임
+   */
+  public SetupResponse(Long setupId, Long sellerId, String name, String shortDesc,
+                       String tipText, String setupImageUrl, SetupTags tags,
+                       List<String> tagsFlat) {
+    this.setupId = setupId;
+    this.sellerId = sellerId;
+    this.name = name;
+    this.shortDesc = shortDesc;
+    this.tipText = tipText;
+    this.setupImageUrl = setupImageUrl;
+    this.tags = tags == null ? SetupTags.empty() : tags;
+    this.tagsFlat = tagsFlat == null ? Collections.emptyList() : tagsFlat;
+  }
+
+  /**
+   * 엔티티 -> DTO 변환 팩토리 메서드
+   * - 엔티티 필드명(setupName 등)과 응답 필드명(name 등)을 여기서 매핑
+   */
+  public static SetupResponse from(Setup setup, SetupTags tags, List<String> tagsFlat) {
+    return new SetupResponse(
+            setup.getId(),
+            setup.getSellerId(),
+            setup.getSetupName(),      // 엔티티 setupName -> 응답 name
+            setup.getShortDesc(),
+            setup.getTipText(),
+            setup.getSetupImageUrl(),
+            tags,
+            tagsFlat
+    );
+  }
+
+  /**
+   * tags 객체의 JSON 필드 출력 순서를 고정 (보기 좋게 + 프론트 기대 순서)
+   */
+  @JsonPropertyOrder({"space", "tone", "situation", "mood"})
+  public static class SetupTags {
+
+    @JsonProperty("space")
+    private final List<String> space;
+
+    @JsonProperty("tone")
+    private final List<String> tone;
+
+    @JsonProperty("situation")
+    private final List<String> situation;
+
+    @JsonProperty("mood")
+    private final List<String> mood;
+
+    /**
+     * 카테고리별 태그 리스트를 담는 객체
+     * - null로 들어오면 빈 리스트로 치환 (null-safe)
+     */
+    public SetupTags(List<String> space, List<String> tone,
+                     List<String> situation, List<String> mood) {
+      this.space = space == null ? Collections.emptyList() : space;
+      this.tone = tone == null ? Collections.emptyList() : tone;
+      this.situation = situation == null ? Collections.emptyList() : situation;
+      this.mood = mood == null ? Collections.emptyList() : mood;
+    }
+
+    /** 빈 tags 기본값 제공 */
+    public static SetupTags empty() {
+      return new SetupTags(Collections.emptyList(), Collections.emptyList(),
+              Collections.emptyList(), Collections.emptyList());
+    }
+
+    // Jackson이 직렬화 시 getter를 통해 값을 읽기 때문에 getter 제공
+    public List<String> getSpace() {
+      return space;
+    }
+
+    public List<String> getTone() {
+      return tone;
+    }
+
+    public List<String> getSituation() {
+      return situation;
+    }
+
+    public List<String> getMood() {
+      return mood;
+    }
+  }
+}

--- a/src/main/java/com/deskit/deskit/setup/dto/package-info.java
+++ b/src/main/java/com/deskit/deskit/setup/dto/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.setup.dto;

--- a/src/main/java/com/deskit/deskit/setup/entity/Setup.java
+++ b/src/main/java/com/deskit/deskit/setup/entity/Setup.java
@@ -7,9 +7,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "setup")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Setup extends BaseEntity {
 
   @Id
@@ -32,9 +37,6 @@ public class Setup extends BaseEntity {
   @Column(name = "setup_image_url", nullable = false, length = 500)
   private String setupImageUrl;
 
-  protected Setup() {
-  }
-
   public Setup(Long sellerId, String setupName, String shortDesc, String tipText,
                String setupImageUrl) {
     this.sellerId = sellerId;
@@ -42,29 +44,5 @@ public class Setup extends BaseEntity {
     this.shortDesc = shortDesc;
     this.tipText = tipText;
     this.setupImageUrl = setupImageUrl;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public Long getSellerId() {
-    return sellerId;
-  }
-
-  public String getSetupName() {
-    return setupName;
-  }
-
-  public String getShortDesc() {
-    return shortDesc;
-  }
-
-  public String getTipText() {
-    return tipText;
-  }
-
-  public String getSetupImageUrl() {
-    return setupImageUrl;
   }
 }

--- a/src/main/java/com/deskit/deskit/setup/entity/SetupTag.java
+++ b/src/main/java/com/deskit/deskit/setup/entity/SetupTag.java
@@ -13,12 +13,19 @@ import jakarta.persistence.Table;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "setup_tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SetupTag {
 
   @Embeddable
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
   public static class SetupTagId implements Serializable {
 
     @Column(name = "setup_id", nullable = false)
@@ -27,20 +34,9 @@ public class SetupTag {
     @Column(name = "tag_id", nullable = false)
     private Long tagId;
 
-    protected SetupTagId() {
-    }
-
     public SetupTagId(Long setupId, Long tagId) {
       this.setupId = setupId;
       this.tagId = tagId;
-    }
-
-    public Long getSetupId() {
-      return setupId;
-    }
-
-    public Long getTagId() {
-      return tagId;
     }
 
     @Override
@@ -81,31 +77,8 @@ public class SetupTag {
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
-  protected SetupTag() {
-  }
-
   public SetupTag(Setup setup, Tag tag) {
     this.setup = setup;
     this.tag = tag;
-  }
-
-  public SetupTagId getId() {
-    return id;
-  }
-
-  public Setup getSetup() {
-    return setup;
-  }
-
-  public Tag getTag() {
-    return tag;
-  }
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
-  }
-
-  public LocalDateTime getDeletedAt() {
-    return deletedAt;
   }
 }

--- a/src/main/java/com/deskit/deskit/setup/entity/package-info.java
+++ b/src/main/java/com/deskit/deskit/setup/entity/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.setup.entity;

--- a/src/main/java/com/deskit/deskit/setup/repository/SetupRepository.java
+++ b/src/main/java/com/deskit/deskit/setup/repository/SetupRepository.java
@@ -1,7 +1,13 @@
 package com.deskit.deskit.setup.repository;
 
 import com.deskit.deskit.setup.entity.Setup;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SetupRepository extends JpaRepository<Setup, Long> {
+
+  List<Setup> findAllByDeletedAtIsNullOrderByIdAsc();
+
+  Optional<Setup> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/deskit/deskit/setup/repository/SetupTagRepository.java
+++ b/src/main/java/com/deskit/deskit/setup/repository/SetupTagRepository.java
@@ -2,7 +2,32 @@ package com.deskit.deskit.setup.repository;
 
 import com.deskit.deskit.setup.entity.SetupTag;
 import com.deskit.deskit.setup.entity.SetupTag.SetupTagId;
+import com.deskit.deskit.tag.entity.TagCategory;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SetupTagRepository extends JpaRepository<SetupTag, SetupTagId> {
+
+  interface SetupTagRow {
+    Long getSetupId();
+    TagCategory.TagCode getTagCode();
+    String getTagName();
+  }
+
+  @Query("""
+      select st.setup.id as setupId,
+             tc.tagCode as tagCode,
+             t.tagName as tagName
+        from SetupTag st
+        join st.tag t
+        join t.tagCategory tc
+       where st.deletedAt is null
+         and t.deletedAt is null
+         and tc.deletedAt is null
+         and st.setup.id in :setupIds
+       order by st.setup.id, tc.tagCode, t.tagName
+      """)
+  List<SetupTagRow> findActiveTagsBySetupIds(@Param("setupIds") List<Long> setupIds);
 }

--- a/src/main/java/com/deskit/deskit/setup/service/SetupService.java
+++ b/src/main/java/com/deskit/deskit/setup/service/SetupService.java
@@ -1,0 +1,184 @@
+package com.deskit.deskit.setup.service;
+
+import com.deskit.deskit.setup.dto.SetupResponse;
+import com.deskit.deskit.setup.dto.SetupResponse.SetupTags;
+import com.deskit.deskit.setup.entity.Setup;
+import com.deskit.deskit.setup.repository.SetupRepository;
+import com.deskit.deskit.setup.repository.SetupTagRepository;
+import com.deskit.deskit.setup.repository.SetupTagRepository.SetupTagRow;
+import com.deskit.deskit.tag.entity.TagCategory.TagCode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service // Setup 관련 조회/조합 로직을 담당하는 스프링 서비스 빈
+public class SetupService {
+
+  private final SetupRepository setupRepository; // Setup 조회용 JPA Repository
+  private final SetupTagRepository setupTagRepository; // Setup-Tag 매핑 조회용 JPA Repository
+
+  // 생성자 주입: final 필드 + 테스트 용이
+  public SetupService(SetupRepository setupRepository,
+                      SetupTagRepository setupTagRepository) {
+    this.setupRepository = setupRepository;
+    this.setupTagRepository = setupTagRepository;
+  }
+
+  // 셋업 목록 조회:
+  // - deleted_at IS NULL인 셋업만 조회
+  // - 셋업ID 리스트로 태그를 한 번에 batch 조회해서 N+1 방지
+  // - 프론트가 원하는 tags(카테고리별) + tagsFlat(합친 리스트)로 조립
+  public List<SetupResponse> getSetups() {
+    List<Setup> setups = setupRepository.findAllByDeletedAtIsNullOrderByIdAsc();
+    if (setups.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<Long> setupIds = setups.stream()
+            .map(Setup::getId)
+            .collect(Collectors.toList());
+
+    // (setup_id, tagCode, tagName) 형태의 projection row들
+    List<SetupTagRow> rows = setupTagRepository.findActiveTagsBySetupIds(setupIds);
+
+    // setupId -> (tags, tagsFlat) 번들로 변환
+    Map<Long, TagsBundle> tagsBySetupId = buildTagsBySetupId(rows);
+
+    // 엔티티 + 태그 번들 => DTO 응답 조립
+    return setups.stream()
+            .map(setup -> {
+              TagsBundle bundle = tagsBySetupId.get(setup.getId());
+              SetupTags tags = bundle == null ? SetupTags.empty() : bundle.getTags();
+              List<String> tagsFlat = bundle == null ? Collections.emptyList() : bundle.getTagsFlat();
+              return SetupResponse.from(setup, tags, tagsFlat);
+            })
+            .collect(Collectors.toList());
+  }
+
+  // 셋업 단건 조회:
+  // - deleted_at IS NULL 조건 포함
+  // - 없으면 Optional.empty()
+  public Optional<SetupResponse> getSetup(Long id) {
+    Optional<Setup> setup = setupRepository.findByIdAndDeletedAtIsNull(id);
+    if (setup.isEmpty()) {
+      return Optional.empty();
+    }
+
+    // 단건이지만 동일 로직 재사용: IN(List.of(id))로 태그 조회
+    List<SetupTagRow> rows = setupTagRepository.findActiveTagsBySetupIds(List.of(id));
+    Map<Long, TagsBundle> tagsBySetupId = buildTagsBySetupId(rows);
+
+    TagsBundle bundle = tagsBySetupId.get(id);
+    SetupTags tags = bundle == null ? SetupTags.empty() : bundle.getTags();
+    List<String> tagsFlat = bundle == null ? Collections.emptyList() : bundle.getTagsFlat();
+
+    return Optional.of(SetupResponse.from(setup.get(), tags, tagsFlat));
+  }
+
+  // DB에서 가져온 태그 row들을 setupId별로 그룹핑하고 tags/tagsFlat을 만든다
+  // - TagCode별 리스트(space/tone/situation/mood)
+  // - 중복 제거 + 입력 순서 유지(LinkedHashSet)
+  static Map<Long, TagsBundle> buildTagsBySetupId(List<SetupTagRow> rows) {
+    Map<Long, TagAccumulator> accumulators = new java.util.HashMap<>();
+
+    for (SetupTagRow row : rows) {
+      // projection row 방어 처리
+      if (row == null || row.getSetupId() == null || row.getTagCode() == null) {
+        continue;
+      }
+
+      // setupId별 누적기 생성/재사용
+      TagAccumulator acc = accumulators.computeIfAbsent(row.getSetupId(),
+              ignored -> new TagAccumulator());
+
+      acc.add(row.getTagCode(), row.getTagName());
+    }
+
+    // 누적기 -> 최종 번들로 변환
+    return accumulators.entrySet().stream()
+            .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> entry.getValue().toBundle()
+            ));
+  }
+
+  // Setup 1건에 대한 태그 결과 묶음
+  // - tags: 카테고리별 리스트
+  // - tagsFlat: UI용 단일 리스트(카테고리 순서대로 합침)
+  static class TagsBundle {
+    private final SetupTags tags;
+    private final List<String> tagsFlat;
+
+    TagsBundle(SetupTags tags, List<String> tagsFlat) {
+      this.tags = tags;
+      this.tagsFlat = tagsFlat;
+    }
+
+    SetupTags getTags() {
+      return tags;
+    }
+
+    List<String> getTagsFlat() {
+      return tagsFlat;
+    }
+  }
+
+  // TagCode별 태그명을 누적하는 내부 헬퍼
+  // - EnumMap: enum 키에 최적화
+  // - LinkedHashSet: 중복 제거 + 순서 유지
+  private static class TagAccumulator {
+    private final Map<TagCode, LinkedHashSet<String>> byCode = new EnumMap<>(TagCode.class);
+
+    void add(TagCode code, String tagName) {
+      if (tagName == null || tagName.isBlank()) {
+        return;
+      }
+      byCode.computeIfAbsent(code, ignored -> new LinkedHashSet<>()).add(tagName);
+    }
+
+    // 누적 데이터를 SetupTags + tagsFlat로 변환
+    TagsBundle toBundle() {
+      // 프론트 기대 순서 유지
+      List<String> space = listFor(TagCode.SPACE);
+      List<String> tone = listFor(TagCode.TONE);
+      List<String> situation = listFor(TagCode.SITUATION);
+      List<String> mood = listFor(TagCode.MOOD);
+
+      SetupTags tags = new SetupTags(space, tone, situation, mood);
+
+      // flat은 카테고리 순서대로 합치되 중복 제거
+      LinkedHashSet<String> flat = new LinkedHashSet<>();
+      addAll(flat, space);
+      addAll(flat, tone);
+      addAll(flat, situation);
+      addAll(flat, mood);
+
+      return new TagsBundle(tags, new ArrayList<>(flat));
+    }
+
+    private List<String> listFor(TagCode code) {
+      LinkedHashSet<String> values = byCode.get(code);
+      if (values == null || values.isEmpty()) {
+        return Collections.emptyList();
+      }
+      return new ArrayList<>(values);
+    }
+
+    private void addAll(LinkedHashSet<String> target, List<String> source) {
+      if (source == null || source.isEmpty()) {
+        return;
+      }
+      for (String value : source) {
+        if (value != null && !value.isBlank()) {
+          target.add(value);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/deskit/deskit/setup/service/package-info.java
+++ b/src/main/java/com/deskit/deskit/setup/service/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.setup.service;

--- a/src/main/java/com/deskit/deskit/tag/entity/package-info.java
+++ b/src/main/java/com/deskit/deskit/tag/entity/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.tag.entity;

--- a/src/test/java/com/deskit/deskit/setup/service/SetupTagAggregationTest.java
+++ b/src/test/java/com/deskit/deskit/setup/service/SetupTagAggregationTest.java
@@ -1,0 +1,63 @@
+package com.deskit.deskit.setup.service;
+
+import com.deskit.deskit.setup.repository.SetupTagRepository.SetupTagRow;
+import com.deskit.deskit.tag.entity.TagCategory.TagCode;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SetupTagAggregationTest {
+
+  @Test
+  void buildTagsBySetupId_buildsOrderedTagsAndFlatList() {
+    List<SetupTagRow> rows = List.of(
+        new Row(10L, TagCode.SPACE, "거실"),
+        new Row(10L, TagCode.SPACE, "거실"),
+        new Row(10L, TagCode.TONE, "미니멀"),
+        new Row(10L, TagCode.SITUATION, "재택근무"),
+        new Row(10L, TagCode.MOOD, "편안한"),
+        new Row(11L, TagCode.MOOD, "집중")
+    );
+
+    Map<Long, SetupService.TagsBundle> result = SetupService.buildTagsBySetupId(rows);
+    SetupService.TagsBundle bundle = result.get(10L);
+
+    assertNotNull(bundle);
+    assertEquals(List.of("거실"), bundle.getTags().getSpace());
+    assertEquals(List.of("미니멀"), bundle.getTags().getTone());
+    assertEquals(List.of("재택근무"), bundle.getTags().getSituation());
+    assertEquals(List.of("편안한"), bundle.getTags().getMood());
+    assertEquals(List.of("거실", "미니멀", "재택근무", "편안한"),
+        bundle.getTagsFlat());
+  }
+
+  private static class Row implements SetupTagRow {
+    private final Long setupId;
+    private final TagCode tagCode;
+    private final String tagName;
+
+    Row(Long setupId, TagCode tagCode, String tagName) {
+      this.setupId = setupId;
+      this.tagCode = tagCode;
+      this.tagName = tagName;
+    }
+
+    @Override
+    public Long getSetupId() {
+      return setupId;
+    }
+
+    @Override
+    public TagCode getTagCode() {
+      return tagCode;
+    }
+
+    @Override
+    public String getTagName() {
+      return tagName;
+    }
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용
- Product 조회 API 추가: GET /api/products, GET /api/products/{id}
- Setup 조회 API 추가: GET /api/setups, GET /api/setups/{id}
- Product/Setup 태그 배치 조회 및 tags/tagsFlat 응답 조립(soft-delete 필터 포함)
- 태그 집계 로직 단위 테스트 추가(Product/Setup)

## 🧐 리뷰 포인트
- DTO snake_case 응답(JSONProperty) 방식이 적절한지 봐주세요.