### PR TITLE
프론트-백 연동 작업 : 회원 가입, 로그인, 로그아웃

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,6 +8,7 @@
       "name": "deskit-front",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.4.0",
         "swiper": "^12.0.3",
         "vue": "^3.5.24",
         "vue-router": "^4.6.4"
@@ -1049,11 +1050,76 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -1065,6 +1131,51 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -1133,6 +1244,42 @@
         }
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1148,6 +1295,103 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1155,6 +1399,36 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/muggle-string": {
@@ -1235,6 +1509,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.53.3",

--- a/front/package.json
+++ b/front/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.4.0",
     "swiper": "^12.0.3",
     "vue": "^3.5.24",
     "vue-router": "^4.6.4"

--- a/front/src/lib/auth.ts
+++ b/front/src/lib/auth.ts
@@ -13,6 +13,8 @@ export type AuthUser = {
   userId?: number
 }
 
+const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
+
 export const getAuthUser = (): AuthUser | null => {
   const raw = localStorage.getItem('deskit-user')
   if (!raw) return null
@@ -77,4 +79,36 @@ export const loginAdmin = (): void => {
 export const logout = (): void => {
   ;['deskit-user', 'deskit-auth', 'token'].forEach((key) => localStorage.removeItem(key))
   window.dispatchEvent(new Event('deskit-user-updated'))
+}
+
+export const hydrateSessionUser = async (): Promise<boolean> => {
+  try {
+    let response = await fetch(`${apiBase}/my`, {credentials: 'include'})
+    if (!response.ok) {
+      if (response.status === 401) {
+        const reissue = await fetch(`${apiBase}/reissue`, {
+          method: 'POST',
+          credentials: 'include',
+        })
+        if (!reissue.ok) return false
+        response = await fetch(`${apiBase}/my`, {credentials: 'include'})
+      }
+      if (!response.ok) return false
+    }
+
+    if (!getAuthUser()) {
+      const authUser = {
+        name: '로그인 사용자',
+        email: '',
+        signupType: '소셜 회원',
+        memberCategory: '일반회원',
+      }
+      localStorage.setItem('deskit-user', JSON.stringify(authUser))
+      window.dispatchEvent(new Event('deskit-user-updated'))
+    }
+
+    return true
+  } catch {
+    return false
+  }
 }

--- a/front/src/pages/Login.vue
+++ b/front/src/pages/Login.vue
@@ -1,50 +1,15 @@
-<script setup lang="ts">
-import { useRouter, useRoute } from 'vue-router'
+﻿<script setup lang="ts">
+import { useRouter } from 'vue-router'
 import PageContainer from '../components/PageContainer.vue'
 import PageHeader from '../components/PageHeader.vue'
-import { loginAdmin, loginSeller } from '../lib/auth'
 
 type Provider = 'kakao' | 'naver' | 'google'
 
 const router = useRouter()
-const route = useRoute()
-
-const mockUserByProvider = (provider: Provider) => {
-  const signupLabel =
-      provider === 'kakao'
-          ? '소셜 회원(Kakao)'
-          : provider === 'naver'
-              ? '소셜 회원(Naver)'
-              : '소셜 회원(Google)'
-
-  return {
-    name: '홍길동',
-    email: `honggildong+${provider}@test.com`,
-    signupType: signupLabel,
-    memberCategory: '일반회원',
-    mbti: 'INFJ',
-    job: '직장인',
-  }
-}
+const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
 
 const handleLogin = (provider: Provider) => {
-  const user = mockUserByProvider(provider)
-  localStorage.setItem('deskit-user', JSON.stringify(user))
-  localStorage.setItem('deskit-auth', provider)
-  window.dispatchEvent(new Event('deskit-user-updated'))
-
-  const redirect = (route.query.redirect as string) || '/'
-  router.push(redirect).catch(() => {})
-}
-
-const goToSeller = () => {
-  loginSeller()
-  router.push('/seller').catch(() => {})
-}
-
-const goToAdmin = () => {
-  loginAdmin()
-  router.push('/admin').catch(() => {})
+  window.location.href = `${apiBase}/oauth2/authorization/${provider}`
 }
 </script>
 
@@ -65,8 +30,8 @@ const goToAdmin = () => {
             <span class="brand-ico" aria-hidden="true">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
                 <path
-                    d="M12 4c-4.7 0-8.5 2.9-8.5 6.6 0 2.4 1.6 4.5 4 5.7l-1 3.6c-.1.4.3.7.6.5l4.2-2.8c.2 0 .5.1.7.1 4.7 0 8.5-2.9 8.5-6.6S16.7 4 12 4z"
-                    fill="currentColor"
+                  d="M12 4c-4.7 0-8.5 2.9-8.5 6.6 0 2.4 1.6 4.5 4 5.7l-1 3.6c-.1.4.3.7.6.5l4.2-2.8c.2 0 .5.1.7.1 4.7 0 8.5-2.9 8.5-6.6S16.7 4 12 4z"
+                  fill="currentColor"
                 />
               </svg>
             </span>
@@ -86,37 +51,27 @@ const goToAdmin = () => {
             <span class="brand-ico google" aria-hidden="true">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
                 <path
-                    d="M21.6 12.3c0-.7-.1-1.2-.2-1.8H12v3.4h5.4c-.1.9-.7 2.2-2 3.1v2.2h3.2c1.9-1.7 3-4.3 3-7.9z"
-                    fill="currentColor"
+                  d="M21.6 12.3c0-.7-.1-1.2-.2-1.8H12v3.4h5.4c-.1.9-.7 2.2-2 3.1v2.2h3.2c1.9-1.7 3-4.3 3-7.9z"
+                  fill="currentColor"
                 />
                 <path
-                    d="M12 22c2.7 0 5-.9 6.6-2.5l-3.2-2.2c-.9.6-2 .9-3.4.9-2.6 0-4.8-1.7-5.6-4.1H3v2.3C4.7 19.8 8.1 22 12 22z"
-                    fill="currentColor"
-                    opacity=".6"
+                  d="M12 22c2.7 0 5-.9 6.6-2.5l-3.2-2.2c-.9.6-2 .9-3.4.9-2.6 0-4.8-1.7-5.6-4.1H3v2.3C4.7 19.8 8.1 22 12 22z"
+                  fill="currentColor"
+                  opacity=".6"
                 />
                 <path
-                    d="M6.4 14.1c-.2-.6-.3-1.2-.3-1.8s.1-1.2.3-1.8V8.2H3C2.4 9.4 2 10.7 2 12.3c0 1.6.4 2.9 1 4.1l3.4-2.3z"
-                    fill="currentColor"
-                    opacity=".4"
+                  d="M6.4 14.1c-.2-.6-.3-1.2-.3-1.8s.1-1.2.3-1.8V8.2H3C2.4 9.4 2 10.7 2 12.3c0 1.6.4 2.9 1 4.1l3.4-2.3z"
+                  fill="currentColor"
+                  opacity=".4"
                 />
                 <path
-                    d="M12 6.7c1.9 0 3.2.8 3.9 1.5l2.9-2.8C17 3.8 14.7 2.7 12 2.7 8.1 2.7 4.7 4.9 3 8.2l3.4 2.3c.8-2.4 3-3.8 5.6-3.8z"
-                    fill="currentColor"
-                    opacity=".8"
+                  d="M12 6.7c1.9 0 3.2.8 3.9 1.5l2.9-2.8C17 3.8 14.7 2.7 12 2.7 8.1 2.7 4.7 4.9 3 8.2l3.4 2.3c.8-2.4 3-3.8 5.6-3.8z"
+                  fill="currentColor"
+                  opacity=".8"
                 />
               </svg>
             </span>
             <span class="btn-text">구글로 시작하기</span>
-          </button>
-
-          <button type="button" class="social-btn seller" @click="goToSeller">
-            <span class="brand-ico" aria-hidden="true">S</span>
-            <span class="btn-text">판매자 로그인</span>
-          </button>
-
-          <button type="button" class="social-btn admin" @click="goToAdmin">
-            <span class="brand-ico" aria-hidden="true">A</span>
-            <span class="btn-text">관리자 로그인</span>
           </button>
         </div>
 
@@ -266,28 +221,6 @@ const goToAdmin = () => {
 
 .social-btn.google .brand-ico {
   background: #f3f4f6;
-}
-
-.social-btn.seller {
-  background: var(--surface);
-  color: var(--text-strong);
-  border-color: var(--border-color);
-}
-
-.social-btn.seller .brand-ico {
-  background: var(--surface-weak);
-  color: var(--text-strong);
-}
-
-.social-btn.admin {
-  background: var(--surface-weak);
-  color: var(--text-strong);
-  border-color: var(--border-color);
-}
-
-.social-btn.admin .brand-ico {
-  background: #ffffff;
-  color: var(--text-strong);
 }
 
 .btn-text {

--- a/front/src/router/index.ts
+++ b/front/src/router/index.ts
@@ -1,5 +1,5 @@
-import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
-import { isAdmin, isLoggedIn, isSeller } from '../lib/auth'
+﻿import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
+import { hydrateSessionUser, isAdmin, isLoggedIn, isSeller } from '../lib/auth'
 
 const routes: RouteRecordRaw[] = [
   {
@@ -56,6 +56,11 @@ const routes: RouteRecordRaw[] = [
     path: '/login',
     name: 'login',
     component: () => import('../pages/Login.vue'),
+  },
+  {
+    path: '/signup',
+    name: 'signup',
+    component: () => import('../pages/Signup.vue'),
   },
   {
     path: '/my',
@@ -201,11 +206,15 @@ export const router = createRouter({
   },
 })
 
-router.beforeEach((to) => {
-  const loggedIn = isLoggedIn()
+router.beforeEach(async (to) => {
+  let loggedIn = isLoggedIn()
   const isSellerPath = to.path.startsWith('/seller')
   if (!loggedIn && to.path.startsWith('/my')) {
-    return { path: '/login', query: { redirect: to.fullPath } }
+    const sessionOk = await hydrateSessionUser()
+    if (!sessionOk) {
+      return { path: '/login', query: { redirect: to.fullPath } }
+    }
+    loggedIn = isLoggedIn()
   }
   if (isSellerPath && !loggedIn) {
     return { path: '/login', query: { redirect: to.fullPath } }
@@ -223,3 +232,5 @@ router.beforeEach((to) => {
   }
   return true
 })
+
+

--- a/src/main/java/com/deskit/deskit/account/config/package-info.java
+++ b/src/main/java/com/deskit/deskit/account/config/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.account.config;

--- a/src/main/java/com/deskit/deskit/account/controller/InvitationController.java
+++ b/src/main/java/com/deskit/deskit/account/controller/InvitationController.java
@@ -1,0 +1,181 @@
+package com.deskit.deskit.account.controller;
+
+import com.deskit.deskit.account.entity.Invitation;
+import com.deskit.deskit.account.entity.Member;
+import com.deskit.deskit.account.entity.Seller;
+import com.deskit.deskit.account.enums.InvitationStatus;
+import com.deskit.deskit.account.enums.SellerRole;
+import com.deskit.deskit.account.oauth.CustomOAuth2User;
+import com.deskit.deskit.account.repository.InvitationRepository;
+import com.deskit.deskit.account.repository.MemberRepository;
+import com.deskit.deskit.account.repository.SellerRepository;
+import com.deskit.deskit.account.service.InviteEmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/invitations")
+public class InvitationController {
+
+    // Maximum number of invitations allowed per owner.
+    private static final int INVITATION_LIMIT = 2;
+
+    // Invitation expiration window in hours.
+    private static final long INVITATION_EXPIRY_HOURS = 24L;
+
+    private final InvitationRepository invitationRepository;
+    private final SellerRepository sellerRepository;
+    private final MemberRepository memberRepository;
+    private final InviteEmailService inviteEmailService;
+
+    // Create a new seller invitation and email the link.
+    @PostMapping
+    @Transactional
+    public ResponseEntity<?> inviteSeller(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @RequestBody Map<String, String> payload
+    ) {
+        // Reject if unauthenticated.
+        if (user == null) {
+            return new ResponseEntity<>("unauthorized", HttpStatus.UNAUTHORIZED);
+        }
+
+        // Extract current user role for authorization.
+        String role = user.getAuthorities().iterator().next().getAuthority();
+        if (!SellerRole.ROLE_SELLER_OWNER.name().equals(role)) {
+            return new ResponseEntity<>("owner role required", HttpStatus.FORBIDDEN);
+        }
+
+        // Extract and validate invite email.
+        String email = trimToNull(payload.get("email"));
+        if (email == null) {
+            return new ResponseEntity<>("email required", HttpStatus.BAD_REQUEST);
+        }
+
+        // Reject duplicate invitations for the same email.
+        if (invitationRepository.existsByEmailAndStatusIn(
+                email,
+                List.of(InvitationStatus.PENDING.name(), InvitationStatus.ACCEPTED.name()))
+        ) {
+            return new ResponseEntity<>("duplicate invitation", HttpStatus.CONFLICT);
+        }
+
+        // Reject if the email already belongs to a registered user.
+        Member existingUser = memberRepository.findByLoginId(email);
+        if (existingUser != null) {
+            return new ResponseEntity<>("email already registered", HttpStatus.CONFLICT);
+        }
+
+        // Lookup owner seller record for invitation linkage.
+        Seller ownerSeller = sellerRepository.findByLoginId(user.getEmail());
+        if (ownerSeller == null) {
+            return new ResponseEntity<>("owner seller not found", HttpStatus.NOT_FOUND);
+        }
+
+        // Enforce invitation limit per owner seller.
+        long inviteCount = invitationRepository.countBySellerIdAndStatusIn(
+                ownerSeller.getSellerId(),
+                List.of(InvitationStatus.PENDING.name(), InvitationStatus.ACCEPTED.name())
+        );
+        if (inviteCount >= INVITATION_LIMIT) {
+            return new ResponseEntity<>("invitation limit reached", HttpStatus.CONFLICT);
+        }
+
+        // Timestamp for invitation creation.
+        LocalDateTime now = LocalDateTime.now();
+
+        // Compute invitation expiry.
+        LocalDateTime expiresAt = now.plusHours(INVITATION_EXPIRY_HOURS);
+
+        // Token format includes UUID and expiry epoch seconds.
+        String token = UUID.randomUUID() + "-" + expiresAt.toEpochSecond(ZoneOffset.UTC);
+
+        // Invitation record for persistence.
+        Invitation invitation = Invitation.builder()
+                .email(email)
+                .createdAt(now)
+                .updatedAt(now)
+                .expiredAt(expiresAt)
+                .status(InvitationStatus.valueOf(InvitationStatus.PENDING.name()))
+                .token(token)
+                .sellerId(ownerSeller.getSellerId())
+                .build();
+
+        invitationRepository.save(invitation);
+
+        // Build invite URL for the signup page.
+        String inviteUrl = "http://localhost:5173/signup?invite=" +
+                URLEncoder.encode(token, StandardCharsets.UTF_8);
+
+        try {
+            inviteEmailService.sendInviteMail(email, inviteUrl);
+        } catch (IOException ex) {
+            throw new IllegalStateException("invite email send failed", ex);
+        }
+
+        return new ResponseEntity<>("invitation sent", HttpStatus.OK);
+    }
+
+    // Validate an invitation token before signup.
+    @GetMapping("/validate")
+    @Transactional
+    public ResponseEntity<?> validateInvitation(@RequestParam("token") String token) {
+        // Normalize and validate token input.
+        String normalizedToken = trimToNull(token);
+        if (normalizedToken == null) {
+            return new ResponseEntity<>("token required", HttpStatus.BAD_REQUEST);
+        }
+
+        // Lookup invitation by token.
+        Invitation invitation = invitationRepository.findByToken(normalizedToken);
+        if (invitation == null) {
+            return new ResponseEntity<>("invitation not found", HttpStatus.NOT_FOUND);
+        }
+
+        // Return conflict for already used invitations.
+        if (!InvitationStatus.PENDING.name().equalsIgnoreCase(String.valueOf(invitation.getStatus()))) {
+            return new ResponseEntity<>("invitation already used", HttpStatus.CONFLICT);
+        }
+
+        // Mark expired invitations and report error.
+        LocalDateTime now = LocalDateTime.now();
+        if (invitation.getExpiredAt() != null && invitation.getExpiredAt().isBefore(now)) {
+            invitation.setStatus(InvitationStatus.valueOf(InvitationStatus.EXPIRED.name()));
+            invitation.setUpdatedAt(now);
+            invitationRepository.save(invitation);
+            return new ResponseEntity<>("invitation expired", HttpStatus.GONE);
+        }
+
+        // Response payload for valid invitation.
+        Map<String, String> payload = Map.of(
+                "email", invitation.getEmail(),
+                "expiresAt", invitation.getExpiredAt().toString()
+        );
+
+        return new ResponseEntity<>(payload, HttpStatus.OK);
+    }
+
+    // Normalize optional text input to null when blank.
+    private String trimToNull(String value) {
+        // Trimmed value from optional input.
+        String trimmed = value == null ? null : value.trim();
+        if (trimmed == null || trimmed.isEmpty()) {
+            return null;
+        }
+        return trimmed;
+    }
+}

--- a/src/main/java/com/deskit/deskit/account/controller/MainController.java
+++ b/src/main/java/com/deskit/deskit/account/controller/MainController.java
@@ -1,0 +1,16 @@
+package com.deskit.deskit.account.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class MainController {
+
+    @GetMapping("/")
+    @ResponseBody
+    public String mainAPI() {
+
+        return "main route";
+    }
+}

--- a/src/main/java/com/deskit/deskit/account/controller/MyController.java
+++ b/src/main/java/com/deskit/deskit/account/controller/MyController.java
@@ -1,0 +1,16 @@
+package com.deskit.deskit.account.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class MyController {
+
+    @GetMapping("/my")
+    @ResponseBody
+    public String myAPI() {
+
+        return "my route";
+    }
+}

--- a/src/main/java/com/deskit/deskit/account/controller/ReissueController.java
+++ b/src/main/java/com/deskit/deskit/account/controller/ReissueController.java
@@ -1,0 +1,98 @@
+package com.deskit.deskit.account.controller;
+
+import com.deskit.deskit.account.jwt.JWTUtil;
+import com.deskit.deskit.account.repository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Log4j2
+@RestController
+@RequiredArgsConstructor
+public class ReissueController {
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+
+        //get refresh token
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                log.info("cookie: " + cookie);
+                if (cookie.getName().equals("refresh")) {
+                    refresh = cookie.getValue();
+                }
+            }
+        }
+
+        if (refresh == null) {
+
+            log.info("refresh token is null");
+            //response status code
+            return new ResponseEntity<>("refresh token null", HttpStatus.BAD_REQUEST);
+        }
+
+        //expired check
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+
+            log.info("refresh token is expired");
+            //response status code
+            return new ResponseEntity<>("refresh token expired", HttpStatus.BAD_REQUEST);
+        }
+
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+
+        if (!category.equals("refresh")) {
+
+            log.info("refresh token is invalid");
+            //response status code
+            return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
+        }
+
+        String username = jwtUtil.getUsername(refresh);
+        String role = jwtUtil.getRole(refresh);
+
+        //make new JWT
+        String newAccess = jwtUtil.createJwt("access", username, role, 600000L);
+        String newRefresh = jwtUtil.createJwt("refresh", username, role, 86400000L);
+        log.info("new access: " + newAccess);
+        log.info("new refresh: " + newRefresh);
+
+        //Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
+        refreshRepository.deleteByRefresh(refresh);
+        refreshRepository.save(username, newRefresh, 86400000L);
+
+        //response
+        response.setHeader("access", newAccess);
+        response.addCookie(createCookie("access", newAccess, 600));
+        response.addCookie(createCookie("refresh", newRefresh, 24 * 60 * 60));
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    private Cookie createCookie(String key, String value, int maxAge) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(maxAge);
+        //cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+}

--- a/src/main/java/com/deskit/deskit/account/controller/SignupController.java
+++ b/src/main/java/com/deskit/deskit/account/controller/SignupController.java
@@ -1,0 +1,511 @@
+package com.deskit.deskit.account.controller;
+
+import com.deskit.deskit.account.dto.SocialSignupRequest;
+import com.deskit.deskit.account.entity.*;
+import com.deskit.deskit.account.enums.*;
+import com.deskit.deskit.account.jwt.JWTUtil;
+import com.deskit.deskit.account.oauth.CustomOAuth2User;
+import com.deskit.deskit.account.repository.*;
+import com.deskit.deskit.common.util.verification.PhoneSendRequest;
+import com.deskit.deskit.common.util.verification.PhoneSendResponse;
+import com.deskit.deskit.common.util.verification.PhoneVerifyRequest;
+import com.deskit.deskit.account.dto.PendingSignupResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/signup/social")
+public class SignupController {
+
+    // Session key for phone number awaiting verification.
+    private static final String SESSION_PHONE_NUMBER = "pendingPhoneNumber";
+
+    // Session key for verification code.
+    private static final String SESSION_PHONE_CODE = "pendingPhoneCode";
+
+    // Session key for verification completion flag.
+    private static final String SESSION_PHONE_VERIFIED = "pendingPhoneVerified";
+
+    private final MemberRepository memberRepository;
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+    private final SellerRepository sellerRepository;
+    private final CompanyRegisteredRepository companyRegisteredRepository;
+    private final SellerRegisterRepository sellerRegisterRepository;
+    private final SellerGradeRepository sellerGradeRepository;
+    private final InvitationRepository invitationRepository;
+
+    // Provide pending signup info to the frontend after social login.
+    @GetMapping("/pending")
+    public ResponseEntity<?> pending(
+            @AuthenticationPrincipal CustomOAuth2User user
+    ) {
+        // Reject if unauthenticated.
+        if (user == null) {
+            return new ResponseEntity<>("unauthorized", HttpStatus.UNAUTHORIZED);
+        }
+
+        // Reject if signup is already completed.
+        if (!user.isNewUser()) {
+            return new ResponseEntity<>("already signed up", HttpStatus.CONFLICT);
+        }
+
+        // Response payload to prefill signup form.
+        PendingSignupResponse response = PendingSignupResponse.builder()
+                .username(user.getUsername())
+                .name(user.getName())
+                .email(user.getEmail())
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    // Send a verification code for phone validation.
+    @PostMapping("/phone/send")
+    public ResponseEntity<?> sendPhoneCode(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @RequestBody PhoneSendRequest request,
+            HttpSession session
+    ) {
+        // Reject if unauthenticated.
+        if (user == null) {
+            return new ResponseEntity<>("unauthorized", HttpStatus.UNAUTHORIZED);
+        }
+
+        // Reject if signup is already completed.
+        if (!user.isNewUser()) {
+            return new ResponseEntity<>("already signed up", HttpStatus.CONFLICT);
+        }
+
+        // Phone number from the request payload.
+        String phoneNumber = request.getPhoneNumber();
+        if (phoneNumber == null || phoneNumber.isBlank()) {
+            return new ResponseEntity<>("phone number required", HttpStatus.BAD_REQUEST);
+        }
+
+        // Generate a 6-digit verification code for development.
+        String code = String.format("%06d", ThreadLocalRandom.current().nextInt(100000, 1000000));
+
+        // Persist phone verification state in session.
+        session.setAttribute(SESSION_PHONE_NUMBER, phoneNumber);
+        session.setAttribute(SESSION_PHONE_CODE, code);
+        session.setAttribute(SESSION_PHONE_VERIFIED, false);
+
+        // Response payload containing dev-only code.
+        PhoneSendResponse response = PhoneSendResponse.builder()
+                .message("verification code generated")
+                .code(code)
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    // Verify phone code submitted by the user.
+    @PostMapping("/phone/verify")
+    public ResponseEntity<?> verifyPhoneCode(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @RequestBody PhoneVerifyRequest request,
+            HttpSession session
+    ) {
+        // Reject if unauthenticated.
+        if (user == null) {
+            return new ResponseEntity<>("unauthorized", HttpStatus.UNAUTHORIZED);
+        }
+
+        // Reject if signup is already completed.
+        if (!user.isNewUser()) {
+            return new ResponseEntity<>("already signed up", HttpStatus.CONFLICT);
+        }
+
+        // Phone number and code from the request payload.
+        String phoneNumber = request.getPhoneNumber();
+        String code = request.getCode();
+
+        // Session-stored verification state.
+        String storedPhone = (String) session.getAttribute(SESSION_PHONE_NUMBER);
+        String storedCode = (String) session.getAttribute(SESSION_PHONE_CODE);
+
+        if (!Objects.equals(phoneNumber, storedPhone) || !Objects.equals(code, storedCode)) {
+            return new ResponseEntity<>("verification failed", HttpStatus.BAD_REQUEST);
+        }
+
+        session.setAttribute(SESSION_PHONE_VERIFIED, true);
+
+        return new ResponseEntity<>("verified", HttpStatus.OK);
+    }
+
+    // Complete signup for general members after phone verification.
+    @PostMapping("/complete")
+    @Transactional
+    public ResponseEntity<?> completeSignup(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @RequestBody SocialSignupRequest request,
+            HttpServletResponse response,
+            HttpSession session
+    ) {
+        // Reject if unauthenticated.
+        if (user == null) {
+            return new ResponseEntity<>("unauthorized", HttpStatus.UNAUTHORIZED);
+        }
+
+        // Reject if signup is already completed.
+        if (!user.isNewUser()) {
+            return new ResponseEntity<>("already signed up", HttpStatus.CONFLICT);
+        }
+
+        // Ensure user does not already exist in DB.
+        Member existData = memberRepository.findByLoginId(user.getEmail());
+        if (existData != null) {
+            return new ResponseEntity<>("already signed up", HttpStatus.CONFLICT);
+        }
+
+        // Ensure seller does not already exist in DB.
+        Seller existSeller = sellerRepository.findByLoginId(user.getEmail());
+        if (existSeller != null) {
+            return new ResponseEntity<>("already signed up", HttpStatus.CONFLICT);
+        }
+
+        // Validate terms agreement.
+        if (!request.isAgreed()) {
+            return new ResponseEntity<>("terms agreement required", HttpStatus.BAD_REQUEST);
+        }
+
+        // Ensure phone verification completed.
+        Boolean verified = (Boolean) session.getAttribute(SESSION_PHONE_VERIFIED);
+        if (verified == null || !verified) {
+            return new ResponseEntity<>("phone verification required", HttpStatus.BAD_REQUEST);
+        }
+
+        // Validate verified phone number matches request.
+        String storedPhone = (String) session.getAttribute(SESSION_PHONE_NUMBER);
+        if (!Objects.equals(storedPhone, request.getPhoneNumber())) {
+            return new ResponseEntity<>("phone number mismatch", HttpStatus.BAD_REQUEST);
+        }
+
+        // Member type selected for signup branching.
+        // Raw member type input from request payload.
+        String memberTypeRaw = trimToNull(request.getMemberType());
+        if (memberTypeRaw == null) {
+            return new ResponseEntity<>("member type required", HttpStatus.BAD_REQUEST);
+        }
+
+        // Normalized member type for signup branching.
+        String memberType = normalizeMemberType(memberTypeRaw);
+        if (memberType == null) {
+            return new ResponseEntity<>("unsupported member type", HttpStatus.BAD_REQUEST);
+        }
+
+        if ("GENERAL".equals(memberType)) {
+            return completeGeneralSignup(user, request, response, session, storedPhone);
+        }
+
+        if ("SELLER".equals(memberType)) {
+            return completeSellerSignup(user, request, response, session, storedPhone);
+        }
+
+        return new ResponseEntity<>("unsupported member type", HttpStatus.BAD_REQUEST);
+    }
+
+    // Handle general member signup completion.
+    private ResponseEntity<?> completeGeneralSignup(
+            CustomOAuth2User user,
+            SocialSignupRequest request,
+            HttpServletResponse response,
+            HttpSession session,
+            String storedPhone
+    ) {
+        // Build and persist the new user entity.
+        Member member = Member.builder()
+                .loginId(user.getEmail())
+                .name(user.getName())
+                .role("ROLE_MEMBER")
+                .phone(storedPhone)
+                .profile(user.getProfileUrl())
+                .status(MemberStatus.ACTIVE)
+                .mbti(MBTI.valueOf(trimToNull(String.valueOf(request.getMbti()))))
+                .jobCategory(JobCategory.valueOf(trimToNull(String.valueOf(request.getJobCategory()))))
+                .isAgreed(request.isAgreed())
+                .build();
+
+        memberRepository.save(member);
+
+        // Issue tokens after successful signup.
+        issueTokens(member.getLoginId(), member.getRole(), response);
+
+        // Clear phone verification state after completion.
+        clearPhoneSession(session);
+
+        return new ResponseEntity<>("signup completed", HttpStatus.OK);
+    }
+
+    // Handle seller signup completion with review data.
+    private ResponseEntity<?> completeSellerSignup(
+            CustomOAuth2User user,
+            SocialSignupRequest request,
+            HttpServletResponse response,
+            HttpSession session,
+            String storedPhone
+    ) {
+        // Invitation token for invited seller signup.
+        String inviteToken = trimToNull(request.getInviteToken());
+        if (inviteToken != null) {
+            return completeInvitedSellerSignup(user, response, session, storedPhone, inviteToken);
+        }
+
+        // Business number required for seller registration.
+        String businessNumber = trimToNull(request.getBusinessNumber());
+        if (businessNumber == null) {
+            return new ResponseEntity<>("business number required", HttpStatus.BAD_REQUEST);
+        }
+
+        // Company name required for seller registration.
+        String companyName = trimToNull(request.getCompanyName());
+        if (companyName == null) {
+            return new ResponseEntity<>("company name required", HttpStatus.BAD_REQUEST);
+        }
+
+        // Plan file payload required for seller registration.
+        String planFileBase64 = trimToNull(request.getPlanFileBase64());
+        if (planFileBase64 == null) {
+            return new ResponseEntity<>("plan file required", HttpStatus.BAD_REQUEST);
+        }
+
+        // Reject when the business number is already registered.
+        CompanyRegistered existingCompany = companyRegisteredRepository.findByBusinessNumber(businessNumber);
+        if (existingCompany != null
+                && CompanyStatus.ACTIVE.name().equalsIgnoreCase(existingCompany.getCompanyStatus().toString())) {
+            return new ResponseEntity<>("business number already registered", HttpStatus.CONFLICT);
+        }
+
+        // Optional seller description for review.
+        String description = trimToNull(request.getDescription());
+
+        // Decode plan file from base64 payload.
+        byte[] planFile;
+        try {
+            planFile = decodePlanFile(planFileBase64);
+        } catch (IllegalArgumentException ex) {
+            return new ResponseEntity<>("invalid plan file payload", HttpStatus.BAD_REQUEST);
+        }
+
+        // Timestamp used for seller-related records.
+        LocalDateTime now = LocalDateTime.now();
+
+        // Build and persist the new seller user entity.
+        Seller seller = Seller.builder()
+                .loginId(user.getEmail())
+                .name(user.getName())
+                .phone(storedPhone)
+                .profile(user.getProfileUrl())
+                .role(SellerRole.valueOf(SellerRole.ROLE_SELLER_OWNER.name()))
+                .status(SellerStatus.valueOf(SellerStatus.PENDING.name()))
+                .createdAt(now)
+                .updatedAt(now)
+                .isAgreed(request.isAgreed())
+                .build();
+
+        sellerRepository.save(seller);
+
+        // Store the registered company for duplicate checks.
+        CompanyRegistered companyRegistered = CompanyRegistered.builder()
+                .companyName(companyName)
+                .businessNumber(businessNumber)
+                .sellerId(seller.getSellerId())
+                .createdAt(now)
+                .companyStatus(CompanyStatus.valueOf(CompanyStatus.ACTIVE.name()))
+                .build();
+
+        companyRegisteredRepository.save(companyRegistered);
+
+        // Store seller review submission details.
+        SellerRegister sellerRegister = SellerRegister.builder()
+                .planFile(planFile)
+                .sellerId(seller.getSellerId())
+                .description(description)
+                .companyName(companyName)
+                .build();
+
+        sellerRegisterRepository.save(sellerRegister);
+
+        // Assign initial seller grade in review status.
+        SellerGrade sellerGrade = SellerGrade.builder()
+                .grade(SellerGradeEnum.valueOf(SellerGradeEnum.C.name()))
+                .gradeStatus(SellerGradeStatus.valueOf(SellerGradeStatus.REVIEW.name()))
+                .createdAt(now)
+                .updatedAt(now)
+                .expiredAt(now.plusYears(1))
+                .companyId(companyRegistered.getCompanyId())
+                .build();
+
+        sellerGradeRepository.save(sellerGrade);
+
+        // Issue tokens after successful signup request.
+        issueTokens(seller.getLoginId(), String.valueOf(seller.getRole()), response);
+
+        // Clear phone verification state after completion.
+        clearPhoneSession(session);
+
+        return new ResponseEntity<>(
+                "판매자 회원 가입 신청이 완료되었습니다. 관리자 승인 후에 서비스 이용이 가능합니다.",
+                HttpStatus.OK
+        );
+    }
+
+    // Handle invited seller signup completion with manager role.
+    private ResponseEntity<?> completeInvitedSellerSignup(
+            CustomOAuth2User user,
+            HttpServletResponse response,
+            HttpSession session,
+            String storedPhone,
+            String inviteToken
+    ) {
+        // Invitation lookup by token.
+        Invitation invitation = invitationRepository.findByToken(inviteToken);
+        if (invitation == null) {
+            return new ResponseEntity<>("invitation not found", HttpStatus.NOT_FOUND);
+        }
+
+        // Validate invitation status.
+        if (!InvitationStatus.PENDING.name().equalsIgnoreCase(String.valueOf(invitation.getStatus()))) {
+            return new ResponseEntity<>("invitation already used", HttpStatus.CONFLICT);
+        }
+
+        // Validate invitation expiration.
+        LocalDateTime now = LocalDateTime.now();
+        if (invitation.getExpiredAt() != null && invitation.getExpiredAt().isBefore(now)) {
+            invitation.setStatus(InvitationStatus.valueOf(InvitationStatus.EXPIRED.name()));
+            invitation.setUpdatedAt(now);
+            invitationRepository.save(invitation);
+            return new ResponseEntity<>("invitation expired", HttpStatus.GONE);
+        }
+
+        // Ensure the invitation email matches the signup email.
+        String inviteEmail = trimToNull(invitation.getEmail());
+        String signupEmail = trimToNull(user.getEmail());
+        if (inviteEmail == null || signupEmail == null || !inviteEmail.equalsIgnoreCase(signupEmail)) {
+            return new ResponseEntity<>("invitation email mismatch", HttpStatus.BAD_REQUEST);
+        }
+
+        // Ensure the invitation owner seller exists.
+        Seller ownerSeller = sellerRepository.findById(invitation.getSellerId()).orElse(null);
+        if (ownerSeller == null) {
+            return new ResponseEntity<>("invitation owner not found", HttpStatus.NOT_FOUND);
+        }
+
+        // Build and persist the new manager seller entity.
+        Seller seller = Seller.builder()
+                .loginId(user.getEmail())
+                .name(user.getName())
+                .phone(storedPhone)
+                .profile(user.getProfileUrl())
+                .role(SellerRole.valueOf(SellerRole.ROLE_SELLER_MANAGER.name()))
+                .status(SellerStatus.valueOf(SellerStatus.ACTIVE.name()))
+                .createdAt(now)
+                .updatedAt(now)
+                .isAgreed(true)
+                .build();
+
+        sellerRepository.save(seller);
+
+        // Mark invitation as accepted after successful signup.
+        invitation.setStatus(InvitationStatus.valueOf(InvitationStatus.ACCEPTED.name()));
+        invitation.setUpdatedAt(now);
+        invitationRepository.save(invitation);
+
+        // Issue tokens after successful invited signup.
+        issueTokens(seller.getLoginId(), String.valueOf(seller.getRole()), response);
+
+        // Clear phone verification state after completion.
+        clearPhoneSession(session);
+
+        return new ResponseEntity<>("invited seller signup completed", HttpStatus.OK);
+    }
+
+    // Issue access/refresh tokens and persist refresh token.
+    private void issueTokens(String username, String role, HttpServletResponse response) {
+        // Access token expiry in milliseconds.
+        long accessExpiryMs = 600000L;
+
+        // Refresh token expiry in milliseconds.
+        long refreshExpiryMs = 86400000L;
+
+        // Create tokens for the signed-up user.
+        String access = jwtUtil.createJwt("access", username, role, accessExpiryMs); // Access token for header.
+        String refresh = jwtUtil.createJwt("refresh", username, role, refreshExpiryMs); // Refresh token for cookie.
+
+        refreshRepository.save(username, refresh, refreshExpiryMs);
+
+        response.setHeader("access", access);
+        response.addCookie(createCookie("access", access, Math.toIntExact(accessExpiryMs / 1000)));
+        response.addCookie(createCookie("refresh", refresh, Math.toIntExact(refreshExpiryMs / 1000)));
+    }
+
+    // Create a cookie with HttpOnly flag.
+    private Cookie createCookie(String key, String value, int maxAge) {
+        // Cookie for refresh token storage.
+        Cookie cookie = new Cookie(key, value);
+
+        cookie.setMaxAge(maxAge);
+        // cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+    // Persist refresh token record for reissue workflow.
+    // Clear phone verification attributes after signup completion.
+    private void clearPhoneSession(HttpSession session) {
+        // Cleanup pending phone state stored in session.
+        session.removeAttribute(SESSION_PHONE_NUMBER);
+        session.removeAttribute(SESSION_PHONE_CODE);
+        session.removeAttribute(SESSION_PHONE_VERIFIED);
+    }
+
+    // Decode base64 plan file payload, tolerating data URL prefixes.
+    private byte[] decodePlanFile(String encodedPlanFile) {
+        // Remove data URL prefix if present.
+        int commaIndex = encodedPlanFile.indexOf(',');
+        String payload = commaIndex >= 0 ? encodedPlanFile.substring(commaIndex + 1) : encodedPlanFile;
+        return Base64.getDecoder().decode(payload);
+    }
+
+    // Normalize optional text input to null when blank.
+    private String trimToNull(String value) {
+        // Trimmed value from optional input.
+        String trimmed = value == null ? null : value.trim();
+        if (trimmed == null || trimmed.isEmpty()) {
+            return null;
+        }
+        return trimmed;
+    }
+
+    // Normalize member type input for routing.
+    private String normalizeMemberType(String memberType) {
+        // Upper-cased member type value for validation.
+        String normalized = memberType == null ? null : memberType.trim().toUpperCase();
+        if (normalized == null || normalized.isEmpty()) {
+            return null;
+        }
+        if ("GENERAL".equals(normalized) || "SELLER".equals(normalized)) {
+            return normalized;
+        }
+        return null;
+    }
+}
+
+
+

--- a/src/main/java/com/deskit/deskit/account/controller/package-info.java
+++ b/src/main/java/com/deskit/deskit/account/controller/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.account.controller;

--- a/src/main/java/com/deskit/deskit/account/dto/SocialSignupRequest.java
+++ b/src/main/java/com/deskit/deskit/account/dto/SocialSignupRequest.java
@@ -1,5 +1,9 @@
 package com.deskit.deskit.account.dto;
 
+import com.deskit.deskit.account.enums.JobCategory;
+import com.deskit.deskit.account.enums.MBTI;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,10 +18,10 @@ public class SocialSignupRequest {
     private String phoneNumber;
 
     // 일반회원 MBTI
-    private String mbti;
+    private MBTI mbti;
 
     // 일반회원 직업 카테고리
-    private String jobCategory;
+    private JobCategory jobCategory;
 
     // 판매자 사업자등록번호
     private String businessNumber;
@@ -35,5 +39,7 @@ public class SocialSignupRequest {
     private String inviteToken;
 
     // 약관 동의 체크
+    @JsonProperty("isAgreed")
+    @JsonAlias({"is_agreed", "agreed", "agreeToTerms"})
     private boolean isAgreed;
 }

--- a/src/main/java/com/deskit/deskit/account/dto/UserDTO.java
+++ b/src/main/java/com/deskit/deskit/account/dto/UserDTO.java
@@ -9,13 +9,21 @@ import lombok.Setter;
 @Builder
 public class UserDTO {
 
+    // 권한
     private String role;
+
+    // 이름
     private String name;
+
+    // provider + providerId
     private String username;
 
-    // Email from the social provider.
+    // Email
     private String email;
 
-    // Flag to indicate social user needs extra signup data.
+    // 프로필 사진 주소
+    private String profileUrl;
+
+    // 신규 가입인지 확인하는 플래그
     private boolean newUser;
 }

--- a/src/main/java/com/deskit/deskit/account/dto/package-info.java
+++ b/src/main/java/com/deskit/deskit/account/dto/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.account.dto;

--- a/src/main/java/com/deskit/deskit/account/entity/CompanyRegistered.java
+++ b/src/main/java/com/deskit/deskit/account/entity/CompanyRegistered.java
@@ -32,6 +32,7 @@ public class CompanyRegistered {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    @Column(name = "company_status", nullable = false)
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
     private CompanyStatus companyStatus;
 }

--- a/src/main/java/com/deskit/deskit/account/entity/Invitation.java
+++ b/src/main/java/com/deskit/deskit/account/entity/Invitation.java
@@ -33,6 +33,7 @@ public class Invitation {
     private LocalDateTime updatedAt;
 
     @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
     private InvitationStatus status;
 
     @Column(name = "token", nullable = false)

--- a/src/main/java/com/deskit/deskit/account/entity/Member.java
+++ b/src/main/java/com/deskit/deskit/account/entity/Member.java
@@ -20,6 +20,7 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
     private Long memberId;
 
     @Column(name = "name", nullable = false)
@@ -38,15 +39,18 @@ public class Member {
     private boolean isAgreed;
 
     @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
     @Column(name = "role", nullable = false)
     private String role;
 
     @Column(name = "mbti")
+    @Enumerated(EnumType.STRING)
     private MBTI mbti;
 
     @Column(name = "job_category")
+    @Enumerated(EnumType.STRING)
     private JobCategory jobCategory;
 
     @CreationTimestamp

--- a/src/main/java/com/deskit/deskit/account/entity/Seller.java
+++ b/src/main/java/com/deskit/deskit/account/entity/Seller.java
@@ -23,8 +23,9 @@ public class Seller {
     @Column(name = "seller_id")
     private Long sellerId;
 
-    @Column(name = "seller_status")
-    private SellerStatus sellerStatus;
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private SellerStatus status;
 
     @CreationTimestamp
     @Column(name = "created_at")
@@ -47,5 +48,9 @@ public class Seller {
     private String phone;
 
     @Column(name = "role", nullable = false)
+    @Enumerated(EnumType.STRING)
     private SellerRole role;
+
+    @Column(name = "is_agreed", nullable = false)
+    private boolean isAgreed;
 }

--- a/src/main/java/com/deskit/deskit/account/entity/SellerGrade.java
+++ b/src/main/java/com/deskit/deskit/account/entity/SellerGrade.java
@@ -24,9 +24,11 @@ public class SellerGrade {
     private Long gradeId;
 
     @Column(name = "grade")
+    @Enumerated(EnumType.STRING)
     private SellerGradeEnum grade;
 
-    @Column(name = "grade_status")
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
     private SellerGradeStatus gradeStatus;
 
     @CreationTimestamp

--- a/src/main/java/com/deskit/deskit/account/entity/package-info.java
+++ b/src/main/java/com/deskit/deskit/account/entity/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.account.entity;

--- a/src/main/java/com/deskit/deskit/account/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/deskit/deskit/account/jwt/CustomLogoutFilter.java
@@ -1,0 +1,119 @@
+package com.deskit.deskit.account.jwt;
+
+import com.deskit.deskit.account.repository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    public CustomLogoutFilter(JWTUtil jwtUtil, RefreshRepository refreshRepository) {
+
+        this.jwtUtil = jwtUtil;
+        this.refreshRepository = refreshRepository;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        //path and method verify
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("^\\/logout$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //get refresh token
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("refresh")) {
+                    refresh = cookie.getValue();
+                }
+            }
+        }
+
+        //refresh null check
+        if (refresh == null) {
+
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //expired check
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //DB에 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if (!isExist) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //로그아웃 진행
+        //Refresh 토큰 DB에서 제거
+        refreshRepository.deleteByRefresh(refresh);
+
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+
+        //Refresh 토큰 Cookie 값 0
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        Cookie accessCookie = new Cookie("access", null);
+        accessCookie.setMaxAge(0);
+        accessCookie.setPath("/");
+
+        response.setHeader("access", "");
+        response.addCookie(cookie);
+        response.addCookie(accessCookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/src/main/java/com/deskit/deskit/account/jwt/JWTFilter.java
+++ b/src/main/java/com/deskit/deskit/account/jwt/JWTFilter.java
@@ -1,0 +1,135 @@
+package com.deskit.deskit.account.jwt;
+
+import com.deskit.deskit.account.dto.UserDTO;
+import com.deskit.deskit.account.oauth.CustomOAuth2User;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@Log4j2
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+    public JWTFilter(JWTUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        // 헤더에서 access키에 담긴 토큰을 꺼냄
+        String accessToken = resolveToken(request);
+
+        // 토큰이 없다면 다음 필터로 넘김
+        if (accessToken == null) {
+            log.info("access token is null");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+        try {
+            jwtUtil.isExpired(accessToken);
+        } catch (ExpiredJwtException e) {
+
+            log.info("expired token");
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("access token expired");
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        // 토큰이 access인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(accessToken);
+
+        if (!category.equals("access")) {
+
+            log.info("access token is not access");
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("invalid access token");
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        //토큰에서 username과 role 획득
+        String username = jwtUtil.getUsername(accessToken);
+        String role = jwtUtil.getRole(accessToken);
+
+        //userDTO를 생성하여 값 set
+        UserDTO userDTO = UserDTO.builder()
+                .username(username)
+                .role(role)
+                .newUser("ROLE_GUEST".equals(role))
+                .name(jwtUtil.getName(accessToken))
+                .email(jwtUtil.getEmail(accessToken))
+                .profileUrl(jwtUtil.getProfileUrl(accessToken))
+                .build();
+
+        //UserDetails에 회원 정보 객체 담기
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDTO);
+
+        //스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
+        //세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        // 1) Authorization: Bearer xxx
+        String auth = request.getHeader("Authorization");
+        if (auth != null && auth.startsWith("Bearer ")) {
+            log.info("Bearer token found");
+            return auth.substring(7);
+        }
+
+        // 2) 기존 access 헤더도 지원(필요하면 유지)
+        String legacy = request.getHeader("access");
+        if (legacy != null && !legacy.isBlank()){
+            log.info("legacy token found");
+            return legacy;
+        }
+
+
+        // 3) Cookie에서 access 읽기
+        if (request.getCookies() == null){
+            log.info("cookie is null");
+            return null;
+        }
+
+        for (Cookie c : request.getCookies()) {
+            log.info("cookie found: " + c.getName());
+            if ("access".equals(c.getName())) {
+                return c.getValue();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        return uri.startsWith("/oauth2/")
+                || uri.startsWith("/login/oauth2/")
+                || uri.startsWith("/login");
+    }
+}
+

--- a/src/main/java/com/deskit/deskit/account/jwt/JWTUtil.java
+++ b/src/main/java/com/deskit/deskit/account/jwt/JWTUtil.java
@@ -1,0 +1,87 @@
+package com.deskit.deskit.account.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+
+    public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUsername(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getRole(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    // Optional name claim for signup flow tokens.
+    public String getName(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("name", String.class);
+    }
+
+    // Optional email claim for signup flow tokens.
+    public String getEmail(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
+    }
+
+    // Optional profile URL claim for signup flow tokens.
+    public String getProfileUrl(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("profileUrl", String.class);
+    }
+
+    public String getCategory(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String category, String username, String role, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // Create a signup token containing profile data for pending signup.
+    public String createSignupJwt(String username, String role, String name, String email, String profileUrl, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("category", "access")
+                .claim("username", username)
+                .claim("role", role)
+                .claim("name", name)
+                .claim("email", email)
+                .claim("profileUrl", profileUrl)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/deskit/deskit/account/jwt/package-info.java
+++ b/src/main/java/com/deskit/deskit/account/jwt/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.account.jwt;

--- a/src/main/java/com/deskit/deskit/account/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/deskit/deskit/account/oauth/CustomOAuth2User.java
@@ -1,0 +1,69 @@
+package com.deskit.deskit.account.oauth;
+
+import com.deskit.deskit.account.dto.UserDTO;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+
+    private final UserDTO userDTO;
+
+    public CustomOAuth2User(UserDTO userDTO) {
+
+        this.userDTO = userDTO;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+
+            @Override
+            public String getAuthority() {
+
+                return userDTO.getRole();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+
+        return userDTO.getName();
+    }
+
+    public String getUsername() {
+
+        return userDTO.getUsername();
+    }
+
+    // Expose email for signup screen population.
+    public String getEmail() {
+
+        return userDTO.getEmail();
+    }
+
+    // Expose whether the user still needs signup completion.
+    public boolean isNewUser() {
+
+        return userDTO.isNewUser();
+    }
+
+    public String getProfileUrl() {
+        return userDTO.getProfileUrl();
+    }
+}

--- a/src/main/java/com/deskit/deskit/account/oauth/CustomSuccessHandler.java
+++ b/src/main/java/com/deskit/deskit/account/oauth/CustomSuccessHandler.java
@@ -1,0 +1,82 @@
+package com.deskit.deskit.account.oauth;
+
+
+import com.deskit.deskit.account.jwt.JWTUtil;
+import com.deskit.deskit.account.repository.RefreshRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException {
+
+        CustomOAuth2User user = (CustomOAuth2User) authentication.getPrincipal();
+        String username = user.getUsername();
+        String role = authentication.getAuthorities().iterator().next().getAuthority();
+
+        // Redirect pending signup users without issuing tokens.
+        if (user.isNewUser()) {
+            // Short-lived signup token to authorize the signup API calls.
+            String signupToken = jwtUtil.createSignupJwt(
+                    username,
+                    role,
+                    user.getName(),
+                    user.getEmail(),
+                    user.getProfileUrl(),
+                    300000L
+            );
+            response.setHeader("access", signupToken);
+            response.addCookie(createCookie("access", signupToken, Math.toIntExact(300000L / 1000)));
+            // Encoded token for safe query parameter transport.
+            String encodedToken = URLEncoder.encode(signupToken, StandardCharsets.UTF_8);
+            response.sendRedirect("http://localhost:5173/signup?token=" + encodedToken);
+            return;
+        }
+
+        long accessExpiryMs = 600000L;
+        long refreshExpiryMs = 86400000L;
+        String access = jwtUtil.createJwt("access", username, role, accessExpiryMs);
+        String refresh = jwtUtil.createJwt("refresh", username, role, refreshExpiryMs);
+
+        refreshRepository.save(username, refresh, refreshExpiryMs);
+
+        response.setHeader("access", access);
+        response.addCookie(createCookie("access", access, Math.toIntExact(accessExpiryMs / 1000)));
+        response.addCookie(createCookie("refresh", refresh, Math.toIntExact(refreshExpiryMs / 1000)));
+        response.sendRedirect("http://localhost:5173/");
+    }
+
+    private Cookie createCookie(String key, String value, int maxAge) {
+
+        Cookie cookie = new Cookie(key, value);
+
+        cookie.setMaxAge(maxAge);
+        // cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+}

--- a/src/main/java/com/deskit/deskit/account/oauth/GoogleResponse.java
+++ b/src/main/java/com/deskit/deskit/account/oauth/GoogleResponse.java
@@ -1,0 +1,44 @@
+package com.deskit.deskit.account.oauth;
+
+import java.util.Map;
+
+public class GoogleResponse implements OAuth2Response{
+
+    private final Map<String, Object> attribute;
+
+    public GoogleResponse(Map<String, Object> attribute) {
+
+        this.attribute = attribute;
+    }
+
+    @Override
+    public String getProvider() {
+
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+
+        return attribute.get("name").toString();
+    }
+
+    @Override
+    public String getProfileUrl() {
+        return attribute.get("picture").toString();
+    }
+
+
+}

--- a/src/main/java/com/deskit/deskit/account/oauth/KakaoResponse.java
+++ b/src/main/java/com/deskit/deskit/account/oauth/KakaoResponse.java
@@ -1,0 +1,56 @@
+package com.deskit.deskit.account.oauth;
+
+import java.util.Map;
+
+public class KakaoResponse implements OAuth2Response {
+
+    private final Map<String, Object> attribute;
+
+    public KakaoResponse(Map<String, Object> attribute) {
+
+        this.attribute = attribute;
+    }
+
+
+    @Override
+    public String getProvider() {
+
+        return "kakao";
+    }
+
+    @Override
+    public String getProviderId() {
+
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> kakaoAccount =
+                (Map<String, Object>) attribute.get("kakao_account");
+
+        return (String) kakaoAccount.get("email");
+    }
+
+    // kakao 이름은 개인 개발자 앱으로는 닉네임(실명 아님)만 수집 가능
+
+    @Override
+    public String getName() {
+        Map<String, Object> kakaoAccount =
+                (Map<String, Object>) attribute.get("kakao_account");
+        Map<String, Object> profile =
+                (Map<String, Object>) kakaoAccount.get("profile");
+
+        return (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getProfileUrl() {
+        Map<String, Object> kakaoAccount =
+                (Map<String, Object>) attribute.get("kakao_account");
+        Map<String, Object> profile =
+                (Map<String, Object>) kakaoAccount.get("profile");
+
+        return (String) profile.get("profile_image_url");
+    }
+}

--- a/src/main/java/com/deskit/deskit/account/oauth/NaverResponse.java
+++ b/src/main/java/com/deskit/deskit/account/oauth/NaverResponse.java
@@ -1,0 +1,42 @@
+package com.deskit.deskit.account.oauth;
+
+import java.util.Map;
+
+public class NaverResponse implements OAuth2Response{
+
+    private final Map<String, Object> attribute;
+
+    public NaverResponse(Map<String, Object> attribute) {
+
+        this.attribute = (Map<String, Object>) attribute.get("response");
+    }
+
+    @Override
+    public String getProvider() {
+
+        return "naver";
+    }
+
+    @Override
+    public String getProviderId() {
+
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+
+        return attribute.get("name").toString();
+    }
+
+    @Override
+    public String getProfileUrl() {
+        return attribute.get("profile_image").toString();
+    }
+}

--- a/src/main/java/com/deskit/deskit/account/oauth/OAuth2Response.java
+++ b/src/main/java/com/deskit/deskit/account/oauth/OAuth2Response.java
@@ -1,0 +1,14 @@
+package com.deskit.deskit.account.oauth;
+
+public interface OAuth2Response {
+
+    //제공자 (Ex. naver, google, ...)
+    String getProvider();
+    //제공자에서 발급해주는 아이디(번호)
+    String getProviderId();
+    //이메일
+    String getEmail();
+    //사용자 실명 (설정한 이름) -> 카카오는 닉네임...
+    String getName();
+    String getProfileUrl();
+}

--- a/src/main/java/com/deskit/deskit/account/oauth/package-info.java
+++ b/src/main/java/com/deskit/deskit/account/oauth/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.account.oauth;

--- a/src/main/java/com/deskit/deskit/account/repository/CompanyRegisteredRepository.java
+++ b/src/main/java/com/deskit/deskit/account/repository/CompanyRegisteredRepository.java
@@ -1,0 +1,10 @@
+package com.deskit.deskit.account.repository;
+
+import com.deskit.deskit.account.entity.CompanyRegistered;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyRegisteredRepository extends JpaRepository<CompanyRegistered, Long> {
+
+    // Lookup for validating duplicate business numbers.
+    CompanyRegistered findByBusinessNumber(String businessNumber);
+}

--- a/src/main/java/com/deskit/deskit/account/repository/InvitationRepository.java
+++ b/src/main/java/com/deskit/deskit/account/repository/InvitationRepository.java
@@ -1,0 +1,18 @@
+package com.deskit.deskit.account.repository;
+
+import com.deskit.deskit.account.entity.Invitation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+
+public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+
+    // Find invitation by token from the email link.
+    Invitation findByToken(String token);
+
+    // Check for duplicate invitations for the same email.
+    boolean existsByEmailAndStatusIn(String email, Collection<String> statuses);
+
+    // Count invitations for a seller to enforce the invite limit.
+    long countBySellerIdAndStatusIn(Long sellerId, Collection<String> statuses);
+}

--- a/src/main/java/com/deskit/deskit/account/repository/MemberRepository.java
+++ b/src/main/java/com/deskit/deskit/account/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.deskit.deskit.account.repository;
+
+import com.deskit.deskit.account.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    // Lookup user by social login username.
+    Member findByLoginId(String loginId);
+}

--- a/src/main/java/com/deskit/deskit/account/repository/RefreshRepository.java
+++ b/src/main/java/com/deskit/deskit/account/repository/RefreshRepository.java
@@ -1,0 +1,34 @@
+package com.deskit.deskit.account.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+public class RefreshRepository {
+    private static final String PREFIX = "refresh:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public RefreshRepository(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(String username, String refresh, long expiredMs) {
+        redisTemplate.opsForValue().set(key(refresh), username, Duration.ofMillis(expiredMs));
+    }
+
+    public boolean existsByRefresh(String refresh) {
+        Boolean exists = redisTemplate.hasKey(key(refresh));
+        return Boolean.TRUE.equals(exists);
+    }
+
+    public void deleteByRefresh(String refresh) {
+        redisTemplate.delete(key(refresh));
+    }
+
+    private String key(String refresh) {
+        return PREFIX + refresh;
+    }
+}

--- a/src/main/java/com/deskit/deskit/account/repository/SellerGradeRepository.java
+++ b/src/main/java/com/deskit/deskit/account/repository/SellerGradeRepository.java
@@ -1,0 +1,7 @@
+package com.deskit.deskit.account.repository;
+
+import com.deskit.deskit.account.entity.SellerGrade;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellerGradeRepository extends JpaRepository<SellerGrade, Long> {
+}

--- a/src/main/java/com/deskit/deskit/account/repository/SellerRegisterRepository.java
+++ b/src/main/java/com/deskit/deskit/account/repository/SellerRegisterRepository.java
@@ -1,0 +1,7 @@
+package com.deskit.deskit.account.repository;
+
+import com.deskit.deskit.account.entity.SellerRegister;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellerRegisterRepository extends JpaRepository<SellerRegister, Long> {
+}

--- a/src/main/java/com/deskit/deskit/account/repository/SellerRepository.java
+++ b/src/main/java/com/deskit/deskit/account/repository/SellerRepository.java
@@ -1,0 +1,10 @@
+package com.deskit.deskit.account.repository;
+
+import com.deskit.deskit.account.entity.Seller;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SellerRepository extends JpaRepository<Seller, Long> {
+
+    // Lookup seller by social login id.
+    Seller findByLoginId(String loginId);
+}

--- a/src/main/java/com/deskit/deskit/account/repository/package-info.java
+++ b/src/main/java/com/deskit/deskit/account/repository/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.account.repository;

--- a/src/main/java/com/deskit/deskit/account/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/deskit/deskit/account/service/CustomOAuth2UserService.java
@@ -1,0 +1,107 @@
+package com.deskit.deskit.account.service;
+
+import com.deskit.deskit.account.dto.UserDTO;
+import com.deskit.deskit.account.entity.Member;
+import com.deskit.deskit.account.entity.Seller;
+import com.deskit.deskit.account.oauth.*;
+import com.deskit.deskit.account.repository.MemberRepository;
+import com.deskit.deskit.account.repository.SellerRepository;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+    private final SellerRepository sellerRepository;
+
+    public CustomOAuth2UserService(MemberRepository memberRepository, SellerRepository sellerRepository) {
+
+        this.memberRepository = memberRepository;
+        this.sellerRepository = sellerRepository;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        System.out.println(oAuth2User);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response = null;
+
+        switch (registrationId) {
+            case "google" -> oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+
+            case "naver" -> oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
+
+            case "kakao" -> oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
+
+            default -> {
+                return null;
+            }
+        }
+
+        String username = oAuth2Response.getProvider()+" "+oAuth2Response.getProviderId();
+        Member existMember = memberRepository.findByLoginId(oAuth2Response.getEmail());
+        Seller existSeller = sellerRepository.findByLoginId(oAuth2Response.getEmail());
+
+        // Member에도 없고 Seller에도 없는 경우 -> 신규 등록, role 임시 부여(GUEST)
+        if (existMember == null && existSeller == null) {
+
+            // Build user info for a pending signup user.
+            UserDTO userDTO = UserDTO.builder()
+                    .username(username)
+                    .name(oAuth2Response.getName())
+                    .email(oAuth2Response.getEmail())
+                    .role("ROLE_GUEST")
+                    .newUser(true)
+                    .profileUrl(oAuth2Response.getProfileUrl() == null ? "" : oAuth2Response.getProfileUrl())
+                    .build();
+
+            return new CustomOAuth2User(userDTO);
+        }
+
+        // Member에 존재할 경우 -> Member 로그인
+        else if (existMember != null) {
+
+            existMember.setLoginId(oAuth2Response.getEmail());
+            existMember.setName(oAuth2Response.getName());
+
+            memberRepository.save(existMember);
+
+            UserDTO userDTO = UserDTO.builder()
+                    .username(existMember.getLoginId())
+                    .name(oAuth2Response.getName())
+                    .email(oAuth2Response.getEmail())
+                    .role(existMember.getRole())
+                    .newUser(false)
+                    .profileUrl(oAuth2Response.getProfileUrl() == null ? "" : oAuth2Response.getProfileUrl())
+                    .build();
+
+            return new CustomOAuth2User(userDTO);
+        }
+
+        // Seller에 존재할 경우 -> Seller 로그인
+        else {
+            existSeller.setLoginId(oAuth2Response.getEmail());
+            existSeller.setName(oAuth2Response.getName());
+
+            sellerRepository.save(existSeller);
+
+            UserDTO userDTO = UserDTO.builder()
+                    .username(existSeller.getLoginId())
+                    .name(existSeller.getName())
+                    .email(oAuth2Response.getEmail())
+                    .role(existSeller.getRole().toString())
+                    .newUser(false)
+                    .profileUrl(oAuth2Response.getProfileUrl() == null ? "" : oAuth2Response.getProfileUrl())
+                    .build();
+
+            return new CustomOAuth2User(userDTO);
+        }
+    }
+}

--- a/src/main/java/com/deskit/deskit/account/service/InviteEmailService.java
+++ b/src/main/java/com/deskit/deskit/account/service/InviteEmailService.java
@@ -1,0 +1,45 @@
+package com.deskit.deskit.account.service;
+
+import com.sendgrid.Method;
+import com.sendgrid.Request;
+import com.sendgrid.SendGrid;
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Log4j2
+@Service
+public class InviteEmailService {
+
+    private final SendGrid sendGrid;
+
+    public InviteEmailService(@Value("${spring.sendgrid.api-key}") String apiKey) {
+        this.sendGrid = new SendGrid(apiKey);
+    }
+
+    public void sendInviteMail(String email, String inviteUrl) throws IOException {
+        Email from = new Email("dyniiyeyo@naver.com");
+        Email to = new Email(email);
+        String subject = "[Deskterior] 판매자 동업자 초대 안내";
+
+        Content content = new Content("text/html",
+                "<h2>판매자 동업자 초대</h2>" +
+                        "<p>아래 버튼을 눌러 회원가입을 완료해주세요.</p>" +
+                        "<a href='" + inviteUrl + "'>회원가입 하러 가기</a>"
+        );
+
+        Mail mail = new Mail(from, subject, to, content);
+
+        Request request = new Request();
+        request.setMethod(Method.POST);
+        request.setEndpoint("mail/send");
+        request.setBody(mail.build());
+
+        sendGrid.api(request);
+    }
+}

--- a/src/main/java/com/deskit/deskit/account/service/package-info.java
+++ b/src/main/java/com/deskit/deskit/account/service/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.account.service;

--- a/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
+++ b/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
@@ -1,0 +1,136 @@
+package com.deskit.deskit.common.config;
+
+import com.deskit.deskit.account.jwt.CustomLogoutFilter;
+import com.deskit.deskit.account.jwt.JWTFilter;
+import com.deskit.deskit.account.jwt.JWTUtil;
+import com.deskit.deskit.account.oauth.CustomSuccessHandler;
+import com.deskit.deskit.account.repository.RefreshRepository;
+import com.deskit.deskit.account.service.CustomOAuth2UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomSuccessHandler customSuccessHandler;
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+    public SecurityConfig(CustomOAuth2UserService customOAuth2UserService,
+                          CustomSuccessHandler customSuccessHandler,
+                          JWTUtil jwtUtil,
+                          RefreshRepository refreshRepository) {
+
+        this.customOAuth2UserService = customOAuth2UserService;
+        this.customSuccessHandler = customSuccessHandler;
+        this.jwtUtil = jwtUtil;
+        this.refreshRepository = refreshRepository;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .cors(corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
+
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
+                        CorsConfiguration configuration = new CorsConfiguration();
+
+                        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:5173"));
+                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowCredentials(true);
+                        configuration.setAllowedHeaders(Collections.singletonList("*"));
+                        configuration.setMaxAge(3600L);
+
+                        configuration.setExposedHeaders(
+                                java.util.List.of("Set-Cookie", "Authorization", "access")
+                        );
+
+                        return configuration;
+                    }
+                }));
+
+        //csrf disable
+        http
+                .csrf((auth) -> auth.disable());
+
+        //From 로그인 방식 disable
+        http
+                .formLogin((auth) -> auth.disable());
+
+        //HTTP Basic 인증 방식 disable
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        http
+                .exceptionHandling(exception -> exception
+                        .defaultAuthenticationEntryPointFor(
+                                (request, response, authException) -> {
+                                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                                    response.setContentType("application/json;charset=UTF-8");
+                                    response.getWriter().write("{\"message\":\"인증이 필요합니다\"}");
+                                },
+                                new AntPathRequestMatcher("/api/**") // API만
+                        )
+                );
+
+        //JWTFilter 추가
+        http
+                .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshRepository), LogoutFilter.class);
+
+        //oauth2
+        http
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService))
+                        .successHandler(customSuccessHandler)
+                );
+
+        //경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers(
+                                "/",
+                                "/reissue",
+                                "/api/invitations/validate",
+                                "/oauth/**",
+                                "/login",
+                                "/login/**",
+                                "/login/oauth2/**"
+                        ).permitAll()
+                        .requestMatchers("/my").hasAnyAuthority(
+                                "ROLE_MEMBER",
+                                "ROLE_SELLER",
+                                "ROLE_SELLER_OWNER",
+                                "ROLE_SELLER_MANAGER",
+                                "ROLE_ADMIN"
+                        )
+                        .anyRequest().authenticated());
+
+        //세션 설정 : STATELESS -> IF_REQUIRED
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/deskit/deskit/common/config/package-info.java
+++ b/src/main/java/com/deskit/deskit/common/config/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.common.config;

--- a/src/main/java/com/deskit/deskit/common/util/package-info.java
+++ b/src/main/java/com/deskit/deskit/common/util/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.common.util;


### PR DESCRIPTION
## 📌 관련 이슈

- closes #10 

## 📝 작업 내용

- 일반회원, 판매자의 회원 가입 기능을 구현하였습니다.
- Access Token 검증 및 Refresh Token 저장 기능을 구현하였습니다.
- 회원 가입시 부여되는 권한(ex. 일반회원 : ROLE_MEMBER)을 기반으로 한 접근 제어 기능을 구현하였습니다.
- 프론트-백 연동 작업을 위해 일부 페이지 script를 수정하였습니다.
- 회원 초대 기능을 구현하였으나, 프론트 연동은 아직 되어 있지 않습니다.

## 🧐 리뷰 포인트

- SignupController에 회원가입의 전반적인 로직이 구현되어 있습니다.
- 단일 책임 원칙에 따라 SignupController는 추후 리팩토링 예정입니다.


