### PR TITLE
[FEAT] 상품/셋업 API 연동 및 공개 조회 허용

### DIFF
--- a/front/src/api/endpoints.ts
+++ b/front/src/api/endpoints.ts
@@ -1,8 +1,8 @@
 export const endpoints = {
   products: '/api/products',
   productDetail: (id: string | number) => `/api/products/${id}`,
-  setups: '/setups',
-  setupDetail: (id: string | number) => `/setups/${id}`,
+  setups: '/api/setups',
+  setupDetail: (id: string | number) => `/api/setups/${id}`,
   cart: '/cart',
   cartItems: '/cart/items',
   orders: '/orders',

--- a/front/src/api/setups.ts
+++ b/front/src/api/setups.ts
@@ -1,0 +1,127 @@
+import { http } from './http'
+import { endpoints } from './endpoints'
+import { type SetupWithProducts } from '../lib/setups-data'
+
+const isPlainObject = (value: unknown) => {
+  if (!value || typeof value !== 'object') return false
+  if (Array.isArray(value)) return false
+  return Object.prototype.toString.call(value) === '[object Object]'
+}
+
+const normalizeSetup = (raw: any): SetupWithProducts => {
+  const productIdsRaw = raw?.product_ids ?? raw?.productIds
+  const setupProducts = raw?.setup_products ?? raw?.setupProducts
+  const products = raw?.products
+  const collectIds = (items: any[]) =>
+    items
+      .map((item) => {
+        if (item && typeof item === 'object') {
+          const source = item?.product && typeof item.product === 'object' ? item.product : item
+          return Number(source?.product_id ?? source?.productId ?? source?.id)
+        }
+        return Number(item)
+      })
+      .filter((id) => Number.isFinite(id))
+  const productIdsFromRelations = Array.isArray(setupProducts)
+    ? collectIds(setupProducts)
+    : Array.isArray(products)
+      ? collectIds(products)
+      : []
+  const product_ids = [
+    ...(Array.isArray(productIdsRaw) ? collectIds(productIdsRaw) : []),
+    ...productIdsFromRelations,
+  ]
+  const uniqueProductIds = Array.from(new Set(product_ids))
+  const tags = Array.isArray(raw?.tags) ? raw.tags : []
+  return {
+    setup_id: raw?.setup_id ?? raw?.id ?? 0,
+    title: raw?.title ?? raw?.name ?? '',
+    short_desc: raw?.short_desc ?? raw?.description ?? '',
+    imageUrl: raw?.imageUrl ?? raw?.image_url ?? '/placeholder-setup.jpg',
+    product_ids: uniqueProductIds,
+    tags,
+    tip: raw?.tip_text ?? raw?.tipText ?? raw?.tip ?? '',
+    created_dt: raw?.created_dt ?? raw?.created_at ?? '',
+    updated_dt: raw?.updated_dt ?? raw?.updated_at ?? '',
+  }
+}
+
+export const listSetups = async (): Promise<SetupWithProducts[]> => {
+  const resolvePayload = (data: unknown) => {
+    let parsed: unknown = data
+    let parseFailed = false
+    if (typeof parsed === 'string' && parsed.trim().length > 0) {
+      try {
+        parsed = JSON.parse(parsed)
+      } catch {
+        parsed = undefined
+        parseFailed = true
+      }
+    }
+    const payload = Array.isArray(parsed)
+      ? parsed
+      : isPlainObject(parsed) && Array.isArray((parsed as { data?: unknown }).data)
+        ? (parsed as { data: unknown[] }).data
+        : []
+    return { payload, parseFailed }
+  }
+
+  const fetchOnce = async () =>
+    http.get<unknown>(endpoints.setups, {
+      params: { _ts: Date.now() },
+      headers: {
+        'Cache-Control': 'no-store',
+        Pragma: 'no-cache',
+      },
+      validateStatus: (status) => (status >= 200 && status < 300) || status === 304,
+      responseType: 'text',
+      transformResponse: (data) => data,
+    })
+
+  let response = await fetchOnce()
+  let { payload, parseFailed } = resolvePayload(response.data)
+  const isRawEmpty =
+    response.data == null || (typeof response.data === 'string' && response.data.trim() === '')
+  if (response.status === 304 || isRawEmpty || parseFailed || payload.length === 0) {
+    response = await fetchOnce()
+    ;({ payload, parseFailed } = resolvePayload(response.data))
+  }
+
+  return (payload as any[]).map(normalizeSetup)
+}
+
+export const getSetupDetail = async (
+  id: string | number
+): Promise<SetupWithProducts | null> => {
+  const response = await http.get<unknown>(endpoints.setupDetail(id), {
+    params: { _ts: Date.now() },
+    headers: {
+      'Cache-Control': 'no-store',
+      Pragma: 'no-cache',
+    },
+    responseType: 'text',
+    transformResponse: (data) => data,
+    validateStatus: (status) => (status >= 200 && status < 300) || status === 404,
+  })
+
+  if (response.status === 404) return null
+
+  let parsed: unknown = response.data
+  if (typeof parsed === 'string' && parsed.trim().length > 0) {
+    try {
+      parsed = JSON.parse(parsed)
+    } catch {
+      parsed = undefined
+    }
+  }
+
+  const item = Array.isArray(parsed)
+    ? parsed[0]
+    : isPlainObject(parsed) && Array.isArray((parsed as { data?: unknown }).data)
+      ? (parsed as { data: unknown[] }).data?.[0]
+      : isPlainObject(parsed) && isPlainObject((parsed as { data?: unknown }).data)
+        ? (parsed as { data: unknown }).data
+        : parsed
+
+  return isPlainObject(item) ? normalizeSetup(item) : null
+}

--- a/front/src/pages/Setup.vue
+++ b/front/src/pages/Setup.vue
@@ -1,11 +1,24 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import { setupsData } from '../lib/setups-data';
+import { onMounted, ref } from 'vue';
+import { listSetups } from '../api/setups';
+import { type SetupWithProducts } from '../lib/setups-data';
 import SetupCard from '../components/SetupCard.vue';
 import PageContainer from '../components/PageContainer.vue';
 import PageHeader from '../components/PageHeader.vue';
 
-const setups = computed(() => setupsData);
+const setups = ref<SetupWithProducts[]>([]);
+
+const loadSetups = async () => {
+  try {
+    setups.value = await listSetups();
+  } catch (error) {
+    console.error('Failed to load setups.', error);
+  }
+};
+
+onMounted(() => {
+  loadSetups();
+});
 </script>
 
 <template>

--- a/front/src/router/index.ts
+++ b/front/src/router/index.ts
@@ -60,7 +60,7 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/signup',
     name: 'signup',
-    component: () => import('../pages/Signup.vue'),
+    component: () => import('../pages/Login.vue'),
   },
   {
     path: '/my',
@@ -232,5 +232,4 @@ router.beforeEach(async (to) => {
   }
   return true
 })
-
 

--- a/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
+++ b/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
@@ -1,2 +1,88 @@
 package com.deskit.deskit.common.config;
 
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+            // 프론트(localhost:5174) → 백엔드 API 호출을 허용하기 위해 CORS 설정 사용
+            .cors(Customizer.withDefaults())
+
+            // /api/** 요청은 브라우저/프론트 호출이 많아서 CSRF 예외 처리 (API는 토큰/세션 정책에 맞게 별도 설계 가능)
+            .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
+
+            // 접근 제어 규칙
+            .authorizeHttpRequests(auth -> auth
+                    // 프리플라이트(OPTIONS) 요청은 무조건 허용 (CORS 통과 목적)
+                    .requestMatchers(HttpMethod.OPTIONS, "/api/**").permitAll()
+
+                    // 상품/셋업 조회 API는 로그인 없이도 접근 가능하도록 허용
+                    .requestMatchers(HttpMethod.GET, "/api/products/**", "/api/setups/**").permitAll()
+
+                    // 로그인/소셜로그인 관련 엔드포인트 및 에러 페이지는 허용
+                    .requestMatchers("/login**", "/oauth2/**", "/error").permitAll()
+
+                    // 그 외 모든 요청은 인증 필요
+                    .anyRequest().authenticated())
+
+            // API 호출에서 인증/인가 실패 시 브라우저 리다이렉트 대신 상태코드로 응답하도록 처리
+            .exceptionHandling(exceptions -> exceptions
+                    // /api/** 에서 인증 안 됐으면 401 반환
+                    .defaultAuthenticationEntryPointFor(
+                            new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
+                            new AntPathRequestMatcher("/api/**"))
+                    // /api/** 에서 권한 부족이면 403 반환
+                    .defaultAccessDeniedHandlerFor(
+                            accessDeniedHandler(),
+                            new AntPathRequestMatcher("/api/**")))
+
+            // OAuth2 로그인 사용 (구글 등)
+            .oauth2Login(Customizer.withDefaults());
+
+    return http.build();
+  }
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+
+    // 프론트 개발 서버 origin 허용
+    configuration.setAllowedOrigins(List.of("http://localhost:5174"));
+
+    // 허용할 HTTP 메서드
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+
+    // 허용할 헤더 (개발 편의상 전체 허용)
+    configuration.setAllowedHeaders(List.of("*"));
+
+    // 쿠키/세션 기반 인증을 위해 credentials 허용
+    configuration.setAllowCredentials(true);
+
+    // /api/** 경로에만 위 CORS 정책 적용
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/api/**", configuration);
+    return source;
+  }
+
+  // API 권한 부족(인가 실패) 시 403 응답
+  private AccessDeniedHandler accessDeniedHandler() {
+    return (request, response, accessDeniedException) ->
+            response.sendError(HttpStatus.FORBIDDEN.value(), HttpStatus.FORBIDDEN.getReasonPhrase());
+  }
+}

--- a/src/main/java/com/deskit/deskit/setup/dto/SetupResponse.java
+++ b/src/main/java/com/deskit/deskit/setup/dto/SetupResponse.java
@@ -1,6 +1,7 @@
 package com.deskit.deskit.setup.dto;
 
 import com.deskit.deskit.setup.entity.Setup;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.Collections;
@@ -32,6 +33,10 @@ public class SetupResponse {
   @JsonProperty("setup_image_url")
   private final String setupImageUrl;
 
+  @JsonProperty("product_ids")
+  @JsonInclude(JsonInclude.Include.ALWAYS)
+  private final List<Long> productIds;
+
   @JsonProperty("tags")
   private final SetupTags tags;
 
@@ -45,12 +50,20 @@ public class SetupResponse {
   public SetupResponse(Long setupId, Long sellerId, String name, String shortDesc,
                        String tipText, String setupImageUrl, SetupTags tags,
                        List<String> tagsFlat) {
+    this(setupId, sellerId, name, shortDesc, tipText, setupImageUrl,
+            Collections.emptyList(), tags, tagsFlat);
+  }
+
+  public SetupResponse(Long setupId, Long sellerId, String name, String shortDesc,
+                       String tipText, String setupImageUrl, List<Long> productIds,
+                       SetupTags tags, List<String> tagsFlat) {
     this.setupId = setupId;
     this.sellerId = sellerId;
     this.name = name;
     this.shortDesc = shortDesc;
     this.tipText = tipText;
     this.setupImageUrl = setupImageUrl;
+    this.productIds = productIds == null ? Collections.emptyList() : productIds;
     this.tags = tags == null ? SetupTags.empty() : tags;
     this.tagsFlat = tagsFlat == null ? Collections.emptyList() : tagsFlat;
   }
@@ -67,6 +80,21 @@ public class SetupResponse {
             setup.getShortDesc(),
             setup.getTipText(),
             setup.getSetupImageUrl(),
+            tags,
+            tagsFlat
+    );
+  }
+
+  public static SetupResponse from(Setup setup, SetupTags tags, List<String> tagsFlat,
+                                   List<Long> productIds) {
+    return new SetupResponse(
+            setup.getId(),
+            setup.getSellerId(),
+            setup.getSetupName(),      // 엔티티 setupName -> 응답 name
+            setup.getShortDesc(),
+            setup.getTipText(),
+            setup.getSetupImageUrl(),
+            productIds,
             tags,
             tagsFlat
     );
@@ -124,5 +152,9 @@ public class SetupResponse {
     public List<String> getMood() {
       return mood;
     }
+  }
+
+  public List<Long> getProductIds() {
+    return productIds;
   }
 }

--- a/src/main/java/com/deskit/deskit/setup/repository/SetupRepository.java
+++ b/src/main/java/com/deskit/deskit/setup/repository/SetupRepository.java
@@ -4,10 +4,19 @@ import com.deskit.deskit.setup.entity.Setup;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SetupRepository extends JpaRepository<Setup, Long> {
 
   List<Setup> findAllByDeletedAtIsNullOrderByIdAsc();
 
   Optional<Setup> findByIdAndDeletedAtIsNull(Long id);
+
+  @Query(value = """
+      select sp.product_id
+      from setup_product sp
+      where sp.setup_id = :setupId
+      """, nativeQuery = true)
+  List<Long> findProductIdsBySetupId(@Param("setupId") Long setupId);
 }

--- a/src/main/java/com/deskit/deskit/setup/service/SetupService.java
+++ b/src/main/java/com/deskit/deskit/setup/service/SetupService.java
@@ -78,7 +78,11 @@ public class SetupService {
     SetupTags tags = bundle == null ? SetupTags.empty() : bundle.getTags();
     List<String> tagsFlat = bundle == null ? Collections.emptyList() : bundle.getTagsFlat();
 
-    return Optional.of(SetupResponse.from(setup.get(), tags, tagsFlat));
+    List<Long> productIdsRaw = setupRepository.findProductIdsBySetupId(id);
+    List<Long> productIds = productIdsRaw == null
+            ? Collections.emptyList()
+            : new ArrayList<>(new LinkedHashSet<>(productIdsRaw));
+    return Optional.of(SetupResponse.from(setup.get(), tags, tagsFlat, productIds));
   }
 
   // DB에서 가져온 태그 row들을 setupId별로 그룹핑하고 tags/tagsFlat을 만든다


### PR DESCRIPTION
## 📝 작업 내용
- 상품 목록(/products) API 엔드포인트를 /api/products로 변경하여 정상 렌더링되도록 수정
- 상품 상세(ProductDetail)에서 getProductDetail()로 API 기반 조회하도록 전환
- 셋업 목록/상세 페이지에서 /api/setups 연동 및 셋업 상세에 product_ids 내려주도록 백엔드 응답 보강
- SecurityConfig 추가: /api/products/**, /api/setups/** GET 공개 + API 호출용 CORS/CSRF 예외 처리