### PR TITLE
[FEAT] 셋업/상품 API 연동 안정화 및 보안 설정 추가

### DIFF
--- a/front/src/api/api-text-json.ts
+++ b/front/src/api/api-text-json.ts
@@ -1,0 +1,83 @@
+import type { AxiosInstance, AxiosRequestConfig } from 'axios'
+
+export const isPlainObject = (value: unknown) => {
+  if (!value || typeof value !== 'object') return false
+  if (Array.isArray(value)) return false
+  return Object.prototype.toString.call(value) === '[object Object]'
+}
+
+export const parseJsonIfString = (data: unknown) => {
+  let parsed: unknown = data
+  let parseFailed = false
+  if (typeof parsed === 'string' && parsed.trim().length > 0) {
+    try {
+      parsed = JSON.parse(parsed)
+    } catch {
+      parsed = undefined
+      parseFailed = true
+    }
+  }
+  return { parsed, parseFailed }
+}
+
+export const pickListPayload = (parsed: unknown) => {
+  if (Array.isArray(parsed)) return parsed
+  if (isPlainObject(parsed) && Array.isArray((parsed as { data?: unknown }).data)) {
+    return (parsed as { data: unknown[] }).data
+  }
+  return []
+}
+
+export const pickDetailItem = (parsed: unknown) => {
+  if (Array.isArray(parsed)) return parsed[0]
+  if (isPlainObject(parsed) && Array.isArray((parsed as { data?: unknown }).data)) {
+    return (parsed as { data: unknown[] }).data?.[0]
+  }
+  if (isPlainObject(parsed) && isPlainObject((parsed as { data?: unknown }).data)) {
+    return (parsed as { data: unknown }).data
+  }
+  return parsed
+}
+
+export const fetchTextNoCache = <T = unknown>(
+  client: AxiosInstance,
+  url: string,
+  options: AxiosRequestConfig = {}
+) =>
+  client.get<T>(url, {
+    ...options,
+    params: { _ts: Date.now(), ...(options.params ?? {}) },
+    headers: { 'Cache-Control': 'no-store', Pragma: 'no-cache', ...(options.headers ?? {}) },
+    responseType: 'text',
+    transformResponse: (data) => data,
+  })
+
+export const fetchListTextJsonWithRetry = async (
+  client: AxiosInstance,
+  url: string,
+  options: AxiosRequestConfig = {}
+) => {
+  const fetchOnce = () => fetchTextNoCache(client, url, options)
+  let response = await fetchOnce()
+  let { parsed, parseFailed } = parseJsonIfString(response.data)
+  let payload = pickListPayload(parsed)
+  const isRawEmpty =
+    response.data == null || (typeof response.data === 'string' && response.data.trim() === '')
+  if (response.status === 304 || isRawEmpty || parseFailed || payload.length === 0) {
+    response = await fetchOnce()
+    ;({ parsed, parseFailed } = parseJsonIfString(response.data))
+    payload = pickListPayload(parsed)
+  }
+  return payload
+}
+
+export const fetchDetailTextJson = async (
+  client: AxiosInstance,
+  url: string,
+  options: AxiosRequestConfig = {}
+) => {
+  const response = await fetchTextNoCache(client, url, options)
+  if (response.status === 404) return null
+  const { parsed } = parseJsonIfString(response.data)
+  return pickDetailItem(parsed)
+}

--- a/front/src/api/products.ts
+++ b/front/src/api/products.ts
@@ -4,58 +4,22 @@ import { USE_MOCK_API } from './config'
 import { type DbProduct } from '../lib/products-data'
 import { deleteMockProduct, getAllMockProducts } from '../lib/mocks/sellerProducts'
 import { normalizeProduct, normalizeProducts } from './products-normalizer'
-
-const isPlainObject = (value: any) => {
-  if (!value || typeof value !== 'object') return false
-  if (Array.isArray(value)) return false
-  return Object.prototype.toString.call(value) === '[object Object]'
-}
+import {
+  fetchDetailTextJson,
+  fetchListTextJsonWithRetry,
+  isPlainObject,
+  parseJsonIfString,
+  pickListPayload,
+} from './api-text-json'
 
 export const listProducts = async (): Promise<DbProduct[]> => {
   if (USE_MOCK_API) {
     return getAllMockProducts()
   }
 
-  const resolvePayload = (data: unknown) => {
-    let parsed: unknown = data
-    let parseFailed = false
-    if (typeof parsed === 'string' && parsed.trim().length > 0) {
-      try {
-        parsed = JSON.parse(parsed)
-      } catch {
-        parsed = undefined
-        parseFailed = true
-      }
-    }
-    const payload = Array.isArray(parsed)
-      ? parsed
-      : isPlainObject(parsed) && Array.isArray((parsed as { data?: unknown }).data)
-        ? (parsed as { data: unknown[] }).data
-        : []
-    return { payload, parseFailed, raw: parsed }
-  }
-
-  const fetchOnce = async () =>
-    http.get<unknown>(endpoints.products, {
-      params: { _ts: Date.now() },
-      headers: {
-        'Cache-Control': 'no-store',
-        Pragma: 'no-cache',
-      },
-      validateStatus: (status) => (status >= 200 && status < 300) || status === 304,
-      responseType: 'text',
-      transformResponse: (data) => data,
-    })
-
-  let response = await fetchOnce()
-  let { payload, parseFailed, raw } = resolvePayload(response.data)
-  const isRawEmpty =
-    response.data == null || (typeof response.data === 'string' && response.data.trim() === '')
-  if (response.status === 304 || isRawEmpty || parseFailed || payload.length === 0) {
-    response = await fetchOnce()
-    ;({ payload, parseFailed, raw } = resolvePayload(response.data))
-  }
-
+  const payload = await fetchListTextJsonWithRetry(http, endpoints.products, {
+    validateStatus: (status) => (status >= 200 && status < 300) || status === 304,
+  })
   return normalizeProducts(payload as DbProduct[])
 }
 
@@ -81,20 +45,8 @@ export const listProductsWithAuthGuard = async (): Promise<{
     return { products: [], authRequired: true }
   }
 
-  let parsed: unknown = response.data
-  if (typeof parsed === 'string' && parsed.trim().length > 0) {
-    try {
-      parsed = JSON.parse(parsed)
-    } catch {
-      parsed = []
-    }
-  }
-
-  const payload = Array.isArray(parsed)
-    ? parsed
-    : isPlainObject(parsed) && Array.isArray((parsed as { data?: unknown }).data)
-      ? (parsed as { data: DbProduct[] }).data
-      : []
+  const { parsed } = parseJsonIfString(response.data)
+  const payload = pickListPayload(parsed)
   return { products: normalizeProducts(payload), authRequired: false }
 }
 
@@ -110,35 +62,9 @@ export const getProductDetail = async (
   return found
   }
 
-  const response = await http.get<unknown>(endpoints.productDetail(id), {
-    params: { _ts: Date.now() },
-    headers: {
-      'Cache-Control': 'no-store',
-      Pragma: 'no-cache',
-    },
-    responseType: 'text',
-    transformResponse: (data) => data,
+  const item = await fetchDetailTextJson(http, endpoints.productDetail(id), {
     validateStatus: (status) => (status >= 200 && status < 300) || status === 404,
   })
-
-  if (response.status === 404) return null
-
-  let parsed: unknown = response.data
-  if (typeof parsed === 'string' && parsed.trim().length > 0) {
-    try {
-      parsed = JSON.parse(parsed)
-    } catch {
-      parsed = undefined
-    }
-  }
-
-  const item = Array.isArray(parsed)
-    ? parsed[0]
-    : isPlainObject(parsed) && Array.isArray((parsed as { data?: unknown }).data)
-      ? (parsed as { data: unknown[] }).data?.[0]
-      : isPlainObject(parsed) && isPlainObject((parsed as { data?: unknown }).data)
-        ? (parsed as { data: unknown }).data
-        : parsed
 
   return isPlainObject(item) ? normalizeProduct(item) : null
 }

--- a/front/src/api/setups.ts
+++ b/front/src/api/setups.ts
@@ -1,12 +1,11 @@
 import { http } from './http'
 import { endpoints } from './endpoints'
 import { type SetupWithProducts } from '../lib/setups-data'
-
-const isPlainObject = (value: unknown) => {
-  if (!value || typeof value !== 'object') return false
-  if (Array.isArray(value)) return false
-  return Object.prototype.toString.call(value) === '[object Object]'
-}
+import {
+  fetchDetailTextJson,
+  fetchListTextJsonWithRetry,
+  isPlainObject,
+} from './api-text-json'
 
 const normalizeSetup = (raw: any): SetupWithProducts => {
   const productIdsRaw = raw?.product_ids ?? raw?.productIds
@@ -47,81 +46,18 @@ const normalizeSetup = (raw: any): SetupWithProducts => {
 }
 
 export const listSetups = async (): Promise<SetupWithProducts[]> => {
-  const resolvePayload = (data: unknown) => {
-    let parsed: unknown = data
-    let parseFailed = false
-    if (typeof parsed === 'string' && parsed.trim().length > 0) {
-      try {
-        parsed = JSON.parse(parsed)
-      } catch {
-        parsed = undefined
-        parseFailed = true
-      }
-    }
-    const payload = Array.isArray(parsed)
-      ? parsed
-      : isPlainObject(parsed) && Array.isArray((parsed as { data?: unknown }).data)
-        ? (parsed as { data: unknown[] }).data
-        : []
-    return { payload, parseFailed }
-  }
-
-  const fetchOnce = async () =>
-    http.get<unknown>(endpoints.setups, {
-      params: { _ts: Date.now() },
-      headers: {
-        'Cache-Control': 'no-store',
-        Pragma: 'no-cache',
-      },
-      validateStatus: (status) => (status >= 200 && status < 300) || status === 304,
-      responseType: 'text',
-      transformResponse: (data) => data,
-    })
-
-  let response = await fetchOnce()
-  let { payload, parseFailed } = resolvePayload(response.data)
-  const isRawEmpty =
-    response.data == null || (typeof response.data === 'string' && response.data.trim() === '')
-  if (response.status === 304 || isRawEmpty || parseFailed || payload.length === 0) {
-    response = await fetchOnce()
-    ;({ payload, parseFailed } = resolvePayload(response.data))
-  }
-
+  const payload = await fetchListTextJsonWithRetry(http, endpoints.setups, {
+    validateStatus: (status) => (status >= 200 && status < 300) || status === 304,
+  })
   return (payload as any[]).map(normalizeSetup)
 }
 
 export const getSetupDetail = async (
   id: string | number
 ): Promise<SetupWithProducts | null> => {
-  const response = await http.get<unknown>(endpoints.setupDetail(id), {
-    params: { _ts: Date.now() },
-    headers: {
-      'Cache-Control': 'no-store',
-      Pragma: 'no-cache',
-    },
-    responseType: 'text',
-    transformResponse: (data) => data,
+  const item = await fetchDetailTextJson(http, endpoints.setupDetail(id), {
     validateStatus: (status) => (status >= 200 && status < 300) || status === 404,
   })
-
-  if (response.status === 404) return null
-
-  let parsed: unknown = response.data
-  if (typeof parsed === 'string' && parsed.trim().length > 0) {
-    try {
-      parsed = JSON.parse(parsed)
-    } catch {
-      parsed = undefined
-    }
-  }
-
-  const item = Array.isArray(parsed)
-    ? parsed[0]
-    : isPlainObject(parsed) && Array.isArray((parsed as { data?: unknown }).data)
-      ? (parsed as { data: unknown[] }).data?.[0]
-      : isPlainObject(parsed) && isPlainObject((parsed as { data?: unknown }).data)
-        ? (parsed as { data: unknown }).data
-        : parsed
 
   return isPlainObject(item) ? normalizeSetup(item) : null
 }

--- a/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
+++ b/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
@@ -21,38 +21,35 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
-            // 프론트(localhost:5174) → 백엔드 API 호출을 허용하기 위해 CORS 설정 사용
+            // 프론트(5174)에서 /api 호출할 때 CORS 허용
             .cors(Customizer.withDefaults())
 
-            // /api/** 요청은 브라우저/프론트 호출이 많아서 CSRF 예외 처리 (API는 토큰/세션 정책에 맞게 별도 설계 가능)
+            // API는 CSRF 토큰 없이도 호출 가능하도록 예외 처리
             .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
 
-            // 접근 제어 규칙
+            // 접근 권한 설정
             .authorizeHttpRequests(auth -> auth
-                    // 프리플라이트(OPTIONS) 요청은 무조건 허용 (CORS 통과 목적)
+                    // 프리플라이트(OPTIONS)는 항상 허용
                     .requestMatchers(HttpMethod.OPTIONS, "/api/**").permitAll()
-
-                    // 상품/셋업 조회 API는 로그인 없이도 접근 가능하도록 허용
+                    // 상품/셋업 조회 GET은 로그인 없이 허용
                     .requestMatchers(HttpMethod.GET, "/api/products/**", "/api/setups/**").permitAll()
-
-                    // 로그인/소셜로그인 관련 엔드포인트 및 에러 페이지는 허용
+                    // 로그인/OAuth/에러 페이지는 허용
                     .requestMatchers("/login**", "/oauth2/**", "/error").permitAll()
-
-                    // 그 외 모든 요청은 인증 필요
+                    // 나머지는 인증 필요
                     .anyRequest().authenticated())
 
-            // API 호출에서 인증/인가 실패 시 브라우저 리다이렉트 대신 상태코드로 응답하도록 처리
+            // API 요청에서 인증/권한 오류를 "리다이렉트" 대신 HTTP 상태코드로 내려주기
             .exceptionHandling(exceptions -> exceptions
-                    // /api/** 에서 인증 안 됐으면 401 반환
+                    // 인증 안 된 상태로 /api/** 접근하면 401
                     .defaultAuthenticationEntryPointFor(
                             new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
                             new AntPathRequestMatcher("/api/**"))
-                    // /api/** 에서 권한 부족이면 403 반환
+                    // 권한 부족으로 /api/** 접근하면 403
                     .defaultAccessDeniedHandlerFor(
                             accessDeniedHandler(),
                             new AntPathRequestMatcher("/api/**")))
 
-            // OAuth2 로그인 사용 (구글 등)
+            // OAuth2 로그인 사용
             .oauth2Login(Customizer.withDefaults());
 
     return http.build();
@@ -61,26 +58,18 @@ public class SecurityConfig {
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
-
-    // 프론트 개발 서버 origin 허용
+    // dev 프론트 origin 허용
     configuration.setAllowedOrigins(List.of("http://localhost:5174"));
-
-    // 허용할 HTTP 메서드
     configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-
-    // 허용할 헤더 (개발 편의상 전체 허용)
     configuration.setAllowedHeaders(List.of("*"));
-
-    // 쿠키/세션 기반 인증을 위해 credentials 허용
+    // 세션 쿠키(예: JSESSIONID) 사용 가능
     configuration.setAllowCredentials(true);
 
-    // /api/** 경로에만 위 CORS 정책 적용
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/api/**", configuration);
     return source;
   }
 
-  // API 권한 부족(인가 실패) 시 403 응답
   private AccessDeniedHandler accessDeniedHandler() {
     return (request, response, accessDeniedException) ->
             response.sendError(HttpStatus.FORBIDDEN.value(), HttpStatus.FORBIDDEN.getReasonPhrase());


### PR DESCRIPTION
## 📝 작업 내용
- 상품/셋업 목록·상세 API 연동(텍스트 응답 JSON 파싱/빈 응답/304 대응 포함)
- 셋업 상세 응답에 product_ids 포함되도록 백엔드 수정(SetupRepository/Service/Response)
- SecurityConfig 추가: GET /api/products/**, /api/setups/** 공개 + /api/** 401/403 처리 + CORS(5174) + CSRF 예외(/api/**)
- 프론트 API 중복 로직 공통화(api-text-json) 및 products.ts/setups.ts 리팩토링