### PR TITLE
[FEAT] (BE) 홈 인기 상품 조회 API 추가

### DIFF
--- a/front/src/api/http.ts
+++ b/front/src/api/http.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios, { AxiosHeaders, type InternalAxiosRequestConfig } from 'axios'
 import { API_BASE_URL, REQUEST_TIMEOUT_MS } from './config'
 
 export const http = axios.create({
@@ -7,13 +7,14 @@ export const http = axios.create({
   headers: { 'Content-Type': 'application/json' },
 })
 
-http.interceptors.request.use((config) => {
+http.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   const token = localStorage.getItem('access_token')
+
   if (token) {
-    config.headers = {
-      ...(config.headers ?? {}),
-      Authorization: `Bearer ${token}`,
-    }
+    const headers = AxiosHeaders.from(config.headers)
+    headers.set('Authorization', `Bearer ${token}`)
+    config.headers = headers
   }
+
   return config
 })

--- a/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
+++ b/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
                     // 프리플라이트(OPTIONS)는 항상 허용
                     .requestMatchers(HttpMethod.OPTIONS, "/api/**").permitAll()
                     // 상품/셋업 조회 GET은 로그인 없이 허용
-                    .requestMatchers(HttpMethod.GET, "/api/products/**", "/api/setups/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/products/**", "/api/setups/**", "/api/home/**").permitAll()
                     // 로그인/OAuth/에러 페이지는 허용
                     .requestMatchers("/login**", "/oauth2/**", "/error").permitAll()
                     // 나머지는 인증 필요

--- a/src/main/java/com/deskit/deskit/home/controller/HomePopularProductController.java
+++ b/src/main/java/com/deskit/deskit/home/controller/HomePopularProductController.java
@@ -1,0 +1,51 @@
+package com.deskit.deskit.home.controller;
+
+import com.deskit.deskit.home.dto.HomePopularProductResponse;
+import com.deskit.deskit.home.service.HomePopularProductService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/home")
+public class HomePopularProductController {
+
+  private static final int DEFAULT_LIMIT = 8;
+  private static final int MAX_LIMIT = 50;
+
+  private final HomePopularProductService homePopularProductService;
+
+  public HomePopularProductController(HomePopularProductService homePopularProductService) {
+    this.homePopularProductService = homePopularProductService;
+  }
+
+  @GetMapping("/popular-products")
+  public List<HomePopularProductResponse> getPopularProducts(
+      @RequestParam(value = "limit", required = false) String limit) {
+    int resolvedLimit = resolveLimit(limit);
+    return homePopularProductService.getPopularProducts(resolvedLimit);
+  }
+
+  private int resolveLimit(String limit) {
+    if (limit == null) {
+      return DEFAULT_LIMIT;
+    }
+
+    String trimmed = limit.trim();
+    if (trimmed.isEmpty()) {
+      return DEFAULT_LIMIT;
+    }
+
+    try {
+      int parsed = Integer.parseInt(trimmed);
+      if (parsed <= 0) {
+        return DEFAULT_LIMIT;
+      }
+      return Math.min(parsed, MAX_LIMIT);
+    } catch (NumberFormatException ex) {
+      return DEFAULT_LIMIT;
+    }
+  }
+}

--- a/src/main/java/com/deskit/deskit/home/dto/HomePopularProductResponse.java
+++ b/src/main/java/com/deskit/deskit/home/dto/HomePopularProductResponse.java
@@ -1,0 +1,41 @@
+package com.deskit.deskit.home.dto;
+
+import com.deskit.deskit.product.repository.ProductRepository.PopularProductRow;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class HomePopularProductResponse {
+
+  @JsonProperty("product_id")
+  private final Long productId;
+
+  @JsonProperty("name")
+  private final String name;
+
+  @JsonProperty("price")
+  private final Integer price;
+
+  @JsonProperty("sold_qty")
+  private final Long soldQty;
+
+  @JsonProperty("thumbnail_url")
+  private final String thumbnailUrl;
+
+  public HomePopularProductResponse(Long productId, String name, Integer price,
+                                    Long soldQty, String thumbnailUrl) {
+    this.productId = productId;
+    this.name = name;
+    this.price = price;
+    this.soldQty = soldQty == null ? 0L : soldQty;
+    this.thumbnailUrl = thumbnailUrl;
+  }
+
+  public static HomePopularProductResponse from(PopularProductRow row) {
+    return new HomePopularProductResponse(
+        row.getProductId(),
+        row.getProductName(),
+        row.getPrice(),
+        row.getSoldQty(),
+        row.getThumbnailUrl()
+    );
+  }
+}

--- a/src/main/java/com/deskit/deskit/home/service/HomePopularProductService.java
+++ b/src/main/java/com/deskit/deskit/home/service/HomePopularProductService.java
@@ -1,0 +1,22 @@
+package com.deskit.deskit.home.service;
+
+import com.deskit.deskit.home.dto.HomePopularProductResponse;
+import com.deskit.deskit.product.repository.ProductRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class HomePopularProductService {
+
+  private final ProductRepository productRepository;
+
+  public HomePopularProductService(ProductRepository productRepository) {
+    this.productRepository = productRepository;
+  }
+
+  public List<HomePopularProductResponse> getPopularProducts(int limit) {
+    return productRepository.findPopularProducts(limit).stream()
+        .map(HomePopularProductResponse::from)
+        .toList();
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- closes #27

## 📝 작업 내용
- GET /api/home/popular-products API 추가 (limit 파라미터 지원, 기본 8 / 최대 50)
- 판매량 기준 정렬: PAID/COMPLETED 주문의 order_item.quantity 합(sold_qty)
- 판매량 데이터 없을 때 최신 등록순(created_at desc) fallback
- 썸네일: product_image(THUMBNAIL, slot_index=0) 우선 조회
- SecurityConfig에 GET /api/home/** permitAll 추가