### PR TITLE
[FEAT] 홈 인기 셋업 조회 API 추가

### DIFF
--- a/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
+++ b/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
                     // 프리플라이트(OPTIONS)는 항상 허용
                     .requestMatchers(HttpMethod.OPTIONS, "/api/**").permitAll()
                     // 상품/셋업 조회 GET은 로그인 없이 허용
-                    .requestMatchers(HttpMethod.GET, "/api/products/**", "/api/setups/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/products/**", "/api/setups/**", "/api/home/**")
+                    .permitAll()
                     // 로그인/OAuth/에러 페이지는 허용
                     .requestMatchers("/login**", "/oauth2/**", "/error").permitAll()
                     // 나머지는 인증 필요

--- a/src/main/java/com/deskit/deskit/home/controller/HomePopularSetupController.java
+++ b/src/main/java/com/deskit/deskit/home/controller/HomePopularSetupController.java
@@ -1,0 +1,51 @@
+package com.deskit.deskit.home.controller;
+
+import com.deskit.deskit.home.dto.HomePopularSetupResponse;
+import com.deskit.deskit.home.service.HomePopularSetupService;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/home")
+public class HomePopularSetupController {
+
+  private static final int DEFAULT_LIMIT = 6;
+  private static final int MAX_LIMIT = 50;
+
+  private final HomePopularSetupService homePopularSetupService;
+
+  public HomePopularSetupController(HomePopularSetupService homePopularSetupService) {
+    this.homePopularSetupService = homePopularSetupService;
+  }
+
+  @GetMapping("/popular-setups")
+  public List<HomePopularSetupResponse> getPopularSetups(
+      @RequestParam(value = "limit", required = false) String limit) {
+    int resolvedLimit = resolveLimit(limit);
+    return homePopularSetupService.getPopularSetups(resolvedLimit);
+  }
+
+  private int resolveLimit(String limit) {
+    if (limit == null) {
+      return DEFAULT_LIMIT;
+    }
+
+    String trimmed = limit.trim();
+    if (trimmed.isEmpty()) {
+      return DEFAULT_LIMIT;
+    }
+
+    try {
+      int parsed = Integer.parseInt(trimmed);
+      if (parsed <= 0) {
+        return DEFAULT_LIMIT;
+      }
+      return Math.min(parsed, MAX_LIMIT);
+    } catch (NumberFormatException ex) {
+      return DEFAULT_LIMIT;
+    }
+  }
+}

--- a/src/main/java/com/deskit/deskit/home/dto/HomePopularSetupResponse.java
+++ b/src/main/java/com/deskit/deskit/home/dto/HomePopularSetupResponse.java
@@ -1,0 +1,41 @@
+package com.deskit.deskit.home.dto;
+
+import com.deskit.deskit.setup.repository.SetupRepository.PopularSetupRow;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class HomePopularSetupResponse {
+
+  @JsonProperty("setup_id")
+  private final Long setupId;
+
+  @JsonProperty("name")
+  private final String name;
+
+  @JsonProperty("short_desc")
+  private final String shortDesc;
+
+  @JsonProperty("sold_qty")
+  private final Long soldQty;
+
+  @JsonProperty("image_url")
+  private final String imageUrl;
+
+  public HomePopularSetupResponse(Long setupId, String name, String shortDesc,
+                                  Long soldQty, String imageUrl) {
+    this.setupId = setupId;
+    this.name = name;
+    this.shortDesc = shortDesc;
+    this.soldQty = soldQty == null ? 0L : soldQty;
+    this.imageUrl = imageUrl;
+  }
+
+  public static HomePopularSetupResponse from(PopularSetupRow row) {
+    return new HomePopularSetupResponse(
+        row.getSetupId(),
+        row.getSetupName(),
+        row.getShortDesc(),
+        row.getSoldQty(),
+        row.getImageUrl()
+    );
+  }
+}

--- a/src/main/java/com/deskit/deskit/home/service/HomePopularSetupService.java
+++ b/src/main/java/com/deskit/deskit/home/service/HomePopularSetupService.java
@@ -1,0 +1,22 @@
+package com.deskit.deskit.home.service;
+
+import com.deskit.deskit.home.dto.HomePopularSetupResponse;
+import com.deskit.deskit.setup.repository.SetupRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class HomePopularSetupService {
+
+  private final SetupRepository setupRepository;
+
+  public HomePopularSetupService(SetupRepository setupRepository) {
+    this.setupRepository = setupRepository;
+  }
+
+  public List<HomePopularSetupResponse> getPopularSetups(int limit) {
+    return setupRepository.findPopularSetups(limit).stream()
+        .map(HomePopularSetupResponse::from)
+        .toList();
+  }
+}

--- a/src/main/java/com/deskit/deskit/setup/repository/SetupRepository.java
+++ b/src/main/java/com/deskit/deskit/setup/repository/SetupRepository.java
@@ -19,4 +19,38 @@ public interface SetupRepository extends JpaRepository<Setup, Long> {
       where sp.setup_id = :setupId
       """, nativeQuery = true)
   List<Long> findProductIdsBySetupId(@Param("setupId") Long setupId);
+
+  @Query(value = """
+      SELECT
+          s.setup_id AS setupId,
+          s.setup_name AS setupName,
+          s.short_desc AS shortDesc,
+          s.setup_image_url AS imageUrl,
+          COALESCE(SUM(CASE WHEN o.order_id IS NOT NULL THEN oi.quantity ELSE 0 END), 0) AS soldQty,
+          MAX(s.created_at) AS createdAt
+      FROM setup s
+      LEFT JOIN setup_product sp
+          ON sp.setup_id = s.setup_id
+          AND sp.deleted_at IS NULL
+      LEFT JOIN order_item oi
+          ON oi.product_id = sp.product_id
+          AND oi.deleted_at IS NULL
+      LEFT JOIN `order` o
+          ON o.order_id = oi.order_id
+          AND o.deleted_at IS NULL
+          AND o.status IN ('PAID', 'COMPLETED')
+      WHERE s.deleted_at IS NULL
+      GROUP BY s.setup_id, s.setup_name, s.short_desc, s.setup_image_url
+      ORDER BY soldQty DESC, createdAt DESC
+      LIMIT :limit
+      """, nativeQuery = true)
+  List<PopularSetupRow> findPopularSetups(@Param("limit") int limit);
+
+  interface PopularSetupRow {
+    Long getSetupId();
+    String getSetupName();
+    String getShortDesc();
+    String getImageUrl();
+    Long getSoldQty();
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closes #28

## 📝 작업 내용
- 홈 인기 셋업 조회 API 추가: GET /api/home/popular-setups?limit=6
  - setup_product로 묶인 상품들의 판매량 합을 setup 기준으로 집계
  - 판매량이 0/없으면 setup.created_at desc로 fallback
  - 이미지: setup.setup_image_url 사용
- SetupRepository native query 추가 (집계 + 정렬)
- HomePopularSetupController/Service/DTO 추가

## 📸 스크린샷
<img width="692" height="917" alt="스크린샷 2025-12-31 10 33 42" src="https://github.com/user-attachments/assets/4a0fc741-a1bb-4874-b406-eef5578eb299" />