### PR TITLE
feat: 관리자 로그인 구현

### DIFF
--- a/front/src/pages/AdminVerify.vue
+++ b/front/src/pages/AdminVerify.vue
@@ -1,0 +1,265 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import PageContainer from '../components/PageContainer.vue'
+import PageHeader from '../components/PageHeader.vue'
+
+type PendingAdmin = {
+  name: string
+  email: string
+  phoneMasked: string
+}
+
+type VerifyResponse = {
+  name: string
+  email: string
+  role: string
+}
+
+const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
+const router = useRouter()
+const pending = ref<PendingAdmin | null>(null)
+
+const form = reactive({
+  code: '',
+  message: '',
+  sentMessage: '',
+})
+
+const loadPending = async () => {
+  const response = await fetch(`${apiBase}/api/admin/auth/pending`, {
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    form.message = '관리자 인증 정보를 찾을 수 없습니다.'
+    return
+  }
+
+  pending.value = (await response.json()) as PendingAdmin
+}
+
+const sendCode = async () => {
+  const response = await fetch(`${apiBase}/api/admin/auth/send`, {
+    method: 'POST',
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    form.sentMessage = '인증번호 재전송에 실패했습니다.'
+    return
+  }
+
+  const data = await response.json()
+  form.sentMessage = `인증번호가 발송되었습니다. (개발용 코드: ${data.code})`
+}
+
+const storeAuthUser = (payload: VerifyResponse) => {
+  const authUser = {
+    name: payload.name ?? '관리자',
+    email: payload.email ?? '',
+    signupType: '관리자',
+    memberCategory: '관리자',
+  }
+
+  localStorage.setItem('deskit-user', JSON.stringify(authUser))
+  localStorage.setItem('deskit-auth', 'admin')
+  window.dispatchEvent(new Event('deskit-user-updated'))
+}
+
+const verifyCode = async () => {
+  if (!form.code.trim()) {
+    form.message = '인증번호를 입력해주세요.'
+    return
+  }
+
+  const response = await fetch(`${apiBase}/api/admin/auth/verify`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify({ code: form.code }),
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    form.message = errorText || '인증에 실패했습니다.'
+    return
+  }
+
+  const payload = (await response.json()) as VerifyResponse
+  storeAuthUser(payload)
+  form.message = ''
+  await router.push('/admin')
+}
+
+const backToLogin = () => {
+  router.push('/login').catch(() => {})
+}
+
+onMounted(() => {
+  loadPending()
+})
+</script>
+
+<template>
+  <PageContainer>
+    <PageHeader eyebrow="DESKIT" title="관리자 2차 인증" />
+    <div class="admin-auth-wrap">
+      <section class="admin-auth-card">
+        <div class="card-top">
+          <p class="lead">관리자 계정 확인을 위해 인증번호를 입력해주세요.</p>
+          <p v-if="pending?.phoneMasked" class="sub">
+            등록된 번호 <strong>{{ pending.phoneMasked }}</strong>로 인증번호가 전송됩니다.
+          </p>
+        </div>
+
+        <div v-if="pending" class="auth-body">
+          <label class="field">
+            <span>인증번호</span>
+            <div class="field-row">
+              <input v-model="form.code" type="text" placeholder="6자리 인증번호" />
+              <button type="button" class="btn primary" @click="verifyCode">인증하기</button>
+            </div>
+          </label>
+
+          <button type="button" class="btn ghost" @click="sendCode">인증번호 재전송</button>
+        </div>
+
+        <div v-else class="alert">
+          <p>인증 세션이 없습니다. 다시 로그인해주세요.</p>
+          <button type="button" class="btn" @click="backToLogin">로그인으로 이동</button>
+        </div>
+
+        <p v-if="form.sentMessage" class="message success">{{ form.sentMessage }}</p>
+        <p v-if="form.message" class="message">{{ form.message }}</p>
+      </section>
+    </div>
+  </PageContainer>
+</template>
+
+<style scoped>
+.admin-auth-wrap {
+  max-width: 560px;
+  margin: 0 auto;
+  padding-top: 12px;
+}
+
+.admin-auth-card {
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  border-radius: 16px;
+  padding: 18px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.03);
+}
+
+.card-top {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lead {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 900;
+  color: var(--text-strong);
+}
+
+.sub {
+  margin: 0;
+  color: var(--text-muted);
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.sub strong {
+  color: var(--text-strong);
+  font-weight: 900;
+}
+
+.auth-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.field-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.field-row input {
+  flex: 1;
+  min-width: 180px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-weight: 600;
+}
+
+.btn {
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  color: var(--text-strong);
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.btn.primary {
+  background: var(--primary-color);
+  border-color: var(--primary-color);
+  color: #fff;
+}
+
+.btn.ghost {
+  background: transparent;
+}
+
+.alert {
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-weak);
+  padding: 14px;
+  font-weight: 700;
+  color: var(--text-strong);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.message {
+  margin: 0;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.message.success {
+  color: #15803d;
+}
+
+@media (max-width: 600px) {
+  .field-row {
+    flex-direction: column;
+  }
+
+  .field-row input {
+    width: 100%;
+  }
+}
+</style>

--- a/front/src/router/index.ts
+++ b/front/src/router/index.ts
@@ -58,6 +58,11 @@ const routes: RouteRecordRaw[] = [
     component: () => import('../pages/Login.vue'),
   },
   {
+    path: '/admin/verify',
+    name: 'admin-verify',
+    component: () => import('../pages/AdminVerify.vue'),
+  },
+  {
     path: '/signup',
     name: 'signup',
     component: () => import('../pages/Signup.vue'),
@@ -226,6 +231,12 @@ router.beforeEach(async (to) => {
   }
   if (isSellerPath && loggedIn && !isSeller()) {
     return { path: '/login', query: { redirect: to.fullPath } }
+  }
+  if (loggedIn && to.path === '/admin/verify') {
+    return { path: '/admin' }
+  }
+  if (to.path === '/admin/verify') {
+    return true
   }
   if (to.path.startsWith('/admin')) {
     if (!loggedIn || !isAdmin()) {

--- a/src/main/java/com/deskit/deskit/account/entity/Member.java
+++ b/src/main/java/com/deskit/deskit/account/entity/Member.java
@@ -42,6 +42,7 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
 
+    // ROLE_MEMBER 고정
     @Column(name = "role", nullable = false)
     private String role;
 

--- a/src/main/java/com/deskit/deskit/admin/controller/AdminAuthController.java
+++ b/src/main/java/com/deskit/deskit/admin/controller/AdminAuthController.java
@@ -1,0 +1,143 @@
+package com.deskit.deskit.admin.controller;
+
+import com.deskit.deskit.account.jwt.JWTUtil;
+import com.deskit.deskit.account.repository.RefreshRepository;
+import com.deskit.deskit.admin.dto.AdminAuthPendingResponse;
+import com.deskit.deskit.admin.dto.AdminAuthVerifyRequest;
+import com.deskit.deskit.admin.dto.AdminAuthVerifyResponse;
+import com.deskit.deskit.admin.entity.Admin;
+import com.deskit.deskit.admin.repository.AdminRepository;
+import com.deskit.deskit.admin.service.AdminAuthService;
+import com.deskit.deskit.common.util.verification.PhoneSendResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/auth")
+public class AdminAuthController {
+
+    private final AdminRepository adminRepository;
+    private final AdminAuthService adminAuthService;
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    @GetMapping("/pending")
+    public ResponseEntity<?> pending(HttpSession session) {
+        String loginId = adminAuthService.getLoginId(session);
+        if (loginId == null) {
+            return new ResponseEntity<>("unauthorized", HttpStatus.UNAUTHORIZED);
+        }
+
+        String name = adminAuthService.getName(session);
+        String phone = adminAuthService.getPhone(session);
+
+        AdminAuthPendingResponse response = AdminAuthPendingResponse.builder()
+                .name(name == null ? "" : name)
+                .email(loginId)
+                .phoneMasked(maskPhone(phone))
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PostMapping("/send")
+    public ResponseEntity<?> sendCode(HttpSession session) {
+        String loginId = adminAuthService.getLoginId(session);
+        if (loginId == null) {
+            return new ResponseEntity<>("unauthorized", HttpStatus.UNAUTHORIZED);
+        }
+
+        String code = adminAuthService.resendCode(session);
+        if (code == null) {
+            Admin admin = adminRepository.findByLoginId(loginId);
+            if (admin == null) {
+                return new ResponseEntity<>("unauthorized", HttpStatus.UNAUTHORIZED);
+            }
+            code = adminAuthService.startSession(admin, session);
+        }
+
+        PhoneSendResponse response = PhoneSendResponse.builder()
+                .message("verification code generated")
+                .code(code)
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<?> verifyCode(
+            @RequestBody AdminAuthVerifyRequest request,
+            HttpSession session,
+            HttpServletResponse response
+    ) {
+        String loginId = adminAuthService.getLoginId(session);
+        if (loginId == null) {
+            return new ResponseEntity<>("unauthorized", HttpStatus.UNAUTHORIZED);
+        }
+
+        String code = request == null ? null : request.getCode();
+        if (code == null || code.isBlank()) {
+            return new ResponseEntity<>("verification code required", HttpStatus.BAD_REQUEST);
+        }
+
+        boolean verified = adminAuthService.verifyCode(session, code);
+        if (!verified) {
+            return new ResponseEntity<>("verification failed", HttpStatus.BAD_REQUEST);
+        }
+
+        String role = adminAuthService.getRole(session);
+        String name = adminAuthService.getName(session);
+
+        issueTokens(loginId, role == null ? "ROLE_ADMIN" : role, response);
+        adminAuthService.clearSession(session);
+
+        AdminAuthVerifyResponse payload = AdminAuthVerifyResponse.builder()
+                .name(name == null ? "관리자" : name)
+                .email(loginId)
+                .role(role == null ? "ROLE_ADMIN" : role)
+                .build();
+
+        return new ResponseEntity<>(payload, HttpStatus.OK);
+    }
+
+    private void issueTokens(String username, String role, HttpServletResponse response) {
+        long accessExpiryMs = 600000L;
+        long refreshExpiryMs = 86400000L;
+
+        String access = jwtUtil.createJwt("access", username, role, accessExpiryMs);
+        String refresh = jwtUtil.createJwt("refresh", username, role, refreshExpiryMs);
+
+        refreshRepository.save(username, refresh, refreshExpiryMs);
+
+        response.setHeader("access", access);
+        response.addCookie(createCookie("access", access, Math.toIntExact(accessExpiryMs / 1000)));
+        response.addCookie(createCookie("refresh", refresh, Math.toIntExact(refreshExpiryMs / 1000)));
+    }
+
+    private Cookie createCookie(String key, String value, int maxAge) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(maxAge);
+        // cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        return cookie;
+    }
+
+    private String maskPhone(String phone) {
+        if (phone == null || phone.isBlank()) {
+            return "";
+        }
+        String digits = phone.replaceAll("\\D", "");
+        if (digits.length() <= 4) {
+            return phone;
+        }
+        String tail = digits.substring(digits.length() - 4);
+        return "****" + tail;
+    }
+}

--- a/src/main/java/com/deskit/deskit/admin/controller/package-info.java
+++ b/src/main/java/com/deskit/deskit/admin/controller/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.admin.controller;

--- a/src/main/java/com/deskit/deskit/admin/dto/AdminAuthPendingResponse.java
+++ b/src/main/java/com/deskit/deskit/admin/dto/AdminAuthPendingResponse.java
@@ -1,0 +1,15 @@
+package com.deskit.deskit.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class AdminAuthPendingResponse {
+
+    private String name;
+    private String email;
+    private String phoneMasked;
+}

--- a/src/main/java/com/deskit/deskit/admin/dto/AdminAuthVerifyRequest.java
+++ b/src/main/java/com/deskit/deskit/admin/dto/AdminAuthVerifyRequest.java
@@ -1,0 +1,11 @@
+package com.deskit.deskit.admin.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminAuthVerifyRequest {
+
+    private String code;
+}

--- a/src/main/java/com/deskit/deskit/admin/dto/AdminAuthVerifyResponse.java
+++ b/src/main/java/com/deskit/deskit/admin/dto/AdminAuthVerifyResponse.java
@@ -1,0 +1,15 @@
+package com.deskit.deskit.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class AdminAuthVerifyResponse {
+
+    private String name;
+    private String email;
+    private String role;
+}

--- a/src/main/java/com/deskit/deskit/admin/dto/package-info.java
+++ b/src/main/java/com/deskit/deskit/admin/dto/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.admin.dto;

--- a/src/main/java/com/deskit/deskit/admin/entity/Admin.java
+++ b/src/main/java/com/deskit/deskit/admin/entity/Admin.java
@@ -1,0 +1,38 @@
+package com.deskit.deskit.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Admin {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "admin_id")
+    private Long adminId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    // Email과 동일
+    @Column(name = "login_id", nullable = false)
+    private String loginId;
+
+    @Column(name = "phone", nullable = false)
+    private String phone;
+
+    // ROLE_ADMIN 고정
+    @Column(name = "role", nullable = false)
+    private String role;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/deskit/deskit/admin/entity/package-info.java
+++ b/src/main/java/com/deskit/deskit/admin/entity/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.admin.entity;

--- a/src/main/java/com/deskit/deskit/admin/repository/AdminRepository.java
+++ b/src/main/java/com/deskit/deskit/admin/repository/AdminRepository.java
@@ -1,0 +1,9 @@
+package com.deskit.deskit.admin.repository;
+
+import com.deskit.deskit.admin.entity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Admin findByLoginId(String loginId);
+}

--- a/src/main/java/com/deskit/deskit/admin/repository/package-info.java
+++ b/src/main/java/com/deskit/deskit/admin/repository/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.admin.repository;

--- a/src/main/java/com/deskit/deskit/admin/service/AdminAuthService.java
+++ b/src/main/java/com/deskit/deskit/admin/service/AdminAuthService.java
@@ -1,0 +1,108 @@
+package com.deskit.deskit.admin.service;
+
+import com.deskit.deskit.admin.entity.Admin;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+public class AdminAuthService {
+
+    public String startSession(Admin admin, HttpSession session) {
+        if (admin == null || session == null) {
+            return null;
+        }
+
+        session.setAttribute(AdminAuthSessionKeys.SESSION_ADMIN_LOGIN_ID, admin.getLoginId());
+        session.setAttribute(AdminAuthSessionKeys.SESSION_ADMIN_PHONE, admin.getPhone());
+        session.setAttribute(AdminAuthSessionKeys.SESSION_ADMIN_NAME, admin.getName());
+        session.setAttribute(AdminAuthSessionKeys.SESSION_ADMIN_ROLE, admin.getRole());
+
+        String code = generateCode();
+        session.setAttribute(AdminAuthSessionKeys.SESSION_ADMIN_CODE, code);
+        session.setAttribute(AdminAuthSessionKeys.SESSION_ADMIN_VERIFIED, false);
+
+        return code;
+    }
+
+    public String resendCode(HttpSession session) {
+        if (session == null) {
+            return null;
+        }
+
+        String loginId = (String) session.getAttribute(AdminAuthSessionKeys.SESSION_ADMIN_LOGIN_ID);
+        if (loginId == null || loginId.isBlank()) {
+            return null;
+        }
+
+        String code = generateCode();
+        session.setAttribute(AdminAuthSessionKeys.SESSION_ADMIN_CODE, code);
+        session.setAttribute(AdminAuthSessionKeys.SESSION_ADMIN_VERIFIED, false);
+
+        return code;
+    }
+
+    public boolean verifyCode(HttpSession session, String code) {
+        if (session == null || code == null) {
+            return false;
+        }
+
+        String storedCode = (String) session.getAttribute(AdminAuthSessionKeys.SESSION_ADMIN_CODE);
+        if (storedCode == null || storedCode.isBlank()) {
+            return false;
+        }
+
+        if (!storedCode.equals(code)) {
+            return false;
+        }
+
+        session.setAttribute(AdminAuthSessionKeys.SESSION_ADMIN_VERIFIED, true);
+        return true;
+    }
+
+    public void clearSession(HttpSession session) {
+        if (session == null) {
+            return;
+        }
+
+        session.removeAttribute(AdminAuthSessionKeys.SESSION_ADMIN_LOGIN_ID);
+        session.removeAttribute(AdminAuthSessionKeys.SESSION_ADMIN_PHONE);
+        session.removeAttribute(AdminAuthSessionKeys.SESSION_ADMIN_NAME);
+        session.removeAttribute(AdminAuthSessionKeys.SESSION_ADMIN_ROLE);
+        session.removeAttribute(AdminAuthSessionKeys.SESSION_ADMIN_CODE);
+        session.removeAttribute(AdminAuthSessionKeys.SESSION_ADMIN_VERIFIED);
+    }
+
+    public String getLoginId(HttpSession session) {
+        if (session == null) {
+            return null;
+        }
+        return (String) session.getAttribute(AdminAuthSessionKeys.SESSION_ADMIN_LOGIN_ID);
+    }
+
+    public String getPhone(HttpSession session) {
+        if (session == null) {
+            return null;
+        }
+        return (String) session.getAttribute(AdminAuthSessionKeys.SESSION_ADMIN_PHONE);
+    }
+
+    public String getName(HttpSession session) {
+        if (session == null) {
+            return null;
+        }
+        return (String) session.getAttribute(AdminAuthSessionKeys.SESSION_ADMIN_NAME);
+    }
+
+    public String getRole(HttpSession session) {
+        if (session == null) {
+            return null;
+        }
+        return (String) session.getAttribute(AdminAuthSessionKeys.SESSION_ADMIN_ROLE);
+    }
+
+    private String generateCode() {
+        return String.format("%06d", ThreadLocalRandom.current().nextInt(100000, 1000000));
+    }
+}

--- a/src/main/java/com/deskit/deskit/admin/service/AdminAuthSessionKeys.java
+++ b/src/main/java/com/deskit/deskit/admin/service/AdminAuthSessionKeys.java
@@ -1,0 +1,14 @@
+package com.deskit.deskit.admin.service;
+
+public final class AdminAuthSessionKeys {
+
+    public static final String SESSION_ADMIN_LOGIN_ID = "pendingAdminLoginId";
+    public static final String SESSION_ADMIN_PHONE = "pendingAdminPhone";
+    public static final String SESSION_ADMIN_NAME = "pendingAdminName";
+    public static final String SESSION_ADMIN_ROLE = "pendingAdminRole";
+    public static final String SESSION_ADMIN_CODE = "pendingAdminCode";
+    public static final String SESSION_ADMIN_VERIFIED = "pendingAdminVerified";
+
+    private AdminAuthSessionKeys() {
+    }
+}

--- a/src/main/java/com/deskit/deskit/admin/service/package-info.java
+++ b/src/main/java/com/deskit/deskit/admin/service/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.admin.service;

--- a/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
+++ b/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
@@ -118,6 +118,7 @@ public class SecurityConfig {
                                 "/chat",
                                 "/chat/**",
                                 "/reissue",
+                                "/api/admin/auth/**",
                                 "/api/invitations/validate",
                                 "/oauth/**",
 								"/login",


### PR DESCRIPTION
## 📌 관련 이슈

- closes #35 

## 📝 작업 내용

- 관리자 로그인 기능 구현
- 2차 인증 페이지 생성 및 프론트 연동

## 🧐 리뷰 포인트

- 관리자 로그인 로직: 소셜 로그인 -> 관리자 DB에 이메일이 있는지 확인 -> 있으면 2차 인증 -> 성공시 admin 메인 이동
- 2차 인증은 개발 단계에서 원활하게 사용할 수 있도록 개발용 인증코드 표시(SMS 미발송)
- 테스트에는 제 네이버 계정으로 테스트했는데, 실배포시에는 미리 DB에 관리자 계정정보를 입력해놓고 운용하면 됩니다.
- 회원조회 기능은 현재 프론트단에서 구현되어 있는데 아직 DB에 넣을 목데이터 구성이 안되어있어 남겨두었습니다.


## ✅ 추가 논의 사항

- IA구조도상에는 로그아웃 / 메인페이지 / 프로필 로 상단바 우측이 구성되어 있는데, 관리자 메인페이지에 어떤 것을 보여주어야 하는지 + 프로필이 필요한지
- 현재 페이지 헤더는 로그인되었을 경우 -> 장바구니 / 마이페이지 / 로그아웃으로 보여주고 있는데, 관리자 장바구니 기능이 필요한지

