### PR TITLE
feat: 장바구니 DB 스키마 기반 Cart/CartItem 엔티티 추가

### DIFF
--- a/src/main/java/com/deskit/deskit/cart/entity/Cart.java
+++ b/src/main/java/com/deskit/deskit/cart/entity/Cart.java
@@ -1,0 +1,39 @@
+package com.deskit.deskit.cart.entity;
+
+import com.deskit.deskit.account.entity.Member;
+import com.deskit.deskit.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cart", uniqueConstraints = {
+    @UniqueConstraint(name = "uk_cart_member", columnNames = "member_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Cart extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "cart_id", nullable = false)
+  private Long id;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false, unique = true)
+  private Member member;
+
+  public Cart(Member member) {
+    this.member = member;
+  }
+}

--- a/src/main/java/com/deskit/deskit/cart/entity/CartItem.java
+++ b/src/main/java/com/deskit/deskit/cart/entity/CartItem.java
@@ -1,0 +1,52 @@
+package com.deskit.deskit.cart.entity;
+
+import com.deskit.deskit.common.entity.BaseEntity;
+import com.deskit.deskit.product.entity.Product;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cart_item", uniqueConstraints = {
+    @UniqueConstraint(name = "uk_cart_item", columnNames = {"cart_id", "product_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartItem extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "cart_item_id", nullable = false)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "cart_id", nullable = false)
+  private Cart cart;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "product_id", nullable = false)
+  private Product product;
+
+  @Column(name = "quantity", nullable = false)
+  private Integer quantity;
+
+  @Column(name = "price_snapshot", nullable = false)
+  private Integer priceSnapshot;
+
+  public CartItem(Cart cart, Product product, Integer quantity, Integer priceSnapshot) {
+    this.cart = cart;
+    this.product = product;
+    this.quantity = quantity;
+    this.priceSnapshot = priceSnapshot;
+  }
+}

--- a/src/main/java/com/deskit/deskit/cart/entity/package-info.java
+++ b/src/main/java/com/deskit/deskit/cart/entity/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.cart.entity;


### PR DESCRIPTION
## 📌 관련 이슈
- closes #45 

## 📝 작업 내용
- cart 테이블 스키마에 맞춰 Cart 엔티티 매핑 추가 (member_id 유니크, BaseEntity 타임스탬프)
- cart_item 테이블 스키마에 맞춰 CartItem 엔티티 매핑 추가 (cart/product FK, quantity/price_snapshot, (cart_id, product_id) 유니크)

## 🧐 리뷰 포인트
- 엔티티 매핑이 SQL 스키마(컬럼명/제약조건/유니크키)와 정확히 일치하는지 확인 부탁드립니다.
- 연관관계(fetch 타입/양방향 여부)를 최소로 둔 것이 이후 서비스 구현에 문제 없는지 봐주세요.