### PR TITLE
[FEAT] 주문 도메인(Order/OrderItem) 엔티티 및 Repository/테스트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# local secrets (do not commit)
+src/main/resources/application.yml
+src/main/resources/application.properties

--- a/src/main/java/com/deskit/deskit/order/entity/Order.java
+++ b/src/main/java/com/deskit/deskit/order/entity/Order.java
@@ -1,0 +1,141 @@
+package com.deskit.deskit.order.entity;
+
+import com.deskit.deskit.common.entity.BaseEntity;
+import com.deskit.deskit.order.enums.OrderStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 주문(헤더) 엔티티
+ *
+ * - livecommerce_create_table.sql의 `order` 테이블 매핑
+ * - BaseEntity를 상속하여 created_at/updated_at/deleted_at(소프트 삭제) 컬럼을 공통으로 사용
+ * - 결제/취소 시각(paid_at/cancelled_at)은 주문 특화 필드이므로 Order에 별도 필드로 보관
+ */
+@Entity
+@Table(name = "`order`")
+@Getter
+// JPA 기본 생성자 요구사항 충족(외부에서 new로 생성하지 못하게 protected로 제한)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+
+  /**
+   * 주문 PK
+   * - order_id (AUTO_INCREMENT)
+   */
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "order_id", nullable = false)
+  private Long id;
+
+  /**
+   * 주문자 식별자
+   * - member 테이블의 member_id를 값으로만 저장(연관관계 대신 primitive id)
+   * - 주문은 "스냅샷성 데이터"라서, 회원 엔티티 변경/삭제와 강결합을 피하려는 의도
+   */
+  @Column(name = "member_id", nullable = false)
+  private Long memberId;
+
+  /**
+   * 주문번호(외부 노출용 식별자)
+   * - order_number (VARCHAR(50))
+   * - 보통 "ORD-YYYYMMDD-XXXX" 같은 규칙으로 생성
+   */
+  @Column(name = "order_number", nullable = false, length = 50)
+  private String orderNumber;
+
+  /**
+   * 상품 금액 합계(할인/배송비 적용 전 기준으로 사용)
+   * - total_product_amount
+   */
+  @Column(name = "total_product_amount", nullable = false)
+  private Integer totalProductAmount;
+
+  /**
+   * 배송비
+   * - shipping_fee (DEFAULT 0)
+   */
+  @Column(name = "shipping_fee", nullable = false)
+  private Integer shippingFee;
+
+  /**
+   * 할인 금액(쿠폰/프로모션 등)
+   * - discount_fee (DEFAULT 0)
+   */
+  @Column(name = "discount_fee", nullable = false)
+  private Integer discountFee;
+
+  /**
+   * 최종 결제 금액
+   * - order_amount
+   * - 일반적으로 total_product_amount + shipping_fee - discount_fee
+   */
+  @Column(name = "order_amount", nullable = false)
+  private Integer orderAmount;
+
+  /**
+   * 주문 상태
+   * - SQL ENUM('CREATED','PAID','CANCELLED','COMPLETED')
+   * - EnumType.STRING으로 저장하여 값이 명확하고, enum 순서 변경에 안전
+   */
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private OrderStatus status;
+
+  /**
+   * 취소 사유
+   * - cancel_reason (nullable)
+   */
+  @Column(name = "cancel_reason", length = 500)
+  private String cancelReason;
+
+  /**
+   * 결제 완료 시각
+   * - paid_at (nullable)
+   */
+  @Column(name = "paid_at")
+  private LocalDateTime paidAt;
+
+  /**
+   * 취소 시각
+   * - cancelled_at (nullable)
+   */
+  @Column(name = "cancelled_at")
+  private LocalDateTime cancelledAt;
+
+  /**
+   * 주문 생성 팩토리 메서드
+   *
+   * - 엔티티 생성 시 필요한 핵심 값들을 한 곳에서 세팅하기 위해 제공
+   * - 현재는 "값만 세팅"하는 최소 형태(검증/계산 로직은 이후 서비스 레이어에서 확장 가능)
+   */
+  public static Order create(
+          Long memberId,
+          String orderNumber,
+          Integer totalProductAmount,
+          Integer shippingFee,
+          Integer discountFee,
+          Integer orderAmount,
+          OrderStatus status
+  ) {
+    Order order = new Order();
+    order.memberId = memberId;
+    order.orderNumber = orderNumber;
+    order.totalProductAmount = totalProductAmount;
+    order.shippingFee = shippingFee;
+    order.discountFee = discountFee;
+    order.orderAmount = orderAmount;
+    order.status = status;
+    return order;
+  }
+}

--- a/src/main/java/com/deskit/deskit/order/entity/OrderItem.java
+++ b/src/main/java/com/deskit/deskit/order/entity/OrderItem.java
@@ -1,0 +1,119 @@
+package com.deskit.deskit.order.entity;
+
+import com.deskit.deskit.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 주문 상품(라인 아이템) 엔티티
+ *
+ * - livecommerce_create_table.sql의 order_item 테이블 매핑
+ * - 주문 시점의 상품 정보 스냅샷(product_name, unit_price 등)을 저장해서
+ *   이후 상품 정보가 변경되어도 "당시 주문 내역"이 변하지 않도록 한다.
+ * - BaseEntity를 상속하여 created_at/updated_at/deleted_at(소프트 삭제) 컬럼을 공통으로 사용
+ */
+@Entity
+@Table(name = "order_item")
+@Getter
+// JPA 기본 생성자 요구사항 충족(외부에서 new로 생성하지 못하게 protected로 제한)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItem extends BaseEntity {
+
+  /**
+   * 주문상품 PK
+   * - order_item_id (AUTO_INCREMENT)
+   */
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "order_item_id", nullable = false)
+  private Long id;
+
+  /**
+   * 소속 주문(부모)
+   * - FK: order_item.order_id → `order`.order_id
+   * - LAZY: 조회 시 주문상품 목록만 필요할 때 Order를 즉시 로딩하지 않도록
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "order_id", nullable = false)
+  private Order order;
+
+  /**
+   * 주문 시점 상품 ID (product.product_id)
+   * - 연관관계 대신 값만 저장: 주문 데이터는 스냅샷 성격이 강하고, 결합도를 낮추기 위함
+   */
+  @Column(name = "product_id", nullable = false)
+  private Long productId;
+
+  /**
+   * 판매자 ID (seller.seller_id)
+   * - 주문 단위 정산/조회 시 seller_id가 빠르게 필요해서 스냅샷으로 보관
+   */
+  @Column(name = "seller_id", nullable = false)
+  private Long sellerId;
+
+  /**
+   * 주문 시점 상품명 스냅샷
+   * - 상품명이 변경되어도 주문 내역은 당시 기준으로 유지
+   */
+  @Column(name = "product_name", nullable = false, length = 100)
+  private String productName;
+
+  /**
+   * 주문 시점 단가 스냅샷
+   * - unit_price
+   */
+  @Column(name = "unit_price", nullable = false)
+  private Integer unitPrice;
+
+  /**
+   * 수량
+   * - quantity
+   */
+  @Column(name = "quantity", nullable = false)
+  private Integer quantity;
+
+  /**
+   * 라인 금액(단가 * 수량)
+   * - subtotal_price
+   * - 보통 unitPrice * quantity로 계산되지만, 쿠폰/프로모션 등을 라인에 반영할 경우
+   *   저장값을 스냅샷으로 유지하는 편이 안전할 수 있음
+   */
+  @Column(name = "subtotal_price", nullable = false)
+  private Integer subtotalPrice;
+
+  /**
+   * 주문상품 생성 팩토리 메서드
+   *
+   * - 주문 생성 시 필요한 스냅샷 값을 한 번에 세팅하기 위한 최소 형태
+   * - (추후) subtotalPrice를 내부에서 계산하도록 바꾸면 불일치 위험을 더 줄일 수 있음
+   */
+  public static OrderItem create(
+          Order order,
+          Long productId,
+          Long sellerId,
+          String productName,
+          Integer unitPrice,
+          Integer quantity,
+          Integer subtotalPrice
+  ) {
+    OrderItem item = new OrderItem();
+    item.order = order;
+    item.productId = productId;
+    item.sellerId = sellerId;
+    item.productName = productName;
+    item.unitPrice = unitPrice;
+    item.quantity = quantity;
+    item.subtotalPrice = subtotalPrice;
+    return item;
+  }
+}

--- a/src/main/java/com/deskit/deskit/order/entity/package-info.java
+++ b/src/main/java/com/deskit/deskit/order/entity/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.order.entity;

--- a/src/main/java/com/deskit/deskit/order/enums/OrderStatus.java
+++ b/src/main/java/com/deskit/deskit/order/enums/OrderStatus.java
@@ -1,0 +1,8 @@
+package com.deskit.deskit.order.enums;
+
+public enum OrderStatus {
+  CREATED,
+  PAID,
+  CANCELLED,
+  COMPLETED
+}

--- a/src/main/java/com/deskit/deskit/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/deskit/deskit/order/repository/OrderItemRepository.java
@@ -1,0 +1,23 @@
+package com.deskit.deskit.order.repository;
+
+import com.deskit.deskit.order.entity.OrderItem;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * OrderItem(주문 상품/라인 아이템) 조회/저장을 담당하는 Repository
+ *
+ * - Spring Data JPA가 메서드 이름 규칙을 해석해서 쿼리를 자동 생성한다.
+ * - 기본 CRUD는 JpaRepository가 제공한다. (save, findById, delete 등)
+ */
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+  /**
+   * 특정 주문(order_id)에 속한 주문 상품 목록을 조회한다.
+   *
+   * - findByOrder_Id:
+   *   - OrderItem의 연관 필드인 "order"의
+   *   - 그 안의 "id" 값을 조건으로 검색한다는 뜻 (order.id)
+   */
+  List<OrderItem> findByOrder_Id(Long orderId);
+}

--- a/src/main/java/com/deskit/deskit/order/repository/OrderRepository.java
+++ b/src/main/java/com/deskit/deskit/order/repository/OrderRepository.java
@@ -1,0 +1,28 @@
+package com.deskit.deskit.order.repository;
+
+import com.deskit.deskit.order.entity.Order;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Order(주문) 엔티티에 대한 조회/저장 Repository.
+ *
+ * - JpaRepository가 기본 CRUD를 제공한다. (save, findById, delete 등)
+ * - 아래 커스텀 메서드는 Spring Data JPA 메서드 네이밍 규칙으로 쿼리를 자동 생성한다.
+ */
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+  /**
+   * 특정 회원(member_id)의 주문 목록을 생성일(created_at) 기준 내림차순으로 조회한다.
+   *
+   * - findByMemberId...:
+   *   Order 엔티티의 memberId 컬럼을 조건으로 필터링한다.
+   *
+   * - OrderByCreatedAtDesc:
+   *   BaseEntity에 있는 createdAt(created_at) 컬럼 기준으로 최신 주문이 먼저 오도록 정렬한다.
+   *
+   * - 사용 예:
+   *   List<Order> orders = orderRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+   */
+  List<Order> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+}

--- a/src/main/java/com/deskit/deskit/order/repository/package-info.java
+++ b/src/main/java/com/deskit/deskit/order/repository/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.order.repository;

--- a/src/test/java/com/deskit/deskit/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/deskit/deskit/order/repository/OrderRepositoryTest.java
@@ -1,0 +1,126 @@
+package com.deskit.deskit.order.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.deskit.deskit.account.entity.Member;
+import com.deskit.deskit.account.entity.Seller;
+import com.deskit.deskit.account.enums.JobCategory;
+import com.deskit.deskit.account.enums.MBTI;
+import com.deskit.deskit.account.enums.MemberStatus;
+import com.deskit.deskit.account.enums.SellerRole;
+import com.deskit.deskit.account.enums.SellerStatus;
+import com.deskit.deskit.order.entity.Order;
+import com.deskit.deskit.order.entity.OrderItem;
+import com.deskit.deskit.order.enums.OrderStatus;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class OrderRepositoryTest {
+
+  @Autowired
+  private OrderRepository orderRepository;
+
+  @Autowired
+  private OrderItemRepository orderItemRepository;
+
+  @Autowired
+  private TestEntityManager entityManager;
+
+  @Test
+  void saveAndLoadOrderWithItems() {
+    Member member = Member.builder()
+      .name("Test Member")
+      .loginId("member@test.com")
+      .phone("010-0000-0000")
+      .isAgreed(true)
+      .status(MemberStatus.ACTIVE)
+      .role("ROLE_MEMBER")
+      .mbti(MBTI.NONE)
+      .jobCategory(JobCategory.NONE)
+      .build();
+    entityManager.persist(member);
+
+    Seller seller = Seller.builder()
+      .status(SellerStatus.ACTIVE)
+      .name("Test Seller")
+      .loginId("seller@test.com")
+      .phone("010-1000-1000")
+      .role(SellerRole.ROLE_SELLER_OWNER)
+      .isAgreed(true)
+      .build();
+    entityManager.persist(seller);
+    entityManager.flush();
+
+    Long memberId = member.getMemberId();
+    Long sellerId = seller.getSellerId();
+    assertNotNull(memberId);
+    assertNotNull(sellerId);
+
+    entityManager.getEntityManager().createNativeQuery(
+      "INSERT INTO product (product_id, seller_id, product_name, short_desc, detail_html, " +
+      "price, cost_price, status, stock_qty, safety_stock) " +
+      "VALUES (:productId, :sellerId, 'Test Product A', 'Short A', '<p>Detail A</p>', " +
+      "10000, 12000, 'ON_SALE', 10, 5)"
+    ).setParameter("productId", 10L)
+      .setParameter("sellerId", sellerId)
+      .executeUpdate();
+
+    entityManager.getEntityManager().createNativeQuery(
+      "INSERT INTO product (product_id, seller_id, product_name, short_desc, detail_html, " +
+      "price, cost_price, status, stock_qty, safety_stock) " +
+      "VALUES (:productId, :sellerId, 'Test Product B', 'Short B', '<p>Detail B</p>', " +
+      "10000, 12000, 'ON_SALE', 10, 5)"
+    ).setParameter("productId", 11L)
+      .setParameter("sellerId", sellerId)
+      .executeUpdate();
+
+    Order order = Order.create(
+      memberId,
+      "ORD-TEST-001",
+      30000,
+      3000,
+      0,
+      33000,
+      OrderStatus.CREATED
+    );
+    Order savedOrder = orderRepository.save(order);
+    assertNotNull(savedOrder.getId());
+
+    OrderItem item1 = OrderItem.create(
+      savedOrder,
+      10L,
+      sellerId,
+      "Test Product A",
+      10000,
+      2,
+      20000
+    );
+    OrderItem item2 = OrderItem.create(
+      savedOrder,
+      11L,
+      sellerId,
+      "Test Product B",
+      10000,
+      1,
+      10000
+    );
+    orderItemRepository.save(item1);
+    orderItemRepository.save(item2);
+
+    List<Order> orders = orderRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+    assertEquals(1, orders.size());
+    assertEquals(savedOrder.getId(), orders.get(0).getId());
+
+    List<OrderItem> items = orderItemRepository.findByOrder_Id(savedOrder.getId());
+    assertEquals(2, items.size());
+  }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:mysql://localhost:3306/livecommerce_test?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.username=YOUR_USERNAME
+spring.datasource.password=YOUR_PASSWORD
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.globally_quoted_identifiers=true


### PR DESCRIPTION
## 📌 관련 이슈
- closes #65 

## 📝 작업 내용
- 주문 도메인 기본 골격 추가: OrderStatus, Order/OrderItem Entity
- OrderRepository/OrderItemRepository 추가 및 기본 조회 메서드 정의
- DataJpaTest 기반 저장/조회 테스트(OrderRepositoryTest) 추가
- test 프로파일 MySQL 설정(application-test.properties) 추가(ddl-auto=create-drop, quoted identifiers)