### PR TITLE
fix: 판매자 로그인 시 권한 분기를 통한 전용 페이지 표시를 구현한다

### DIFF
--- a/src/main/java/com/deskit/deskit/account/oauth/CustomSuccessHandler.java
+++ b/src/main/java/com/deskit/deskit/account/oauth/CustomSuccessHandler.java
@@ -80,7 +80,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.setHeader("access", access);
         response.addCookie(createCookie("access", access, Math.toIntExact(accessExpiryMs / 1000)));
         response.addCookie(createCookie("refresh", refresh, Math.toIntExact(refreshExpiryMs / 1000)));
-        response.sendRedirect("http://localhost:5173/");
+        response.sendRedirect(resolveRedirectUrl(role));
     }
 
     private Cookie createCookie(String key, String value, int maxAge) {
@@ -93,6 +93,13 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         cookie.setHttpOnly(true);
 
         return cookie;
+    }
+
+    private String resolveRedirectUrl(String role) {
+        if (role != null && role.startsWith("ROLE_SELLER")) {
+            return "http://localhost:5173/seller";
+        }
+        return "http://localhost:5173/";
     }
 
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closes #74 

## 📝 작업 내용

- 판매자 로그인 후 접근 URI 수정: / -> /seller
- 판매자 탭 분기 적용: / -> /seller
-백엔드 OAuth 후 리다이렉트 경로 변경

## 🧐 리뷰 포인트

- 판매자 로그인 후 메인부터 확인(/seller)