### PR TITLE
feat: 관리자와 사용자 1:1 채팅을 구현한다

### DIFF
--- a/src/main/java/com/deskit/deskit/ai/chatbot/controller/ChatController.java
+++ b/src/main/java/com/deskit/deskit/ai/chatbot/controller/ChatController.java
@@ -50,6 +50,12 @@ public class ChatController {
 
         // 현재 진행 중인 대화 조회 or 생성
         ChatInfo chatInfo = conversationService.getOrCreateActiveConversation(memberId);
+        if (chatInfo.getStatus() != com.deskit.deskit.ai.chatbot.openai.entity.ConversationStatus.BOT_ACTIVE) {
+            return ChatResponse.builder()
+                    .answer("상담 진행 중입니다. 관리자 상담은 종료 후 자동으로 시작됩니다.")
+                    .escalated(true)
+                    .build();
+        }
 
         if (question == null || question.isBlank()) {
             log.warn("Empty question received: {}", request);

--- a/src/main/java/com/deskit/deskit/ai/chatbot/openai/repository/ChatHandoffRepository.java
+++ b/src/main/java/com/deskit/deskit/ai/chatbot/openai/repository/ChatHandoffRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ChatHandoffRepository extends JpaRepository<ChatHandoff, Long> {
 
     boolean existsByChatIdAndStatus(Long chatId, HandoffStatus status);
+
+    java.util.Optional<ChatHandoff> findTopByChatIdOrderByCreatedAtDesc(Long chatId);
 }

--- a/src/main/java/com/deskit/deskit/ai/chatbot/openai/service/ConversationService.java
+++ b/src/main/java/com/deskit/deskit/ai/chatbot/openai/service/ConversationService.java
@@ -20,7 +20,18 @@ public class ConversationService {
 
         return conversationRepository
                 .findTopByMemberIdOrderByCreatedAtDesc(memberId)
-                .filter(c -> c.getStatus() == ConversationStatus.BOT_ACTIVE)
+                .map(latest -> {
+                    if (latest.getStatus() == ConversationStatus.BOT_ACTIVE) {
+                        return latest;
+                    }
+                    if (latest.getStatus() == ConversationStatus.CLOSED) {
+                        ChatInfo c = new ChatInfo();
+                        c.setMemberId(memberId);
+                        c.setStatus(ConversationStatus.BOT_ACTIVE);
+                        return conversationRepository.save(c);
+                    }
+                    return latest;
+                })
                 .orElseGet(() -> {
                     ChatInfo c = new ChatInfo();
                     c.setMemberId(memberId);

--- a/src/main/java/com/deskit/deskit/directchat/controller/AdminDirectChatController.java
+++ b/src/main/java/com/deskit/deskit/directchat/controller/AdminDirectChatController.java
@@ -1,0 +1,40 @@
+package com.deskit.deskit.directchat.controller;
+
+import com.deskit.deskit.directchat.dto.DirectChatAcceptRequest;
+import com.deskit.deskit.directchat.dto.DirectChatSummaryResponse;
+import com.deskit.deskit.directchat.service.DirectChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/direct-chats")
+public class AdminDirectChatController {
+
+    private final DirectChatService directChatService;
+
+    @GetMapping("/escalated")
+    public List<DirectChatSummaryResponse> getEscalatedChats() {
+        return directChatService.getEscalatedChats();
+    }
+
+    @PostMapping("/{chatId}/accept")
+    public DirectChatSummaryResponse acceptChat(
+            @PathVariable Long chatId,
+            @RequestBody DirectChatAcceptRequest request
+    ) {
+        return directChatService.acceptChat(chatId, request.getAdminId());
+    }
+
+    @PostMapping("/{chatId}/close")
+    public void closeChat(@PathVariable Long chatId) {
+        directChatService.closeChat(chatId);
+    }
+}

--- a/src/main/java/com/deskit/deskit/directchat/controller/DirectChatController.java
+++ b/src/main/java/com/deskit/deskit/directchat/controller/DirectChatController.java
@@ -1,0 +1,46 @@
+package com.deskit.deskit.directchat.controller;
+
+import com.deskit.deskit.directchat.dto.DirectChatLatestResponse;
+import com.deskit.deskit.directchat.dto.DirectChatMessageRequest;
+import com.deskit.deskit.directchat.dto.DirectChatMessageResponse;
+import com.deskit.deskit.directchat.service.DirectChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/direct-chats")
+public class DirectChatController {
+
+    private final DirectChatService directChatService;
+
+    @GetMapping("/latest/{memberId}")
+    public DirectChatLatestResponse getLatestConversation(@PathVariable Long memberId) {
+        return directChatService.getLatestConversation(memberId);
+    }
+
+    @PostMapping("/start/{memberId}")
+    public DirectChatLatestResponse startConversation(@PathVariable Long memberId) {
+        return directChatService.startNewConversation(memberId);
+    }
+
+    @GetMapping("/{chatId}/messages")
+    public List<DirectChatMessageResponse> getMessages(@PathVariable Long chatId) {
+        return directChatService.getMessages(chatId);
+    }
+
+    @PostMapping("/{chatId}/messages")
+    public DirectChatMessageResponse sendMessage(
+            @PathVariable Long chatId,
+            @RequestBody DirectChatMessageRequest request
+    ) {
+        return directChatService.saveMessage(chatId, request);
+    }
+}

--- a/src/main/java/com/deskit/deskit/directchat/controller/DirectChatSocketController.java
+++ b/src/main/java/com/deskit/deskit/directchat/controller/DirectChatSocketController.java
@@ -1,0 +1,27 @@
+package com.deskit.deskit.directchat.controller;
+
+import com.deskit.deskit.directchat.dto.DirectChatMessageRequest;
+import com.deskit.deskit.directchat.dto.DirectChatMessageResponse;
+import com.deskit.deskit.directchat.service.DirectChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class DirectChatSocketController {
+
+    private final DirectChatService directChatService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/direct-chats/{chatId}")
+    public void sendMessage(
+            @DestinationVariable Long chatId,
+            DirectChatMessageRequest request
+    ) {
+        DirectChatMessageResponse response = directChatService.saveMessage(chatId, request);
+        messagingTemplate.convertAndSend("/topic/direct-chats/" + chatId, response);
+    }
+}

--- a/src/main/java/com/deskit/deskit/directchat/dto/DirectChatAcceptRequest.java
+++ b/src/main/java/com/deskit/deskit/directchat/dto/DirectChatAcceptRequest.java
@@ -1,0 +1,11 @@
+package com.deskit.deskit.directchat.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DirectChatAcceptRequest {
+
+    private Long adminId;
+}

--- a/src/main/java/com/deskit/deskit/directchat/dto/DirectChatLatestResponse.java
+++ b/src/main/java/com/deskit/deskit/directchat/dto/DirectChatLatestResponse.java
@@ -1,0 +1,12 @@
+package com.deskit.deskit.directchat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DirectChatLatestResponse {
+
+    private Long chatId;
+    private String status;
+}

--- a/src/main/java/com/deskit/deskit/directchat/dto/DirectChatMessageRequest.java
+++ b/src/main/java/com/deskit/deskit/directchat/dto/DirectChatMessageRequest.java
@@ -1,0 +1,12 @@
+package com.deskit.deskit.directchat.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DirectChatMessageRequest {
+
+    private String sender;
+    private String content;
+}

--- a/src/main/java/com/deskit/deskit/directchat/dto/DirectChatMessageResponse.java
+++ b/src/main/java/com/deskit/deskit/directchat/dto/DirectChatMessageResponse.java
@@ -1,0 +1,17 @@
+package com.deskit.deskit.directchat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DirectChatMessageResponse {
+
+    private Long messageId;
+    private Long chatId;
+    private String sender;
+    private String content;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/deskit/deskit/directchat/dto/DirectChatSummaryResponse.java
+++ b/src/main/java/com/deskit/deskit/directchat/dto/DirectChatSummaryResponse.java
@@ -1,0 +1,19 @@
+package com.deskit.deskit.directchat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DirectChatSummaryResponse {
+
+    private Long chatId;
+    private Long memberId;
+    private String loginId;
+    private String status;
+    private LocalDateTime createdAt;
+    private Long assignedAdminId;
+    private String handoffStatus;
+}

--- a/src/main/java/com/deskit/deskit/directchat/service/DirectChatService.java
+++ b/src/main/java/com/deskit/deskit/directchat/service/DirectChatService.java
@@ -1,0 +1,212 @@
+package com.deskit.deskit.directchat.service;
+
+import com.deskit.deskit.ai.chatbot.openai.entity.ChatHandoff;
+import com.deskit.deskit.ai.chatbot.openai.entity.ChatInfo;
+import com.deskit.deskit.ai.chatbot.openai.entity.ChatMessage;
+import com.deskit.deskit.ai.chatbot.openai.entity.ConversationStatus;
+import com.deskit.deskit.ai.chatbot.openai.entity.HandoffStatus;
+import com.deskit.deskit.ai.chatbot.openai.repository.ChatHandoffRepository;
+import com.deskit.deskit.ai.chatbot.openai.repository.ChatRepository;
+import com.deskit.deskit.ai.chatbot.rag.repository.ConversationRepository;
+import com.deskit.deskit.account.entity.Member;
+import com.deskit.deskit.account.entity.Seller;
+import com.deskit.deskit.account.repository.MemberRepository;
+import com.deskit.deskit.account.repository.SellerRepository;
+import com.deskit.deskit.directchat.dto.DirectChatLatestResponse;
+import com.deskit.deskit.directchat.dto.DirectChatMessageRequest;
+import com.deskit.deskit.directchat.dto.DirectChatMessageResponse;
+import com.deskit.deskit.directchat.dto.DirectChatSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DirectChatService {
+
+    private final ConversationRepository conversationRepository;
+    private final ChatRepository chatRepository;
+    private final ChatHandoffRepository chatHandoffRepository;
+    private final MemberRepository memberRepository;
+    private final SellerRepository sellerRepository;
+
+    @Transactional(readOnly = true)
+    public List<DirectChatSummaryResponse> getEscalatedChats() {
+        return conversationRepository.findByStatus(ConversationStatus.ESCALATED).stream()
+                .map(chatInfo -> {
+                    ChatHandoff handoff = chatHandoffRepository.findTopByChatIdOrderByCreatedAtDesc(chatInfo.getChatId())
+                            .orElse(null);
+                    String loginId = resolveLoginId(chatInfo.getMemberId());
+                    return DirectChatSummaryResponse.builder()
+                            .chatId(chatInfo.getChatId())
+                            .memberId(chatInfo.getMemberId())
+                            .loginId(loginId)
+                            .status(chatInfo.getStatus().name())
+                            .createdAt(chatInfo.getCreatedAt())
+                            .assignedAdminId(handoff != null ? handoff.getAssignedAdminId() : null)
+                            .handoffStatus(handoff != null ? handoff.getStatus().name() : null)
+                            .build();
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public DirectChatLatestResponse getLatestConversation(Long memberId) {
+        ChatInfo chatInfo = conversationRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Conversation not found. memberId=" + memberId));
+        return DirectChatLatestResponse.builder()
+                .chatId(chatInfo.getChatId())
+                .status(chatInfo.getStatus().name())
+                .build();
+    }
+
+    @Transactional
+    public DirectChatLatestResponse startNewConversation(Long memberId) {
+        ChatInfo chatInfo = conversationRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
+                .filter(latest -> latest.getStatus() != ConversationStatus.CLOSED)
+                .orElseGet(() -> {
+                    ChatInfo created = new ChatInfo();
+                    created.setMemberId(memberId);
+                    created.setStatus(ConversationStatus.BOT_ACTIVE);
+                    return conversationRepository.save(created);
+                });
+
+        return DirectChatLatestResponse.builder()
+                .chatId(chatInfo.getChatId())
+                .status(chatInfo.getStatus().name())
+                .build();
+    }
+
+    @Transactional
+    public DirectChatSummaryResponse acceptChat(Long chatId, Long adminId) {
+        ChatInfo chatInfo = conversationRepository.findById(chatId)
+                .orElseThrow(() -> new IllegalArgumentException("Conversation not found. id=" + chatId));
+
+        chatInfo.setStatus(ConversationStatus.ADMIN_ACTIVE);
+        conversationRepository.save(chatInfo);
+
+        ChatHandoff handoff = chatHandoffRepository.findTopByChatIdOrderByCreatedAtDesc(chatId)
+                .orElseGet(() -> {
+                    ChatHandoff created = new ChatHandoff();
+                    created.setChatId(chatId);
+                    created.setStatus(HandoffStatus.ADMIN_WAITING);
+                    return created;
+                });
+        handoff.setAssignedAdminId(adminId);
+        handoff.setStatus(HandoffStatus.ADMIN_CHECKED);
+        chatHandoffRepository.save(handoff);
+
+        String loginId = resolveLoginId(chatInfo.getMemberId());
+        return DirectChatSummaryResponse.builder()
+                .chatId(chatInfo.getChatId())
+                .memberId(chatInfo.getMemberId())
+                .loginId(loginId)
+                .status(chatInfo.getStatus().name())
+                .createdAt(chatInfo.getCreatedAt())
+                .assignedAdminId(handoff.getAssignedAdminId())
+                .handoffStatus(handoff.getStatus().name())
+                .build();
+    }
+
+    @Transactional
+    public void closeChat(Long chatId) {
+        ChatInfo chatInfo = conversationRepository.findById(chatId)
+                .orElseThrow(() -> new IllegalArgumentException("Conversation not found. id=" + chatId));
+
+        if (chatInfo.getStatus() == ConversationStatus.CLOSED) {
+            return;
+        }
+
+        chatInfo.setStatus(ConversationStatus.CLOSED);
+        conversationRepository.save(chatInfo);
+
+        ChatMessage closeMessage = new ChatMessage();
+        closeMessage.setChatId(chatId);
+        closeMessage.setType(MessageType.SYSTEM);
+        closeMessage.setContent("상담이 종료되었습니다");
+        chatRepository.save(closeMessage);
+
+        chatHandoffRepository.findTopByChatIdOrderByCreatedAtDesc(chatId)
+                .ifPresent(handoff -> {
+                    handoff.setStatus(HandoffStatus.ADMIN_ANSWERED);
+                    chatHandoffRepository.save(handoff);
+                });
+    }
+
+    @Transactional(readOnly = true)
+    public List<DirectChatMessageResponse> getMessages(Long chatId) {
+        return chatRepository.findByChatIdOrderByCreatedAtAsc(chatId).stream()
+                .map(message -> DirectChatMessageResponse.builder()
+                        .messageId(message.getMessageId())
+                        .chatId(message.getChatId())
+                        .sender(resolveSender(message.getType()))
+                        .content(message.getContent())
+                        .createdAt(message.getCreatedAt())
+                        .build())
+                .toList();
+    }
+
+    @Transactional
+    public DirectChatMessageResponse saveMessage(Long chatId, DirectChatMessageRequest request) {
+        ChatMessage message = new ChatMessage();
+        message.setChatId(chatId);
+        message.setContent(request.getContent());
+        message.setType(resolveMessageType(request.getSender()));
+        chatRepository.save(message);
+
+        if ("ADMIN".equalsIgnoreCase(request.getSender())) {
+            chatHandoffRepository.findTopByChatIdOrderByCreatedAtDesc(chatId)
+                    .ifPresent(handoff -> {
+                        handoff.setStatus(HandoffStatus.ADMIN_ANSWERED);
+                        chatHandoffRepository.save(handoff);
+                    });
+        }
+
+        return DirectChatMessageResponse.builder()
+                .messageId(message.getMessageId())
+                .chatId(message.getChatId())
+                .sender(resolveSender(message.getType()))
+                .content(message.getContent())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+
+    private MessageType resolveMessageType(String sender) {
+        if (sender == null) {
+            return MessageType.USER;
+        }
+        if ("SYSTEM".equalsIgnoreCase(sender)) {
+            return MessageType.SYSTEM;
+        }
+        if ("USER".equalsIgnoreCase(sender)) {
+            return MessageType.USER;
+        }
+        return MessageType.ASSISTANT;
+    }
+
+    private String resolveSender(MessageType type) {
+        if (type == null) {
+            return "SYSTEM";
+        }
+        return switch (type) {
+            case USER -> "USER";
+            case SYSTEM -> "SYSTEM";
+            default -> "ADMIN";
+        };
+    }
+
+    private String resolveLoginId(Long memberId) {
+        if (memberId == null) {
+            return null;
+        }
+        Member member = memberRepository.findById(memberId).orElse(null);
+        if (member != null) {
+            return member.getLoginId();
+        }
+        Seller seller = sellerRepository.findById(memberId).orElse(null);
+        return seller != null ? seller.getLoginId() : null;
+    }
+}

--- a/src/main/resources/sql/livecommerce_create_table.sql
+++ b/src/main/resources/sql/livecommerce_create_table.sql
@@ -1,7 +1,8 @@
 -- =========================================================
 -- DESKIT & LIVE COMMERCE INTEGRATED DB SCHEMA
--- 최근작성일: 2026-01-05
+-- 최근작성일: 2026-01-06
 -- 수정사항:
+-- chat_info, chat_handoff 테이블 updated_at 컬럼 추가 (26.01.06)
 -- broadcast_result, view_history 테이블 컬럼 수정 (26.01.05)
 -- seller_grade 테이블 컬럼(grade) 수정 : enum 요소 추가 (26.01.04)
 -- spring_ai_chat_memory 테이블 추가 (25.12.31)
@@ -542,6 +543,7 @@ CREATE TABLE chat_info (
     chat_id       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     `status`      ENUM('BOT_ACTIVE', 'ADMIN_ACTIVE', 'ESCALATED', 'CLOSED') NOT NULL DEFAULT 'BOT_ACTIVE',
     created_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     member_id     BIGINT UNSIGNED NOT NULL COMMENT 'FK: member',
     PRIMARY KEY (chat_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='CS 채팅방';
@@ -560,6 +562,7 @@ CREATE TABLE chat_handoff (
     assigned_admin_id BIGINT UNSIGNED NULL COMMENT 'FK: admin',
     `status`      ENUM('ADMIN_WAITING', 'ADMIN_CHECKED', 'ADMIN_ANSWERED') NOT NULL DEFAULT 'ADMIN_WAITING',
     created_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     chat_id       BIGINT UNSIGNED NOT NULL COMMENT 'FK: chat_info',
     PRIMARY KEY (handoff_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='상담원 연결 요청';


### PR DESCRIPTION
## 📌 관련 이슈

- closes #63 

## 📝 작업 내용

- 이관된 문의에 대해 관리자와 사용자 간 1:1 채팅을 구현했습니다.
- 관리자 - 문의 내역에 이관된 문의사항 채팅이 보여지도록 구현했습니다.


## 🧐 리뷰 포인트

- 사용자로 챗봇 채팅 시작 -> 관리자 이관 -> 관리자로 채팅 확인 -> 1:1 채팅 시작 -> 관리자가 상담 종료(CLOSED)

## ✅ 비고

- 정보 표시와 같은 자잘한 문제 및 세션 유지 관련 문제 발생 가능성 있어 품질 개선 작업 예정입니다.

