### PR TITLE
feat: 회원가입 완료 페이지 구현 및 회원가입 즉시 로그인 방지

### DIFF
--- a/front/src/router/index.ts
+++ b/front/src/router/index.ts
@@ -68,6 +68,11 @@ const routes: RouteRecordRaw[] = [
     component: () => import('../pages/Signup.vue'),
   },
   {
+    path: '/signup/complete',
+    name: 'register-complete',
+    component: () => import('../pages/RegisterComplete.vue'),
+  },
+  {
     path: '/chat',
     name: 'chatbot',
     component: () => import('../pages/Chatbot.vue'),

--- a/src/main/java/com/deskit/deskit/account/controller/SignupController.java
+++ b/src/main/java/com/deskit/deskit/account/controller/SignupController.java
@@ -3,7 +3,6 @@ package com.deskit.deskit.account.controller;
 import com.deskit.deskit.account.dto.SocialSignupRequest;
 import com.deskit.deskit.account.entity.*;
 import com.deskit.deskit.account.enums.*;
-import com.deskit.deskit.account.jwt.JWTUtil;
 import com.deskit.deskit.account.oauth.CustomOAuth2User;
 import com.deskit.deskit.account.repository.*;
 import com.deskit.deskit.common.util.verification.PhoneSendRequest;
@@ -41,8 +40,6 @@ public class SignupController {
     private static final String SESSION_PHONE_VERIFIED = "pendingPhoneVerified";
 
     private final MemberRepository memberRepository;
-    private final JWTUtil jwtUtil;
-    private final RefreshRepository refreshRepository;
     private final SellerRepository sellerRepository;
     private final CompanyRegisteredRepository companyRegisteredRepository;
     private final SellerRegisterRepository sellerRegisterRepository;
@@ -171,10 +168,6 @@ public class SignupController {
             return new ResponseEntity<>("already signed up", HttpStatus.CONFLICT);
         }
 
-        if (!request.isAgreed()) {
-            return new ResponseEntity<>("terms agreement required", HttpStatus.BAD_REQUEST);
-        }
-
         Boolean verified = (Boolean) session.getAttribute(SESSION_PHONE_VERIFIED);
         if (verified == null || !verified) {
             return new ResponseEntity<>("phone verification required", HttpStatus.BAD_REQUEST);
@@ -231,8 +224,7 @@ public class SignupController {
 
         memberRepository.save(member);
 
-        // 가입 성공 후 토큰 발행
-        issueTokens(member.getLoginId(), member.getRole(), response);
+        clearAuthCookies(response);
 
         // 폰 인증 세션 삭제
         clearPhoneSession(session);
@@ -344,8 +336,7 @@ public class SignupController {
 
         sellerGradeRepository.save(sellerGrade);
 
-        // 가입 완료 후 토큰 발행
-        issueTokens(seller.getLoginId(), String.valueOf(seller.getRole()), response);
+        clearAuthCookies(response);
 
         // 폰 인증 세션 삭제
         clearPhoneSession(session);
@@ -443,40 +434,24 @@ public class SignupController {
         invitation.setUpdatedAt(now);
         invitationRepository.save(invitation);
 
-        issueTokens(seller.getLoginId(), String.valueOf(seller.getRole()), response);
+        clearAuthCookies(response);
 
         clearPhoneSession(session);
 
         return new ResponseEntity<>("invited seller signup completed", HttpStatus.OK);
     }
 
-    // access/refresh token 발행
-    private void issueTokens(String username, String role, HttpServletResponse response) {
-        long accessExpiryMs = 600000L;
-
-        long refreshExpiryMs = 86400000L;
-
-        // 토큰 생성
-        String access = jwtUtil.createJwt("access", username, role, accessExpiryMs); // Access token for header.
-        String refresh = jwtUtil.createJwt("refresh", username, role, refreshExpiryMs); // Refresh token for cookie.
-
-        refreshRepository.save(username, refresh, refreshExpiryMs);
-
-        response.setHeader("access", access);
-        response.addCookie(createCookie("access", access, Math.toIntExact(accessExpiryMs / 1000)));
-        response.addCookie(createCookie("refresh", refresh, Math.toIntExact(refreshExpiryMs / 1000)));
+    private void clearAuthCookies(HttpServletResponse response) {
+        response.addCookie(expireCookie("access"));
+        response.addCookie(expireCookie("refresh"));
     }
 
-    // HttpOnly로 안전한 쿠키 생성
-    private Cookie createCookie(String key, String value, int maxAge) {
-        // refresh token 쿠키
-        Cookie cookie = new Cookie(key, value);
-
-        cookie.setMaxAge(maxAge);
+    private Cookie expireCookie(String key) {
+        Cookie cookie = new Cookie(key, "");
+        cookie.setMaxAge(0);
         // cookie.setSecure(true);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
-
         return cookie;
     }
 

--- a/src/main/java/com/deskit/deskit/account/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/deskit/deskit/account/service/CustomOAuth2UserService.java
@@ -127,6 +127,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         // Seller에 존재할 경우 -> Seller 로그인
         else {
+            if (existSeller.getStatus() == SellerStatus.PENDING) {
+                throw new OAuth2AuthenticationException(
+                        new OAuth2Error("seller_pending", "관리자 승인 후에 서비스 이용 가능합니다.", null)
+                );
+            }
             if (existSeller.getStatus() == SellerStatus.INACTIVE) {
                 ensureRejoinAllowed(existSeller.getUpdatedAt());
                 existSeller.setStatus(SellerStatus.ACTIVE);


### PR DESCRIPTION
## 📌 관련 이슈

- closes #87 

## 📝 작업 내용

- 회원가입 완료 페이지를 별도로 구현하였습니다. 
사유는 회원가입 완료를 UI상으로 더 직관적으로 확인하기 위함입니다.
- 완료 페이지를 별도로 구현하면서 회원가입 즉시 로그인 처리가 되는 문제 해결도 진행하였습니다.
- PENDING 상태인 판매자는 로그인시 관리자 승인 후 사용 가능하다는 안내 메시지를 출력하고 로그인 불가 처리하였습니다.

## 🧐 리뷰 포인트

- 일반회원 및 판매자 회원가입 및 로그인
