### PR TITLE
[FEAT] 주문 API 구현 및 권한 정책 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	testRuntimeOnly 'com.h2database:h2'
 
 	// Redis
 	implementation "org.springframework.ai:spring-ai-starter-vector-store-redis"

--- a/src/main/java/com/deskit/deskit/order/controller/OrderController.java
+++ b/src/main/java/com/deskit/deskit/order/controller/OrderController.java
@@ -1,0 +1,131 @@
+package com.deskit.deskit.order.controller;
+
+import com.deskit.deskit.account.entity.Member;
+import com.deskit.deskit.account.oauth.CustomOAuth2User;
+import com.deskit.deskit.account.repository.MemberRepository;
+import com.deskit.deskit.order.dto.CreateOrderRequest;
+import com.deskit.deskit.order.dto.CreateOrderResponse;
+import com.deskit.deskit.order.dto.OrderDetailResponse;
+import com.deskit.deskit.order.dto.OrderStatusUpdateRequest;
+import com.deskit.deskit.order.dto.OrderStatusUpdateResponse;
+import com.deskit.deskit.order.dto.OrderSummaryResponse;
+import com.deskit.deskit.order.service.OrderService;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+  private final OrderService orderService;
+  private final MemberRepository memberRepository;
+
+  public OrderController(OrderService orderService, MemberRepository memberRepository) {
+    this.orderService = orderService;
+    this.memberRepository = memberRepository;
+  }
+
+  @PostMapping
+  public ResponseEntity<CreateOrderResponse> createOrder(
+          @AuthenticationPrincipal CustomOAuth2User user,
+          @Valid @RequestBody CreateOrderRequest request
+  ) {
+    Long memberId = resolveMemberId(user);
+    return ResponseEntity.ok(orderService.createOrder(memberId, request));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<OrderSummaryResponse>> getMyOrders(
+          @AuthenticationPrincipal CustomOAuth2User user
+  ) {
+    Long memberId = resolveMemberId(user);
+    return ResponseEntity.ok(orderService.getMyOrders(memberId));
+  }
+
+  @GetMapping("/{orderId}")
+  public ResponseEntity<OrderDetailResponse> getMyOrderDetail(
+          @AuthenticationPrincipal CustomOAuth2User user,
+          @PathVariable("orderId") Long orderId
+  ) {
+    Long memberId = resolveMemberId(user);
+    return ResponseEntity.ok(orderService.getMyOrderDetail(memberId, orderId));
+  }
+
+  @PatchMapping("/{orderId}/status")
+  public ResponseEntity<OrderStatusUpdateResponse> updateOrderStatus(
+          @AuthenticationPrincipal CustomOAuth2User user,
+          @PathVariable("orderId") Long orderId,
+          @Valid @RequestBody OrderStatusUpdateRequest request
+  ) {
+    Long memberId = resolveMemberId(user);
+    return ResponseEntity.ok(orderService.updateOrderStatus(memberId, orderId, request));
+  }
+
+  private Long resolveMemberId(CustomOAuth2User user) {
+    if (user == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized");
+    }
+
+    Long memberId = tryExtractMemberId(user);
+    if (memberId != null) {
+      return memberId;
+    }
+
+    String loginId = user.getUsername();
+    if (loginId == null || loginId.isBlank()) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found");
+    }
+
+    Member member = memberRepository.findByLoginId(loginId);
+    if (member == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found");
+    }
+
+    return member.getMemberId();
+  }
+
+  private Long tryExtractMemberId(CustomOAuth2User user) {
+    Map<String, Object> attributes = user.getAttributes();
+    if (attributes == null || attributes.isEmpty()) {
+      return null;
+    }
+
+    Object value = attributes.get("memberId");
+    if (value == null) {
+      value = attributes.get("member_id");
+    }
+    if (value == null) {
+      value = attributes.get("id");
+    }
+
+    if (value instanceof Number) {
+      return ((Number) value).longValue();
+    }
+
+    if (value instanceof String) {
+      String text = ((String) value).trim();
+      if (text.isEmpty()) {
+        return null;
+      }
+      try {
+        return Long.parseLong(text);
+      } catch (NumberFormatException ex) {
+        return null;
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/deskit/deskit/order/controller/package-info.java
+++ b/src/main/java/com/deskit/deskit/order/controller/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.order.controller;

--- a/src/main/java/com/deskit/deskit/order/dto/CreateOrderItemRequest.java
+++ b/src/main/java/com/deskit/deskit/order/dto/CreateOrderItemRequest.java
@@ -1,0 +1,16 @@
+package com.deskit.deskit.order.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CreateOrderItemRequest(
+  @JsonProperty("product_id")
+  @NotNull
+  Long productId,
+
+  @JsonProperty("quantity")
+  @NotNull
+  @Positive
+  Integer quantity
+) {}

--- a/src/main/java/com/deskit/deskit/order/dto/CreateOrderRequest.java
+++ b/src/main/java/com/deskit/deskit/order/dto/CreateOrderRequest.java
@@ -1,0 +1,13 @@
+package com.deskit.deskit.order.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record CreateOrderRequest(
+  @JsonProperty("items")
+  @NotNull
+  @Size(min = 1)
+  List<CreateOrderItemRequest> items
+) {}

--- a/src/main/java/com/deskit/deskit/order/dto/CreateOrderResponse.java
+++ b/src/main/java/com/deskit/deskit/order/dto/CreateOrderResponse.java
@@ -1,0 +1,18 @@
+package com.deskit.deskit.order.dto;
+
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CreateOrderResponse(
+  @JsonProperty("order_id")
+  Long orderId,
+
+  @JsonProperty("order_number")
+  String orderNumber,
+
+  @JsonProperty("status")
+  OrderStatus status,
+
+  @JsonProperty("order_amount")
+  Integer orderAmount
+) {}

--- a/src/main/java/com/deskit/deskit/order/dto/OrderDetailResponse.java
+++ b/src/main/java/com/deskit/deskit/order/dto/OrderDetailResponse.java
@@ -1,0 +1,41 @@
+package com.deskit.deskit.order.dto;
+
+import com.deskit.deskit.order.entity.Order;
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderDetailResponse(
+  @JsonProperty("order_id")
+  Long orderId,
+
+  @JsonProperty("order_number")
+  String orderNumber,
+
+  @JsonProperty("status")
+  OrderStatus status,
+
+  @JsonProperty("order_amount")
+  Integer orderAmount,
+
+  @JsonProperty("created_at")
+  LocalDateTime createdAt,
+
+  @JsonProperty("items")
+  List<OrderItemResponse> items
+) {
+  public static OrderDetailResponse from(Order order, List<OrderItemResponse> items) {
+    if (order == null) {
+      return new OrderDetailResponse(null, null, null, null, null, items);
+    }
+    return new OrderDetailResponse(
+      order.getId(),
+      order.getOrderNumber(),
+      order.getStatus(),
+      order.getOrderAmount(),
+      order.getCreatedAt(),
+      items
+    );
+  }
+}

--- a/src/main/java/com/deskit/deskit/order/dto/OrderItemResponse.java
+++ b/src/main/java/com/deskit/deskit/order/dto/OrderItemResponse.java
@@ -1,0 +1,30 @@
+package com.deskit.deskit.order.dto;
+
+import com.deskit.deskit.order.entity.OrderItem;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OrderItemResponse(
+  @JsonProperty("product_id")
+  Long productId,
+
+  @JsonProperty("quantity")
+  Integer quantity,
+
+  @JsonProperty("unit_price")
+  Integer unitPrice,
+
+  @JsonProperty("subtotal_price")
+  Integer subtotalPrice
+) {
+  public static OrderItemResponse from(OrderItem item) {
+    if (item == null) {
+      return new OrderItemResponse(null, null, null, null);
+    }
+    return new OrderItemResponse(
+      item.getProductId(),
+      item.getQuantity(),
+      item.getUnitPrice(),
+      item.getSubtotalPrice()
+    );
+  }
+}

--- a/src/main/java/com/deskit/deskit/order/dto/OrderStatusUpdateRequest.java
+++ b/src/main/java/com/deskit/deskit/order/dto/OrderStatusUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.deskit.deskit.order.dto;
+
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+public record OrderStatusUpdateRequest(
+  @JsonProperty("status")
+  @NotNull
+  OrderStatus status
+) {}

--- a/src/main/java/com/deskit/deskit/order/dto/OrderStatusUpdateResponse.java
+++ b/src/main/java/com/deskit/deskit/order/dto/OrderStatusUpdateResponse.java
@@ -1,0 +1,12 @@
+package com.deskit.deskit.order.dto;
+
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OrderStatusUpdateResponse(
+  @JsonProperty("order_id")
+  Long orderId,
+
+  @JsonProperty("status")
+  OrderStatus status
+) {}

--- a/src/main/java/com/deskit/deskit/order/dto/OrderSummaryResponse.java
+++ b/src/main/java/com/deskit/deskit/order/dto/OrderSummaryResponse.java
@@ -1,0 +1,36 @@
+package com.deskit.deskit.order.dto;
+
+import com.deskit.deskit.order.entity.Order;
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+
+public record OrderSummaryResponse(
+  @JsonProperty("order_id")
+  Long orderId,
+
+  @JsonProperty("order_number")
+  String orderNumber,
+
+  @JsonProperty("status")
+  OrderStatus status,
+
+  @JsonProperty("order_amount")
+  Integer orderAmount,
+
+  @JsonProperty("created_at")
+  LocalDateTime createdAt
+) {
+  public static OrderSummaryResponse from(Order order) {
+    if (order == null) {
+      return new OrderSummaryResponse(null, null, null, null, null);
+    }
+    return new OrderSummaryResponse(
+      order.getId(),
+      order.getOrderNumber(),
+      order.getStatus(),
+      order.getOrderAmount(),
+      order.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/deskit/deskit/order/dto/package-info.java
+++ b/src/main/java/com/deskit/deskit/order/dto/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.order.dto;

--- a/src/main/java/com/deskit/deskit/order/entity/Order.java
+++ b/src/main/java/com/deskit/deskit/order/entity/Order.java
@@ -138,4 +138,8 @@ public class Order extends BaseEntity {
     order.status = status;
     return order;
   }
+
+  public void changeStatus(OrderStatus status) {
+    this.status = status;
+  }
 }

--- a/src/main/java/com/deskit/deskit/order/service/OrderService.java
+++ b/src/main/java/com/deskit/deskit/order/service/OrderService.java
@@ -1,0 +1,227 @@
+package com.deskit.deskit.order.service;
+
+import com.deskit.deskit.account.repository.MemberRepository;
+import com.deskit.deskit.order.dto.CreateOrderItemRequest;
+import com.deskit.deskit.order.dto.CreateOrderRequest;
+import com.deskit.deskit.order.dto.CreateOrderResponse;
+import com.deskit.deskit.order.dto.OrderDetailResponse;
+import com.deskit.deskit.order.dto.OrderItemResponse;
+import com.deskit.deskit.order.dto.OrderStatusUpdateRequest;
+import com.deskit.deskit.order.dto.OrderStatusUpdateResponse;
+import com.deskit.deskit.order.dto.OrderSummaryResponse;
+import com.deskit.deskit.order.entity.Order;
+import com.deskit.deskit.order.entity.OrderItem;
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.deskit.deskit.order.repository.OrderItemRepository;
+import com.deskit.deskit.order.repository.OrderRepository;
+import com.deskit.deskit.product.entity.Product;
+import com.deskit.deskit.product.repository.ProductRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@Transactional
+public class OrderService {
+
+  private final OrderRepository orderRepository;
+  private final OrderItemRepository orderItemRepository;
+  private final ProductRepository productRepository;
+  private final MemberRepository memberRepository;
+
+  public OrderService(OrderRepository orderRepository,
+                      OrderItemRepository orderItemRepository,
+                      ProductRepository productRepository,
+                      MemberRepository memberRepository) {
+    this.orderRepository = orderRepository;
+    this.orderItemRepository = orderItemRepository;
+    this.productRepository = productRepository;
+    this.memberRepository = memberRepository;
+  }
+
+  public CreateOrderResponse createOrder(Long memberId, CreateOrderRequest request) {
+    if (memberId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "member_id required");
+    }
+    if (!memberRepository.existsById(memberId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found");
+    }
+    if (request == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "request required");
+    }
+
+    List<CreateOrderItemRequest> items = request.items();
+    if (items == null || items.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "items required");
+    }
+
+    Map<Long, Integer> quantityByProductId = new HashMap<>();
+    for (CreateOrderItemRequest item : items) {
+      if (item == null) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "item required");
+      }
+      Long productId = item.productId();
+      if (productId == null) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "product_id required");
+      }
+      int quantity = safeQuantity(item.quantity());
+      quantityByProductId.merge(productId, quantity, Integer::sum);
+    }
+
+    List<Long> productIds = new ArrayList<>(quantityByProductId.keySet());
+    Collections.sort(productIds);
+
+    Map<Long, Product> productsById = new HashMap<>();
+    for (Long productId : productIds) {
+      Product product = productRepository.findByIdForUpdate(productId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "product not found"));
+      int requestedQty = quantityByProductId.get(productId);
+      Integer stockQty = product.getStockQty();
+      int currentStock = stockQty == null ? 0 : stockQty;
+      if (currentStock < requestedQty) {
+        throw new ResponseStatusException(HttpStatus.CONFLICT, "insufficient stock: product_id=" + productId);
+      }
+      product.decreaseStock(requestedQty);
+      productsById.put(productId, product);
+    }
+
+    int totalProductAmount = 0;
+    for (CreateOrderItemRequest item : items) {
+      int quantity = safeQuantity(item.quantity());
+      Product product = productsById.get(item.productId());
+      totalProductAmount += product.getPrice() * quantity;
+    }
+
+    int shippingFee = 0;
+    int discountFee = 0;
+    int orderAmount = totalProductAmount - discountFee + shippingFee;
+    String orderNumber = generateOrderNumber();
+
+    Order order = Order.create(
+      memberId,
+      orderNumber,
+      totalProductAmount,
+      shippingFee,
+      discountFee,
+      orderAmount,
+      OrderStatus.CREATED
+    );
+    Order savedOrder = orderRepository.save(order);
+
+    for (CreateOrderItemRequest item : items) {
+      int quantity = safeQuantity(item.quantity());
+      Product product = productsById.get(item.productId());
+      int unitPrice = product.getPrice();
+      int subtotal = unitPrice * quantity;
+      OrderItem orderItem = OrderItem.create(
+        savedOrder,
+        product.getId(),
+        product.getSellerId(),
+        product.getProductName(),
+        unitPrice,
+        quantity,
+        subtotal
+      );
+      orderItemRepository.save(orderItem);
+    }
+
+    return new CreateOrderResponse(
+      savedOrder.getId(),
+      savedOrder.getOrderNumber(),
+      savedOrder.getStatus(),
+      savedOrder.getOrderAmount()
+    );
+  }
+
+  @Transactional(readOnly = true)
+  public List<OrderSummaryResponse> getMyOrders(Long memberId) {
+    if (memberId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "member_id required");
+    }
+    if (!memberRepository.existsById(memberId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found");
+    }
+
+    return orderRepository.findByMemberIdOrderByCreatedAtDesc(memberId)
+      .stream()
+      .map(OrderSummaryResponse::from)
+      .collect(Collectors.toList());
+  }
+
+  @Transactional(readOnly = true)
+  public OrderDetailResponse getMyOrderDetail(Long memberId, Long orderId) {
+    if (memberId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "member_id required");
+    }
+    if (!memberRepository.existsById(memberId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found");
+    }
+    if (orderId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "order_id required");
+    }
+
+    Order order = orderRepository.findById(orderId)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "order not found"));
+    if (!order.getMemberId().equals(memberId)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+    }
+
+    List<OrderItemResponse> items = orderItemRepository.findByOrder_Id(orderId)
+      .stream()
+      .map(OrderItemResponse::from)
+      .collect(Collectors.toList());
+
+    return OrderDetailResponse.from(order, items);
+  }
+
+  public OrderStatusUpdateResponse updateOrderStatus(Long memberId, Long orderId, OrderStatusUpdateRequest request) {
+    if (memberId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "member_id required");
+    }
+    if (!memberRepository.existsById(memberId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found");
+    }
+    if (orderId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "order_id required");
+    }
+    if (request == null || request.status() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status required");
+    }
+
+    Order order = orderRepository.findById(orderId)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "order not found"));
+    if (!order.getMemberId().equals(memberId)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+    }
+
+    OrderStatus newStatus = request.status();
+    if (newStatus == order.getStatus()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status unchanged");
+    }
+
+    order.changeStatus(newStatus);
+    orderRepository.save(order);
+    return new OrderStatusUpdateResponse(order.getId(), order.getStatus());
+  }
+
+  private int safeQuantity(Integer quantity) {
+    if (quantity == null || quantity < 1) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "quantity must be >= 1");
+    }
+    return quantity;
+  }
+
+  private String generateOrderNumber() {
+    long now = System.currentTimeMillis();
+    int suffix = ThreadLocalRandom.current().nextInt(1000, 10000);
+    return "ORD-" + now + "-" + suffix;
+  }
+}

--- a/src/main/java/com/deskit/deskit/order/service/package-info.java
+++ b/src/main/java/com/deskit/deskit/order/service/package-info.java
@@ -1,1 +1,0 @@
-package com.deskit.deskit.order.service;

--- a/src/main/java/com/deskit/deskit/product/entity/Product.java
+++ b/src/main/java/com/deskit/deskit/product/entity/Product.java
@@ -78,4 +78,17 @@ public class Product extends BaseEntity {
     this.stockQty = stockQty;
     this.safetyStock = safetyStock;
   }
+
+  public void decreaseStock(int quantity) {
+    if (quantity <= 0) {
+      throw new IllegalArgumentException("quantity must be > 0");
+    }
+    if (this.stockQty == null) {
+      this.stockQty = 0;
+    }
+    if (this.stockQty < quantity) {
+      throw new IllegalStateException("insufficient stock");
+    }
+    this.stockQty -= quantity;
+  }
 }

--- a/src/main/java/com/deskit/deskit/product/repository/ProductRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductRepository.java
@@ -3,7 +3,9 @@ package com.deskit.deskit.product.repository;
 import com.deskit.deskit.product.entity.Product;
 import java.util.List;
 import java.util.Optional;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -31,6 +33,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
    * 예: id는 존재하지만 deleted_at이 채워져 있으면(논리삭제) -> Optional.empty()
    */
   Optional<Product> findByIdAndDeletedAtIsNull(Long id);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select p from Product p where p.id = :id and p.deletedAt is null")
+  Optional<Product> findByIdForUpdate(@Param("id") Long id);
 
   @Query(value = """
       SELECT

--- a/src/main/resources/sql/livecommerce_create_table.sql
+++ b/src/main/resources/sql/livecommerce_create_table.sql
@@ -10,6 +10,10 @@
 -- 사용자 커스텀 반영 및 toss_payment 테이블 에러(VARCHAR AUTO_INCREMENT) 수정 (25.12.25)
 -- =========================================================
 
+DROP DATABASE livecommerce;
+CREATE DATABASE livecommerce;
+USE livecommerce;
+
 SET FOREIGN_KEY_CHECKS = 0;
 
 -- =========================================================

--- a/src/main/resources/sql/seed-products-setups.sql
+++ b/src/main/resources/sql/seed-products-setups.sql
@@ -1,3 +1,12 @@
+INSERT INTO admin(login_id, phone, name, role)
+VALUES ('dyniiyeyo@naver.com', '010-4255-1027', '김도윤', 'ROLE_ADMIN');
+INSERT INTO admin(login_id, phone, name, role)
+VALUES ('hawon2k2k@naver.com', '010-2775-9804', '고하원', 'ROLE_ADMIN');
+INSERT INTO admin(login_id, phone, name, role)
+VALUES ('00parkyh@naver.com', '010-8318-8176', '박용헌', 'ROLE_ADMIN');
+INSERT INTO admin(login_id, phone, name, role)
+VALUES ('jwscape@naver.com', '010-9258-2658', '주장우', 'ROLE_ADMIN');
+
 -- 상품/셋업 더미 데이터 (한국어 버전)
 -- 실행 방법 (MySQL):
 --   SOURCE src/main/resources/sql/livecommerce_create_table.sql;
@@ -91,3 +100,7 @@ FROM setup_product sp
          JOIN product p ON p.product_id = sp.product_id
 ORDER BY sp.setup_id, sp.product_id
 LIMIT 10;
+
+SELECT * FROM seller WHERE seller_id = 3;
+
+UPDATE seller SET status = 'ACTIVE' WHERE seller_id=3;

--- a/src/test/java/com/deskit/deskit/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/deskit/deskit/order/repository/OrderRepositoryTest.java
@@ -67,18 +67,18 @@ class OrderRepositoryTest {
 
     entityManager.getEntityManager().createNativeQuery(
       "INSERT INTO product (product_id, seller_id, product_name, short_desc, detail_html, " +
-      "price, cost_price, status, stock_qty, safety_stock) " +
+      "price, cost_price, status, stock_qty, safety_stock, created_at, updated_at) " +
       "VALUES (:productId, :sellerId, 'Test Product A', 'Short A', '<p>Detail A</p>', " +
-      "10000, 12000, 'ON_SALE', 10, 5)"
+      "10000, 12000, 'ON_SALE', 10, 5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     ).setParameter("productId", 10L)
       .setParameter("sellerId", sellerId)
       .executeUpdate();
 
     entityManager.getEntityManager().createNativeQuery(
       "INSERT INTO product (product_id, seller_id, product_name, short_desc, detail_html, " +
-      "price, cost_price, status, stock_qty, safety_stock) " +
+      "price, cost_price, status, stock_qty, safety_stock, created_at, updated_at) " +
       "VALUES (:productId, :sellerId, 'Test Product B', 'Short B', '<p>Detail B</p>', " +
-      "10000, 12000, 'ON_SALE', 10, 5)"
+      "10000, 12000, 'ON_SALE', 10, 5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
     ).setParameter("productId", 11L)
       .setParameter("sellerId", sellerId)
       .executeUpdate();

--- a/src/test/java/com/deskit/deskit/order/service/OrderServiceTest.java
+++ b/src/test/java/com/deskit/deskit/order/service/OrderServiceTest.java
@@ -1,0 +1,164 @@
+package com.deskit.deskit.order.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.deskit.deskit.account.entity.Member;
+import com.deskit.deskit.account.entity.Seller;
+import com.deskit.deskit.account.enums.JobCategory;
+import com.deskit.deskit.account.enums.MBTI;
+import com.deskit.deskit.account.enums.MemberStatus;
+import com.deskit.deskit.account.enums.SellerRole;
+import com.deskit.deskit.account.enums.SellerStatus;
+import com.deskit.deskit.order.dto.CreateOrderItemRequest;
+import com.deskit.deskit.order.dto.CreateOrderRequest;
+import com.deskit.deskit.order.dto.CreateOrderResponse;
+import com.deskit.deskit.order.entity.Order;
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.deskit.deskit.order.repository.OrderItemRepository;
+import com.deskit.deskit.order.repository.OrderRepository;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(OrderService.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class OrderServiceTest {
+
+  @Autowired
+  private OrderService orderService;
+
+  @Autowired
+  private OrderRepository orderRepository;
+
+  @Autowired
+  private OrderItemRepository orderItemRepository;
+
+  @Autowired
+  private TestEntityManager entityManager;
+
+  @Test
+  void createOrderPersistsOrderAndItems() {
+    Member member = persistMember();
+    Seller seller = persistSeller();
+    insertProduct(10L, seller.getSellerId(), "Test Product A", 10);
+    insertProduct(11L, seller.getSellerId(), "Test Product B", 10);
+
+    CreateOrderRequest request = new CreateOrderRequest(List.of(
+      new CreateOrderItemRequest(10L, 2),
+      new CreateOrderItemRequest(11L, 1)
+    ));
+
+    CreateOrderResponse response = orderService.createOrder(member.getMemberId(), request);
+    assertNotNull(response.orderId());
+    assertEquals(OrderStatus.CREATED, response.status());
+
+    Order order = orderRepository.findById(response.orderId()).orElse(null);
+    assertNotNull(order);
+    assertEquals(2, orderItemRepository.findByOrder_Id(response.orderId()).size());
+
+    int stockA = ((Number) entityManager.getEntityManager()
+      .createNativeQuery("SELECT stock_qty FROM product WHERE product_id = :productId")
+      .setParameter("productId", 10L)
+      .getSingleResult()).intValue();
+    int stockB = ((Number) entityManager.getEntityManager()
+      .createNativeQuery("SELECT stock_qty FROM product WHERE product_id = :productId")
+      .setParameter("productId", 11L)
+      .getSingleResult()).intValue();
+    assertEquals(8, stockA);
+    assertEquals(9, stockB);
+  }
+
+  @Test
+  void createOrderRejectsInvalidQuantity() {
+    Member member = persistMember();
+    Seller seller = persistSeller();
+    insertProduct(20L, seller.getSellerId(), "Test Product C", 10);
+
+    CreateOrderRequest request = new CreateOrderRequest(List.of(
+      new CreateOrderItemRequest(20L, 0)
+    ));
+
+    ResponseStatusException ex = assertThrows(
+      ResponseStatusException.class,
+      () -> orderService.createOrder(member.getMemberId(), request)
+    );
+    assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+  }
+
+  @Test
+  void createOrderRejectsInsufficientStock() {
+    Member member = persistMember();
+    Seller seller = persistSeller();
+    insertProduct(30L, seller.getSellerId(), "Test Product D", 1);
+
+    CreateOrderRequest request = new CreateOrderRequest(List.of(
+      new CreateOrderItemRequest(30L, 2)
+    ));
+
+    ResponseStatusException ex = assertThrows(
+      ResponseStatusException.class,
+      () -> orderService.createOrder(member.getMemberId(), request)
+    );
+    assertEquals(HttpStatus.CONFLICT, ex.getStatusCode());
+
+    int stock = ((Number) entityManager.getEntityManager()
+      .createNativeQuery("SELECT stock_qty FROM product WHERE product_id = :productId")
+      .setParameter("productId", 30L)
+      .getSingleResult()).intValue();
+    assertEquals(1, stock);
+  }
+
+  private Member persistMember() {
+    Member member = Member.builder()
+      .name("Test Member")
+      .loginId("member@test.com")
+      .phone("010-0000-0000")
+      .isAgreed(true)
+      .status(MemberStatus.ACTIVE)
+      .role("ROLE_MEMBER")
+      .mbti(MBTI.NONE)
+      .jobCategory(JobCategory.NONE)
+      .build();
+    entityManager.persist(member);
+    entityManager.flush();
+    return member;
+  }
+
+  private Seller persistSeller() {
+    Seller seller = Seller.builder()
+      .status(SellerStatus.ACTIVE)
+      .name("Test Seller")
+      .loginId("seller@test.com")
+      .phone("010-1000-1000")
+      .role(SellerRole.ROLE_SELLER_OWNER)
+      .isAgreed(true)
+      .build();
+    entityManager.persist(seller);
+    entityManager.flush();
+    return seller;
+  }
+
+  private void insertProduct(Long productId, Long sellerId, String productName, int stockQty) {
+    entityManager.getEntityManager().createNativeQuery(
+      "INSERT INTO product (product_id, seller_id, product_name, short_desc, detail_html, " +
+      "price, cost_price, status, stock_qty, safety_stock, created_at, updated_at) " +
+      "VALUES (:productId, :sellerId, :productName, 'Short', '<p>Detail</p>', " +
+      "10000, 12000, 'ON_SALE', :stockQty, 5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+    ).setParameter("productId", productId)
+      .setParameter("sellerId", sellerId)
+      .setParameter("productName", productName)
+      .setParameter("stockQty", stockQty)
+      .executeUpdate();
+  }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,6 +1,8 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/livecommerce_test?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.username=YOUR_USERNAME
-spring.datasource.password=YOUR_PASSWORD
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:h2:mem:livecommerce_test;MODE=MySQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.properties.hibernate.globally_quoted_identifiers=true
+spring.jpa.properties.hibernate.globally_quoted_identifiers_skip_column_definitions=true


### PR DESCRIPTION
## 📌 관련 이슈
- closes #66 

## 📝 작업 내용
- 주문 생성/조회/상태변경 API 구현 (POST /api/orders, GET /api/orders, GET /api/orders/{orderId}, PATCH /api/orders/{orderId}/status)
- 주문 생성 DTO/Validation 적용 (items 필수, quantity 양수 등)
- 인증/권한 정책 적용: 내 주문만 조회 가능하도록 소유권 검증
- 401/403 처리 기준 정리 및 예외 응답 일관화(최소 1차)

## 📸 스크린샷 
<img width="1840" height="1119" alt="스크린샷 2026-01-08 12 29 16" src="https://github.com/user-attachments/assets/8269dfd6-4d6a-4a85-92ce-d85855cd5dff" />
<img width="1840" height="1119" alt="스크린샷 2026-01-08 12 29 17" src="https://github.com/user-attachments/assets/bee8c5ce-e821-4e92-8289-26b0739a83a1" />
<img width="1840" height="1119" alt="스크린샷 2026-01-08 12 29 19" src="https://github.com/user-attachments/assets/24f2892a-f8ed-47ae-8a00-1429c7978376" />
<img width="1840" height="1119" alt="스크린샷 2026-01-08 12 29 22" src="https://github.com/user-attachments/assets/ccbe6137-105c-4185-8c3f-c92b5f30c353" />
