### PR TITLE
bug: 관리자 승인 이메일 템플릿 경로를 수정한다

### DIFF
--- a/src/main/java/com/deskit/deskit/account/jwt/JWTFilter.java
+++ b/src/main/java/com/deskit/deskit/account/jwt/JWTFilter.java
@@ -65,6 +65,7 @@ public class JWTFilter extends OncePerRequestFilter {
         //토큰에서 username과 role 획득
         String username = jwtUtil.getUsername(accessToken);
         String role = jwtUtil.getRole(accessToken);
+        log.info("username {} role {}", username, role);
 
         //userDTO를 생성하여 값 set
         UserDTO userDTO = UserDTO.builder()
@@ -81,6 +82,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         //스프링 시큐리티 인증 토큰 생성
         Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
+        log.info("auth token {}", authToken);
         //세션에 사용자 등록
         SecurityContextHolder.getContext().setAuthentication(authToken);
 

--- a/src/main/java/com/deskit/deskit/ai/evaluate/controller/AdminEvaluationController.java
+++ b/src/main/java/com/deskit/deskit/ai/evaluate/controller/AdminEvaluationController.java
@@ -6,6 +6,7 @@ import com.deskit.deskit.ai.evaluate.dto.AiEvaluationDetailResponse;
 import com.deskit.deskit.ai.evaluate.dto.AiEvaluationSummaryResponse;
 import com.deskit.deskit.ai.evaluate.service.AdminEvaluationService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -16,6 +17,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+@Log4j2
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/evaluations")
@@ -62,6 +64,7 @@ public class AdminEvaluationController {
 		} catch (IllegalStateException ex) {
 			return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
 		} catch (IOException ex) {
+			log.error("Finalize evaluation email send failed", ex);
 			return new ResponseEntity<>("email send failed", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}


### PR DESCRIPTION
## 📌 관련 이슈

- closes #101 

## 📝 작업 내용

- 관리자 승인 이메일 발송 관련 로직에 로그 추가
- 기존 하드코딩된 이메일 주소를 설정값으로 고정
- 이메일 템플릿(.html) 경로 수정

## 🧐 리뷰 포인트

- 이메일 템플릿 경로 불일치 문제였으며, 해결되었습니다.
- 어떤 관리자로 로그인하더라도 발신자 이메일 주소는 고정되어 기능 작동에 문제 없습니다.
