### PR TITLE
Wire live broadcast create flow to APIs, add seller‑scoped draft persistence, and filter sold‑out products

### DIFF
--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -1,0 +1,95 @@
+import { http } from '../../api/http'
+
+export type BroadcastCategory = {
+  id: number
+  name: string
+}
+
+export type ReservationSlot = {
+  time: string
+  remainingCapacity: number
+}
+
+export type SellerProduct = {
+  id: string
+  name: string
+  option: string
+  price: number
+  broadcastPrice: number
+  stock: number
+  quantity: number
+  thumb?: string
+}
+
+type ApiResult<T> = {
+  success: boolean
+  data: T
+  error?: { code: string; message: string }
+}
+
+type BroadcastPayload = {
+  title: string
+  notice: string
+  categoryId: number
+  scheduledAt: string
+  thumbnailUrl: string
+  waitScreenUrl: string | null
+  broadcastLayout: string
+  products: Array<{ productId: number; salePrice: number; quantity: number }>
+  qcards: Array<{ question: string }>
+}
+
+const ensureSuccess = <T>(response: ApiResult<T>) => {
+  if (response?.success) return response.data
+  const error = response?.error
+  const message = error?.message ?? '요청 처리에 실패했습니다.'
+  const apiError = { message, code: error?.code }
+  throw apiError
+}
+
+export const fetchCategories = async (): Promise<BroadcastCategory[]> => {
+  const { data } = await http.get<ApiResult<Array<{ id: number; name: string }>>>('/api/categories')
+  const payload = ensureSuccess(data)
+  return payload.map((category) => ({ id: category.id, name: category.name }))
+}
+
+export const fetchSellerProducts = async (): Promise<SellerProduct[]> => {
+  const { data } = await http.get<ApiResult<Array<{ productId: number; productName: string; price: number; stockQty: number; imageUrl?: string }>>>(
+    '/api/seller/broadcasts/products',
+  )
+  const payload = ensureSuccess(data)
+  return payload.map((item) => ({
+    id: `prod-${item.productId}`,
+    name: item.productName,
+    option: '-',
+    price: item.price,
+    broadcastPrice: item.price,
+    stock: item.stockQty,
+    quantity: 1,
+    thumb: item.imageUrl ?? '',
+  }))
+}
+
+export const fetchReservationSlots = async (date: string): Promise<ReservationSlot[]> => {
+  const { data } = await http.get<ApiResult<Array<{ slotDateTime: string; remainingCapacity: number; selectable: boolean }>>>(
+    '/api/seller/broadcasts/reservation-slots',
+    { params: { date } },
+  )
+  const payload = ensureSuccess(data)
+  return payload
+    .filter((slot) => slot.selectable)
+    .map((slot) => ({
+      time: slot.slotDateTime.slice(11, 16),
+      remainingCapacity: slot.remainingCapacity,
+    }))
+}
+
+export const createBroadcast = async (payload: BroadcastPayload): Promise<number> => {
+  const { data } = await http.post<ApiResult<number>>('/api/seller/broadcasts', payload)
+  return ensureSuccess(data)
+}
+
+export const updateBroadcast = async (broadcastId: number, payload: BroadcastPayload): Promise<number> => {
+  const { data } = await http.put<ApiResult<number>>(`/api/seller/broadcasts/${broadcastId}`, payload)
+  return ensureSuccess(data)
+}

--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -219,6 +219,7 @@ public class BroadcastService {
 
         var condition = sellerField.eq(sellerId)
                 .and(statusField.in(statuses))
+                .and(stockQty.gt(0))
                 .and(deletedAt.isNull());
         if (keyword != null && !keyword.isBlank()) {
             condition = condition.and(productName.containsIgnoreCase(keyword));


### PR DESCRIPTION
### Motivation
- Replace front-end mock data with real backend APIs for the seller live broadcast creation flow to reflect production behavior.  
- Persist in-progress broadcast drafts per seller/session and avoid accidental cross-user restores.  
- Make available reservation time options and categories dynamic from the server and guard against overbooked slots.  
- Prevent selection of sold-out products in the product picker on the backend.

### Description
- Added a new client module `front/src/lib/live/api.ts` providing `fetchCategories`, `fetchSellerProducts`, `fetchReservationSlots`, `createBroadcast`, and `updateBroadcast` that wrap the HTTP `http` helper.  
- Updated `front/src/pages/seller/LiveCreateBasic.vue` to call the new APIs for categories, seller products and reservation slots, use dynamic `timeOptions`, enforce `:min`/`:max` date bounds, and submit creation/updation via `createBroadcast`/`updateBroadcast` with `B005` (slot full) handling.  
- Reworked draft persistence in `front/src/composables/useLiveCreateDraft.ts` to use session-scoped storage with an owner key and flow flag, and added `clearDraft`, `activateDraftFlow`, `deactivateDraftFlow`, and `isDraftFlowActive`; the cue and basic pages now prompt to restore prior drafts and manage the draft flow lifecycle.  
- Backend change in `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java` to filter seller product listings with `stockQty.gt(0)` so sold-out items are excluded.

### Testing
- No automated tests were run for these changes in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fcc25275c832a802176a99cb2263c)