### PR TITLE
[FEAT] 내 주문 리스트 및 주문 상품 상세 조회 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ src/main/resources/application.properties
 
 # local secrets (do not commit)
 src/main/resources/application.yml
-src/main/resources/application.properties
+src/main/resources/application햑 .properties


### PR DESCRIPTION
## 📌 관련 이슈
- closes #70 

## 📝 작업 내용
- 내 주문 리스트 페이지 API 연동 (GET /api/orders)
- 주문 상품 보기 시 주문 상세 조회 연동 (GET /api/orders/{id})
- 주문 상품 상세 lazy loading 처리 (toggle 시 조회)
- 로딩 / 에러 / 빈 상태 UI 처리
- 비로그인(401/403) 시 로그인 페이지 redirect 처리