### PR TITLE
[FEAT] 주문 내역 최초 진입 시 주문 상품 정보 Preload

### DIFF
--- a/front/src/api/endpoints.ts
+++ b/front/src/api/endpoints.ts
@@ -5,8 +5,9 @@ export const endpoints = {
   setupDetail: (id: string | number) => `/api/setups/${id}`,
   homePopularProducts: '/api/home/popular-products',
   homePopularSetups: '/api/home/popular-setups',
-  cart: '/cart',
-  cartItems: '/cart/items',
-  orders: '/orders',
-  orderDetail: (id: string | number) => `/orders/${id}`,
+  cart: '/api/cart',
+  cartItems: '/api/cart/items',
+  orders: '/api/orders',
+  orderDetail: (id: string | number) => `/api/orders/${id}`,
+  orderStatus: (id: string | number) => `/api/orders/${id}/status`,
 }

--- a/front/src/api/http.ts
+++ b/front/src/api/http.ts
@@ -1,34 +1,55 @@
 import axios, { AxiosHeaders, type InternalAxiosRequestConfig } from 'axios'
 import { API_BASE_URL, REQUEST_TIMEOUT_MS } from './config'
 
+/**
+ * 공통 Axios 인스턴스
+ * - baseURL: API 서버 주소 (ex. http://localhost:8080)
+ * - 모든 API 요청은 이 인스턴스를 통해 나가도록 강제
+ */
 export const http = axios.create({
   baseURL: API_BASE_URL,
   timeout: REQUEST_TIMEOUT_MS,
   headers: { 'Content-Type': 'application/json' },
 })
 
+/**
+ * Request Interceptor
+ *
+ * 역할:
+ * 1. localStorage에 access_token 이 있으면 Authorization 헤더 자동 주입
+ * 2. 단, 공개 API(GET) 요청은 토큰 제외
+ *
+ * 주의:
+ * - /api/orders 는 인증 필수 → 무조건 Authorization 헤더 포함됨
+ */
 http.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   const token = localStorage.getItem('access_token')
+
   const method = (config.method ?? 'get').toLowerCase()
   const rawUrl = config.url ?? ''
-  const path = rawUrl.startsWith('http')
-    ? (() => {
-      try {
-        return new URL(rawUrl).pathname
-      } catch {
-        return rawUrl
-      }
-    })()
-    : rawUrl
-  const isPublicGet =
-    method === 'get' &&
-    (path.startsWith('/api/home/') ||
-      path.startsWith('/api/products') ||
-      path.startsWith('/api/setups') ||
-      path === '/api/home' ||
-      path === '/api/products' ||
-      path === '/api/setups')
 
+  // absolute / relative URL 모두 pathname 기준으로 판별
+  const path = rawUrl.startsWith('http')
+      ? (() => {
+        try {
+          return new URL(rawUrl).pathname
+        } catch {
+          return rawUrl
+        }
+      })()
+      : rawUrl
+
+  /**
+   * 인증 없이 접근 가능한 공개 GET API 목록
+   * 👉 여기에 없는 API는 전부 "로그인 필요"
+   */
+  const isPublicGet =
+      method === 'get' &&
+      (path.startsWith('/api/home') ||
+          path.startsWith('/api/products') ||
+          path.startsWith('/api/setups'))
+
+  // 인증 필요 API → Authorization 헤더 주입
   if (token && !isPublicGet) {
     const headers = AxiosHeaders.from(config.headers)
     headers.set('Authorization', `Bearer ${token}`)


### PR DESCRIPTION
## 📌 관련 이슈
- closes #114 

## 📝 작업 내용
- 주문 내역 페이지(`/my/orders`) API 연동 로직 정리
- GET /api/orders 응답을 OrderHistory UI 모델로 매핑
- 주문 상세(GET /api/orders/{id}) 데이터를 최초 진입 시 미리 로드하도록 개선
- `details` 토글 클릭 전에도 주문 상품/이미지가 노출되도록 UX 개선
- 주문 상세 로딩/에러 상태 분리 관리 (`itemsLoading`, `itemsError`)
- 기존 localStorage 기반 주문 로직 제거 및 서버 기준 단일화