### PR TITLE
Fix Live carousel navigation typing and watch initialization

### DIFF
--- a/front/src/components/LiveCarousel.vue
+++ b/front/src/components/LiveCarousel.vue
@@ -2,6 +2,7 @@
 import { nextTick, ref } from 'vue'
 import { Swiper, SwiperSlide } from 'swiper/vue'
 import type { Swiper as SwiperClass } from 'swiper'
+import type { NavigationOptions } from 'swiper/types'
 import { Autoplay, Pagination, Navigation } from 'swiper/modules'
 
 import LiveCard from './LiveCard.vue'
@@ -22,12 +23,8 @@ const handleSwiper = (swiper: SwiperClass) => {
     }
 
     const rawNavigation = swiper.params.navigation
-    const navigation =
-      typeof rawNavigation === 'boolean' || !rawNavigation ? {} : rawNavigation
-    const navigationParams = navigation as {
-      prevEl?: Element | null
-      nextEl?: Element | null
-    }
+    const navigationParams: NavigationOptions =
+      typeof rawNavigation === 'object' && rawNavigation ? { ...rawNavigation } : {}
 
     navigationParams.prevEl = prevEl.value
     navigationParams.nextEl = nextEl.value

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -689,7 +689,7 @@ const openVodDetail = (item: LiveItem) => {
   router.push(`/seller/broadcasts/vods/${item.id}`).catch(() => {})
 }
 
-const loadCurrentLiveDetails = async (item: LiveItem | null) => {
+async function loadCurrentLiveDetails(item: LiveItem | null) {
   if (!item) {
     liveStats.value = null
     liveProducts.value = []


### PR DESCRIPTION
### Motivation
- Address TypeScript errors where Swiper navigation objects were not assignable to the expected `NavigationOptions` type. 
- Prevent runtime `ReferenceError: Cannot access 'loadCurrentLiveDetails' before initialization` caused by the loader being a non-hoisted function expression used in an immediate `watch` callback. 
- Reduce fragility when wiring custom navigation buttons for the live carousel. 

### Description
- Import and use `NavigationOptions` from `swiper/types` and construct `navigationParams` as a typed object before assigning `prevEl`/`nextEl` in `front/src/components/LiveCarousel.vue` to satisfy Swiper typings. 
- Replace the arrow-async loader with a hoisted function declaration `async function loadCurrentLiveDetails(...)` in `front/src/pages/seller/Live.vue` so the immediate `watch` can call it without initialization errors. 
- Keep existing Swiper `destroy`/`init`/`update` sequence to reinitialize navigation after wiring custom buttons. 

### Testing
- No automated tests were run as part of this change. 
- The change was committed locally and basic repository checks (`git status`) were performed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69604d28d21c832a91de85a6c75a0cd2)