### PR TITLE
Fix live typing, carousel navigation, and stream chat timing

### DIFF
--- a/front/src/components/LiveCarousel.vue
+++ b/front/src/components/LiveCarousel.vue
@@ -2,10 +2,11 @@
 import { nextTick, ref } from 'vue'
 import { Swiper, SwiperSlide } from 'swiper/vue'
 import type { Swiper as SwiperClass } from 'swiper'
+import type { NavigationOptions } from 'swiper/types'
 import { Autoplay, Pagination, Navigation } from 'swiper/modules'
 
 import LiveCard from './LiveCard.vue'
-import type { LiveItem } from '../lib/home-data'
+import type { LiveItem } from '../lib/live/types'
 
 defineProps<{
   items: LiveItem[]
@@ -22,12 +23,8 @@ const handleSwiper = (swiper: SwiperClass) => {
     }
 
     const rawNavigation = swiper.params.navigation
-    const navigation =
-      typeof rawNavigation === 'boolean' || !rawNavigation ? {} : rawNavigation
-    const navigationParams = navigation as {
-      prevEl?: Element | null
-      nextEl?: Element | null
-    }
+    const navigationParams: NavigationOptions =
+      typeof rawNavigation === 'object' && rawNavigation ? { ...rawNavigation } : {}
 
     navigationParams.prevEl = prevEl.value
     navigationParams.nextEl = nextEl.value

--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -33,6 +33,7 @@ type LiveItem = {
   startedAt?: string
   startedAtMs?: number
   startAtMs?: number
+  endAtMs?: number
   lifecycleStatus?: BroadcastStatus
 }
 
@@ -67,7 +68,6 @@ const activeTab = ref<LiveTab>('all')
 
 const LIVE_SECTION_STATUSES: BroadcastStatus[] = ['READY', 'ON_AIR', 'ENDED', 'STOPPED']
 const SCHEDULED_SECTION_STATUSES: BroadcastStatus[] = ['RESERVED', 'CANCELED']
-const VOD_SECTION_STATUSES: BroadcastStatus[] = ['VOD', 'STOPPED']
 const statusPriority: Record<BroadcastStatus, number> = {
   ON_AIR: 0,
   READY: 1,

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -53,7 +53,6 @@ const activeTab = ref<LiveTab>('all')
 
 const LIVE_SECTION_STATUSES: BroadcastStatus[] = ['READY', 'ON_AIR', 'ENDED', 'STOPPED']
 const SCHEDULED_SECTION_STATUSES: BroadcastStatus[] = ['RESERVED', 'CANCELED']
-const VOD_SECTION_STATUSES: BroadcastStatus[] = ['VOD', 'STOPPED']
 const statusPriority: Record<BroadcastStatus, number> = {
   ON_AIR: 0,
   READY: 1,
@@ -366,7 +365,7 @@ const loadCategories = async () => {
 
 const vodItemsWithStatus = computed(() => vodItems.value.map(withLifecycleStatus))
 
-const stoppedVodItems = computed(() =>
+const stoppedVodItems = computed<LiveItem[]>(() =>
   scheduledWithStatus.value
     .filter(
       (item) =>
@@ -376,14 +375,14 @@ const stoppedVodItems = computed(() =>
     .map((item) => ({
       ...item,
       status: 'STOPPED',
-      lifecycleStatus: 'STOPPED',
+      lifecycleStatus: 'STOPPED' as BroadcastStatus,
       statusBadge: 'STOPPED',
       visibility: item.visibility ?? 'public',
       datetime: item.datetime || formatDateLabel(item.startAtMs, '종료'),
     })),
 )
 
-const combinedVodItems = computed(() => [...vodItemsWithStatus.value, ...stoppedVodItems.value])
+const combinedVodItems = computed<LiveItem[]>(() => [...vodItemsWithStatus.value, ...stoppedVodItems.value])
 
 const filteredVodItems = computed(() => {
   const startMs = vodStartDate.value ? Date.parse(`${vodStartDate.value}T00:00:00`) : null
@@ -689,7 +688,7 @@ const openVodDetail = (item: LiveItem) => {
   router.push(`/seller/broadcasts/vods/${item.id}`).catch(() => {})
 }
 
-const loadCurrentLiveDetails = async (item: LiveItem | null) => {
+async function loadCurrentLiveDetails(item: LiveItem | null) {
   if (!item) {
     liveStats.value = null
     liveProducts.value = []

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -138,8 +138,7 @@ const formatScheduleWindow = (scheduledAt?: string, startedAt?: string) => {
   return `${dateLabel} ${pad(base.getHours())}:${pad(base.getMinutes())} - ${pad(end.getHours())}:${pad(end.getMinutes())}`
 }
 
-const formatChatTime = (timestamp?: number) => {
-  if (!timestamp) return ''
+const formatChatTime = (timestamp: number = Date.now()) => {
   const date = new Date(timestamp)
   const hours = date.getHours()
   const displayHour = hours % 12 || 12
@@ -270,7 +269,7 @@ const hydrateStream = async () => {
     const baseTime = detail.scheduledAt ?? detail.startedAt ?? ''
     const startAtMs = baseTime ? parseLiveDate(baseTime).getTime() : NaN
     scheduleStartAtMs.value = Number.isNaN(startAtMs) ? null : startAtMs
-    scheduleEndAtMs.value = scheduleStartAtMs.value ? getScheduledEndMs(scheduleStartAtMs.value) : null
+    scheduleEndAtMs.value = scheduleStartAtMs.value ? getScheduledEndMs(scheduleStartAtMs.value) ?? null : null
     streamStatus.value = normalizeBroadcastStatus(detail.status)
 
     const products = (detail.products ?? []).map((product) => ({
@@ -371,7 +370,7 @@ const refreshInfo = async (broadcastId: number) => {
     const baseTime = detail.scheduledAt ?? detail.startedAt ?? ''
     const startAtMs = baseTime ? parseLiveDate(baseTime).getTime() : NaN
     scheduleStartAtMs.value = Number.isNaN(startAtMs) ? null : startAtMs
-    scheduleEndAtMs.value = scheduleStartAtMs.value ? getScheduledEndMs(scheduleStartAtMs.value) : null
+    scheduleEndAtMs.value = scheduleStartAtMs.value ? getScheduledEndMs(scheduleStartAtMs.value) ?? null : null
     streamStatus.value = normalizeBroadcastStatus(detail.status)
     if (stream.value) {
       stream.value = {
@@ -665,14 +664,6 @@ watch(showSanctionModal, (open) => {
     sanctionTarget.value = null
   }
 })
-
-const formatChatTime = () => {
-  const now = new Date()
-  const hours = now.getHours()
-  const displayHour = hours % 12 || 12
-  const minutes = String(now.getMinutes()).padStart(2, '0')
-  return `${hours >= 12 ? '오후' : '오전'} ${displayHour}:${minutes}`
-}
 
 const handleSendChat = () => {
   if (!isInteractive.value) return


### PR DESCRIPTION
### Motivation
- Resolve TypeScript and runtime fragility across live-related UI code by aligning shared types and removing duplicated helpers. 
- Ensure Swiper navigation wiring is type-safe when attaching custom buttons. 
- Avoid duplicate `formatChatTime` implementations and ensure scheduled end timestamps are handled consistently. 
- Reduce mixed/mismatched live item shapes that caused type errors when composing lists.

### Description
- In `LiveCarousel.vue` import `NavigationOptions` and the shared `LiveItem` from `lib/live/types`, and construct a typed `navigationParams` before assigning `prevEl`/`nextEl` to satisfy Swiper typings. 
- Add missing `endAtMs?: number` to admin `LiveItem` shape and remove the redundant `VOD_SECTION_STATUSES` constant to reduce inconsistent item shapes in admin lists. 
- In seller `Live.vue` tighten VOD-related computed typing by using `computed<LiveItem[]>`, cast `lifecycleStatus` where needed, and hoist `loadCurrentLiveDetails` as an `async function` to avoid initialization timing issues. 
- In `LiveStream.vue` deduplicate/centralize `formatChatTime` to a single function with a default timestamp and normalize `scheduleEndAtMs` assignments using `getScheduledEndMs(...) ?? null` to avoid `undefined` inconsistencies.

### Testing
- Ran `npx --prefix front vue-tsc -b` from repo root which failed due to missing `/workspace/DESKIT/tsconfig.json` when invoked from root. 
- Ran `npx vue-tsc -b` in `front/` which still reports existing type issues across the front-end sources (the changes reduce some errors but there remain other unrelated type errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69604d28d21c832a91de85a6c75a0cd2)