### PR TITLE
Fix lint warnings and harden live-related code

### DIFF
--- a/front/src/components/DeviceSetupModal.vue
+++ b/front/src/components/DeviceSetupModal.vue
@@ -110,22 +110,30 @@ const startPreview = async () => {
       if (selectedCamera.value || selectedMic.value) {
         stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true })
       } else {
-        throw error
+        deviceError.value = '카메라 또는 마이크 접근 권한이 필요합니다.'
+        return
       }
     }
     if (!stream) {
-      throw new Error('No stream')
+      deviceError.value = '카메라 또는 마이크 접근 권한이 필요합니다.'
+      return
     }
     mediaStream.value = stream
     const [videoTrack] = stream.getVideoTracks()
     const [audioTrack] = stream.getAudioTracks()
-    if (videoTrack?.getSettings().deviceId) {
-      isSyncingDevices.value = true
-      selectedCamera.value = videoTrack.getSettings().deviceId ?? selectedCamera.value
+    if (videoTrack) {
+      const deviceId = videoTrack.getSettings().deviceId
+      if (deviceId) {
+        isSyncingDevices.value = true
+        selectedCamera.value = deviceId
+      }
     }
-    if (audioTrack?.getSettings().deviceId) {
-      isSyncingDevices.value = true
-      selectedMic.value = audioTrack.getSettings().deviceId ?? selectedMic.value
+    if (audioTrack) {
+      const deviceId = audioTrack.getSettings().deviceId
+      if (deviceId) {
+        isSyncingDevices.value = true
+        selectedMic.value = deviceId
+      }
     }
     if (isSyncingDevices.value) {
       await nextTick()

--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -5,7 +5,6 @@ import {getAuthUser, hydrateSessionUser, isAdmin, isLoggedIn as checkLoggedIn, i
 
 const route = useRoute()
 const router = useRouter()
-const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
 const isScrolled = ref(false)
 const isMenuOpen = ref(false)
 const panelRef = ref<HTMLElement | null>(null)

--- a/front/src/composables/useInfiniteScroll.ts
+++ b/front/src/composables/useInfiniteScroll.ts
@@ -33,7 +33,7 @@ export const useInfiniteScroll = (options: UseInfiniteScrollOptions) => {
         if (isVisible && options.canLoadMore() && !isLoading.value) {
           isLoading.value = true
           options.loadMore()
-          nextTick(() => {
+          void nextTick(() => {
             isLoading.value = false
           })
         }
@@ -49,7 +49,7 @@ export const useInfiniteScroll = (options: UseInfiniteScrollOptions) => {
   }
 
   onMounted(() => {
-    nextTick(initObserver)
+    void nextTick(initObserver)
   })
 
   onBeforeUnmount(() => {
@@ -58,7 +58,9 @@ export const useInfiniteScroll = (options: UseInfiniteScrollOptions) => {
 
   watch(
     [sentinelRef as Ref<HTMLElement | null>, () => (options.enabled ? options.enabled() : true), () => options.canLoadMore()],
-    () => nextTick(initObserver),
+    () => {
+      void nextTick(initObserver)
+    },
   )
 
   return {

--- a/front/src/composables/useLiveCreateDraft.ts
+++ b/front/src/composables/useLiveCreateDraft.ts
@@ -40,7 +40,8 @@ type StoredDraft = {
 const resolveSellerKey = () => {
   const user = getAuthUser()
   const sellerId = user?.seller_id ?? user?.sellerId ?? user?.id ?? user?.user_id ?? user?.userId
-  return typeof sellerId === 'number' ? sellerId.toString() : ''
+  if (!sellerId) return ''
+  return String(sellerId)
 }
 
 const getDraftStorage = () => sessionStorage
@@ -151,12 +152,6 @@ export const saveDraft = (draft: LiveCreateDraft) => {
 
 export const clearDraft = () => {
   clearDraftStorage()
-}
-
-const parseCurrency = (value: string) => {
-  const digits = value.replace(/\D/g, '')
-  const parsed = Number.parseInt(digits, 10)
-  return Number.isNaN(parsed) ? 0 : parsed
 }
 
 const formatReservationDate = (scheduledAt?: string) => {

--- a/front/src/composables/useSellerBroadcasts.ts
+++ b/front/src/composables/useSellerBroadcasts.ts
@@ -89,13 +89,3 @@ export const getScheduledBroadcasts = (): ScheduledBroadcast[] => {
     return []
   }
 }
-
-export const addScheduledBroadcast = (item: ScheduledBroadcast): void => {
-  const current = getScheduledBroadcasts()
-  const next = [item, ...current]
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
-}
-
-export const clearScheduledBroadcasts = (): void => {
-  localStorage.removeItem(STORAGE_KEY)
-}

--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -241,6 +241,17 @@ const withInFlight = async <T>(key: string, request: () => Promise<T>): Promise<
   }
 }
 
+const resolveBroadcastList = (payload: unknown): BroadcastListItem[] => {
+  if (Array.isArray(payload)) {
+    return payload as BroadcastListItem[]
+  }
+  const content = (payload as { content?: BroadcastListItem[] } | null)?.content
+  if (Array.isArray(content)) return content
+  const slice = (payload as { slice?: BroadcastListItem[] } | null)?.slice
+  if (Array.isArray(slice)) return slice
+  return []
+}
+
 export const fetchCategories = async (): Promise<BroadcastCategory[]> => {
   const { data } = await http.get<ApiResult<Array<{ id: number; name: string }>>>('/api/categories')
   const payload = ensureSuccess(data)
@@ -386,11 +397,6 @@ export const fetchMediaConfig = async (broadcastId: number): Promise<MediaConfig
   return ensureSuccess(data)
 }
 
-export const saveMediaConfig = async (broadcastId: number, payload: MediaConfig): Promise<void> => {
-  const { data } = await http.put<ApiResult<void>>(`/api/seller/broadcasts/${broadcastId}/media-config`, payload)
-  return ensureSuccess(data)
-}
-
 export const fetchSellerBroadcasts = async (params: {
   tab?: string
   statusFilter?: string
@@ -404,14 +410,7 @@ export const fetchSellerBroadcasts = async (params: {
 }) => {
   const { data } = await http.get<ApiResult<{ content?: BroadcastListItem[]; slice?: BroadcastListItem[] }>>('/api/seller/broadcasts', { params })
   const payload = ensureSuccess(data)
-  if (Array.isArray(payload)) {
-    return payload as BroadcastListItem[]
-  }
-  const content = (payload as any)?.content
-  if (Array.isArray(content)) return content
-  const slice = (payload as any)?.slice
-  if (Array.isArray(slice)) return slice
-  return []
+  return resolveBroadcastList(payload)
 }
 
 export const fetchAdminBroadcasts = async (params: {
@@ -427,14 +426,7 @@ export const fetchAdminBroadcasts = async (params: {
 }) => {
   const { data } = await http.get<ApiResult<{ content?: BroadcastListItem[]; slice?: BroadcastListItem[] }>>('/api/admin/broadcasts', { params })
   const payload = ensureSuccess(data)
-  if (Array.isArray(payload)) {
-    return payload as BroadcastListItem[]
-  }
-  const content = (payload as any)?.content
-  if (Array.isArray(content)) return content
-  const slice = (payload as any)?.slice
-  if (Array.isArray(slice)) return slice
-  return []
+  return resolveBroadcastList(payload)
 }
 
 export const createBroadcast = async (payload: BroadcastPayload): Promise<number> => {

--- a/front/src/lib/live/utils.ts
+++ b/front/src/lib/live/utils.ts
@@ -17,7 +17,10 @@ export const parseLiveDate = (value: string): Date => {
     return new Date(value)
   }
 
-  const [year, month, day] = datePart.split('-').map((part) => Number(part))
+  const [yearRaw, monthRaw = '1', dayRaw = '1'] = datePart.split('-')
+  const year = Number(yearRaw)
+  const month = Number(monthRaw)
+  const day = Number(dayRaw)
   if ([year, month, day].some((part) => Number.isNaN(part))) {
     return new Date(value)
   }
@@ -29,7 +32,7 @@ export const parseLiveDate = (value: string): Date => {
   const seconds = Number(secPart) || 0
   const milliseconds = Number(msPart) || 0
 
-  return new Date(year, (month ?? 1) - 1, day ?? 1, hours, minutes, seconds, milliseconds)
+  return new Date(year, month - 1, day, hours, minutes, seconds, milliseconds)
 }
 
 export const getLiveStatus = (item: LiveItem, now: Date = new Date()): LiveStatus => {


### PR DESCRIPTION
### Motivation

- Address several lint errors and warnings in live-related frontend code to improve code quality and prevent runtime undefined access.
- Prevent local `throw` paths and unsafe optional access in device preview setup to avoid unhandled exceptions in the UI.
- Remove unused exports and constants flagged by the linter to reduce dead code.
- Consolidate duplicated parsing logic for broadcast lists and make date parsing more robust.

### Description

- Remove unused `apiBase` constant from `front/src/components/Header.vue` to silence an unused-variable lint error.
- Harden `startPreview` in `front/src/components/DeviceSetupModal.vue` by replacing local `throw` with setting `deviceError` and guarding `getSettings().deviceId` access to avoid possible `undefined` reads.
- Mark deferred `nextTick` calls with `void` in `front/src/composables/useInfiniteScroll.ts` to explicitly ignore the returned `Promise` and avoid warnings.
- Simplify seller key resolution and drop unused `parseCurrency` in `front/src/composables/useLiveCreateDraft.ts` to remove dead code and fix type checks.
- Remove unused mutator functions from `front/src/composables/useSellerBroadcasts.ts` to eliminate unused-constant warnings.
- Extract `resolveBroadcastList` helper and remove duplicated list-parsing fragments in `front/src/lib/live/api.ts`, and remove unused `saveMediaConfig` export.
- Make `parseLiveDate` in `front/src/lib/live/utils.ts` more type-safe by handling missing month/day parts and constructing `Date` values consistently.

### Testing

- No automated tests were executed for this change.
- Local TypeScript/ESLint warnings were addressed by the changes and a commit was created successfully.
- Manual code review of modified files was performed to ensure no new runtime errors were introduced.
- Further automated test runs and CI verification are recommended before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696056ef1208832abf9678cc8bbb4ac7)