### PR TITLE
Fix admin live typings and add VOD actions

### DIFF
--- a/front/src/pages/admin/live/SanctionStats.vue
+++ b/front/src/pages/admin/live/SanctionStats.vue
@@ -45,7 +45,9 @@ const sumValues = (items: ChartDatum[]) => items.reduce((acc, item) => acc + ite
 const summaryCards = computed(() => {
   const totalStops = sumValues(stopChart.value)
   const totalViewers = sumValues(viewerChart.value)
-  const recentLabel = stopChart.value.at(-1)?.label || viewerChart.value.at(-1)?.label || '-'
+  const lastStop = stopChart.value.length ? stopChart.value[stopChart.value.length - 1] : undefined
+  const lastViewer = viewerChart.value.length ? viewerChart.value[viewerChart.value.length - 1] : undefined
+  const recentLabel = lastStop?.label || lastViewer?.label || '-'
   return [
     { label: '총 송출 중지', value: `${totalStops.toLocaleString('ko-KR')}건` },
     { label: '시청자 제재', value: `${totalViewers.toLocaleString('ko-KR')}건` },


### PR DESCRIPTION
### Motivation

- Resolve TypeScript / Vue type errors caused by using a single generic mapper for multiple admin broadcast list types. 
- Ensure VOD detail page in the admin section exposes the same action affordances (visibility toggle, download, delete) available in seller UI. 
- Avoid use of `Array.at` to improve compatibility with older TS lib targets. 

### Description

- Split the admin broadcast mapping into `mapLiveItem`, `mapReservationItem`, and `mapVodItem` to preserve correct shapes for `LiveItem`, `ReservationItem` and `AdminVodItem` and ensure lifecycle status computation remains type-safe in `front/src/pages/admin/AdminLive.vue`.
- Narrowed `withLifecycleStatus` generic typing and adjusted `liveLoopItems` typing to `LiveItem[]` to remove mismatched computed overload errors in `AdminLive.vue`.
- Replaced `stopChart.value.at(-1)` usage with explicit last-index lookup to avoid `Array.at` dependency in `front/src/pages/admin/live/SanctionStats.vue`.
- Added VOD action UI and supporting logic (visibility toggle, download and delete handlers, styles and state) to the admin VOD detail view and types in `front/src/pages/admin/live/VodDetail.vue`.

### Testing

- Started the dev server with `npm --prefix front run dev -- --host 0.0.0.0 --port 4173`, which launched successfully.
- Loaded the admin VOD detail page and captured a screenshot using Playwright to verify the new VOD action controls rendered; the script completed successfully and produced an artifact.
- No automated unit test suite was executed as part of this change.
- Manual smoke checks performed via the running dev server succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696059f2a7d4832aa04aaf9d2b48261e)