### PR TITLE
Fix device selection safety and AdminLive VOD typing

### DIFF
--- a/front/src/components/DeviceSetupModal.vue
+++ b/front/src/components/DeviceSetupModal.vue
@@ -64,8 +64,8 @@ const startMeter = (stream: MediaStream) => {
   const update = () => {
     analyserNode.getByteTimeDomainData(buffer)
     let sum = 0
-    for (let i = 0; i < buffer.length; i += 1) {
-      const normalized = (buffer[i] - 128) / 128
+    for (const sample of buffer) {
+      const normalized = (sample - 128) / 128
       sum += normalized * normalized
     }
     const rms = Math.sqrt(sum / buffer.length)
@@ -84,10 +84,16 @@ const loadDevices = async () => {
   deviceCameras.value = devices.filter((device) => device.kind === 'videoinput')
   deviceMics.value = devices.filter((device) => device.kind === 'audioinput')
   if (!selectedCamera.value && deviceCameras.value.length > 0) {
-    selectedCamera.value = deviceCameras.value[0].deviceId
+    const firstCamera = deviceCameras.value[0]
+    if (firstCamera) {
+      selectedCamera.value = firstCamera.deviceId
+    }
   }
   if (!selectedMic.value && deviceMics.value.length > 0) {
-    selectedMic.value = deviceMics.value[0].deviceId
+    const firstMic = deviceMics.value[0]
+    if (firstMic) {
+      selectedMic.value = firstMic.deviceId
+    }
   }
 }
 

--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -366,7 +366,9 @@ const stoppedVodItems = computed<AdminVodItem[]>(() => {
     .filter((item) => getLifecycleStatus(item) === 'STOPPED' && isPastScheduledEnd(item))
     .map((item) => ({
       ...item,
+      sellerName: item.sellerName ?? '',
       statusLabel: 'STOPPED',
+      category: item.category ?? '기타',
       lifecycleStatus: 'STOPPED',
       visibility: 'public',
       datetime: item.datetime ?? (item.startedAt ? `업로드: ${item.startedAt}` : ''),


### PR DESCRIPTION
### Motivation

- Prevent potential runtime and TypeScript errors from unchecked accesses when iterating audio samples and selecting the first media device.
- Ensure computed stopped VOD entries conform to the `AdminVodItem` shape so downstream code and templates receive required fields.

### Description

- Use `for (const sample of buffer)` when computing the audio RMS to avoid indexed access issues with the analyser buffer in `DeviceSetupModal.vue`.
- Guard initial device selection by checking `firstCamera` and `firstMic` before assigning to `selectedCamera.value` and `selectedMic.value` in `DeviceSetupModal.vue`.
- Populate `sellerName` and `category` (and keep existing fields) when mapping stopped items into `AdminVodItem` inside `AdminLive.vue` to satisfy typing and UI expectations.

### Testing

- No automated tests were executed for this change.
- Basic repository inspection and file updates were performed locally without running a test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69605fa1603c832a8a761f08fc6aa026)