### PR TITLE
Fix Vue lint warnings in live pages

### DIFF
--- a/front/src/pages/Live.vue
+++ b/front/src/pages/Live.vue
@@ -64,7 +64,7 @@ const handleCancelWatchHistory = () => {
 }
 
 const dayWindow = computed(() => getDayWindow(today))
-const selectedDay = ref(normalizeDay(dayWindow.value[3]))
+const selectedDay = ref(normalizeDay(dayWindow.value[3] ?? today))
 
 const formatTime = (value: string) => {
   const time = parseLiveDate(value)
@@ -581,6 +581,7 @@ onMounted(() => {
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   white-space: normal;
   line-height: 1.4;

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -374,7 +374,7 @@ const connectSse = (id: number) => {
   sseSource.value = source
 }
 
-const startStatsPolling = (id: number) => {
+const startStatsPolling = () => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
     if (!sseConnected.value) {
@@ -695,7 +695,7 @@ watch(
         connectChat()
       }
       connectSse(value)
-      startStatsPolling(value)
+      startStatsPolling()
     }
   },
   { immediate: true }

--- a/front/src/pages/Vod.vue
+++ b/front/src/pages/Vod.vue
@@ -323,7 +323,6 @@ watch(showChat, (visible) => {
               class="player-embed"
               :src="vodItem.vodUrl"
               title="VOD 플레이어"
-              frameborder="0"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen
             />


### PR DESCRIPTION
### Motivation
- Address TypeScript/Vue warnings where a `Date | undefined` could be passed to APIs expecting `Date` by providing a safe default for the selected day.
- Resolve a lint compatibility warning by adding the standard `line-clamp` CSS property alongside the WebKit variant.
- Remove an unused function parameter that caused a declared-but-unused variable warning in the live detail polling logic.
- Remove an obsolete `iframe` attribute flagged by the linter/HTML validator in the VOD view.

### Description
- Update `front/src/pages/Live.vue` to default `selectedDay` with `dayWindow.value[3] ?? today` to avoid passing `undefined` to date utilities and add `line-clamp: 2;` to `.meta__desc` for standard CSS compatibility.
- Change `startStatsPolling` in `front/src/pages/LiveDetail.vue` to remove the unused `id: number` parameter and call it as `startStatsPolling()`.
- Remove the obsolete `frameborder="0"` attribute from the iframe in `front/src/pages/Vod.vue`.
- Minor formatting/housekeeping to address the reported Vue/HTML lint warnings.

### Testing
- No automated tests were run for these changes.
- Manual static checks: updated code compiles type-wise in-editor (no CI run was executed).
- Lint warnings reported originally are expected to be resolved by these edits.
- No runtime behavior changes to API calls or polling logic beyond removing the unused parameter.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960643780c8832a8c856ec66743551e)