### PR TITLE
Fix category select when id is missing

### DIFF
--- a/front/src/pages/seller/LiveCreateBasic.vue
+++ b/front/src/pages/seller/LiveCreateBasic.vue
@@ -452,7 +452,11 @@ watch(
           <span class="field__label">카테고리</span>
           <select v-model="draft.category">
             <option value="" disabled>카테고리를 선택하세요</option>
-            <option v-for="category in categories" :key="category.id" :value="category.id.toString()">
+            <option
+              v-for="category in categories"
+              :key="category.id ?? category.name"
+              :value="category?.id != null ? category.id.toString() : ''"
+            >
               {{ category.name }}
             </option>
           </select>


### PR DESCRIPTION
### Motivation
- Prevent runtime errors caused by calling `toString()` on an undefined `category.id` when rendering options.
- Avoid Vue render/update errors and uncaught `TypeError` originating from `LiveCreateBasic.vue` during form render.
- Ensure the category `<select>` renders gracefully when backend-provided category objects may lack an `id`.
- Improve robustness of the broadcast creation form UI.

### Description
- Update `front/src/pages/seller/LiveCreateBasic.vue` option rendering to use `:key="category.id ?? category.name"` and `:value="category?.id != null ? category.id.toString() : ''"` to guard missing ids.
- Replace direct `category.id.toString()` call with a safe conditional expression to avoid undefined property access.
- Reformat the `<option>` markup to multiline for clarity and maintainability.
- Change is limited to the category `<select>` template and does not alter business logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69607821a91c8324bee3ee3ce1068689)