### PR TITLE
Fix live category and visibility mappings in frontend

### DIFF
--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -38,6 +38,7 @@ export type BroadcastListItem = {
   totalSales?: number | string
   totalLikes?: number
   isPublic?: boolean
+  public?: boolean
   adminLock?: boolean
 }
 
@@ -252,9 +253,9 @@ const resolveBroadcastList = (payload: unknown): BroadcastListItem[] => {
 }
 
 export const fetchCategories = async (): Promise<BroadcastCategory[]> => {
-  const { data } = await http.get<ApiResult<Array<{ id: number; name: string }>>>('/api/categories')
+  const { data } = await http.get<ApiResult<Array<{ categoryId: number; categoryName: string }>>>('/api/categories')
   const payload = ensureSuccess(data)
-  return payload.map((category) => ({ id: category.id, name: category.name }))
+  return payload.map((category) => ({ id: category.categoryId, name: category.categoryName }))
 }
 
 export const fetchSellerProducts = async (): Promise<SellerProduct[]> => {

--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -218,7 +218,8 @@ const mapLiveItem = (item: any, kind: 'live' | 'scheduled' | 'vod'): LiveItem =>
   const startAtMs = item.startAt ? toDateMs(item.startAt) : undefined
   const endAtMs = item.endAt ? toDateMs(item.endAt) : getScheduledEndMs(startAtMs)
   const status = normalizeBroadcastStatus(item.status)
-  const visibility = typeof item.isPublic === 'boolean' ? (item.isPublic ? 'public' : 'private') : 'public'
+  const rawPublic = item.isPublic ?? item.public
+  const visibility = typeof rawPublic === 'boolean' ? (rawPublic ? 'public' : 'private') : 'public'
   const dateLabel = formatDateTime(item.startAt)
   const datetime = kind === 'vod' ? (dateLabel ? `업로드: ${dateLabel}` : '') : dateLabel
   const liveViewerCount = typeof item.liveViewerCount === 'number' ? item.liveViewerCount : undefined
@@ -258,7 +259,8 @@ const mapReservationItem = (item: any): ReservationItem => {
 
 const mapVodItem = (item: any): AdminVodItem => {
   const base = mapLiveItem(item, 'vod')
-  const visibility = typeof item.isPublic === 'boolean' ? (item.isPublic ? 'public' : 'private') : 'public'
+  const rawPublic = item.isPublic ?? item.public
+  const visibility = typeof rawPublic === 'boolean' ? (rawPublic ? 'public' : 'private') : 'public'
   return {
     ...base,
     sellerName: base.sellerName ?? '',

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -140,7 +140,8 @@ const getVisibility = (item: LiveItem): 'public' | 'private' => {
     if (item.visibility === 'public' || item.visibility === '공개') return 'public'
     if (item.visibility === 'private' || item.visibility === '비공개') return 'private'
   }
-  if ((item as any)?.isPublic === true) return 'public'
+  const rawPublic = (item as any)?.isPublic ?? (item as any)?.public
+  if (typeof rawPublic === 'boolean') return rawPublic ? 'public' : 'private'
   return 'public'
 }
 
@@ -265,7 +266,8 @@ const mapBroadcastItem = (item: any, kind: 'live' | 'scheduled' | 'vod'): LiveIt
   const startAtMs = item.startAt ? parseLiveDate(item.startAt).getTime() : undefined
   const endAtMs = item.endAt ? parseLiveDate(item.endAt).getTime() : getScheduledEndMs(startAtMs)
   const status = normalizeBroadcastStatus(item.status)
-  const visibility = typeof item.isPublic === 'boolean' ? (item.isPublic ? 'public' : 'private') : 'public'
+  const rawPublic = item.isPublic ?? item.public
+  const visibility = typeof rawPublic === 'boolean' ? (rawPublic ? 'public' : 'private') : 'public'
   const dateLabel = formatDateTime(item.startAt)
   const datetime = kind === 'vod' ? (dateLabel ? `업로드: ${dateLabel}` : '') : dateLabel
   const liveViewerCount = typeof item.liveViewerCount === 'number' ? item.liveViewerCount : undefined


### PR DESCRIPTION
### Motivation

- The frontend expected category fields and visibility flags with different names than the backend (`id`/`name` vs `categoryId`/`categoryName`, and `isPublic` vs `public`), causing filter/visibility mismatches and possible `undefined` values in live views.
- Live list and VOD visibility logic relied on a single field name which produced incorrect status badges and filtering when the backend used a different property name.

### Description

- Extended the `BroadcastListItem` type with a `public?: boolean` field and normalized visibility derivation to check `item.isPublic ?? item.public` in `front/src/pages/seller/Live.vue` and `front/src/pages/admin/AdminLive.vue`.
- Updated `mapBroadcastItem`, `mapLiveItem`, and `mapVodItem` to derive `visibility` from the combined `isPublic/public` value to avoid `undefined` visibility.
- Changed `fetchCategories` in `front/src/lib/live/api.ts` to map backend `categoryId`/`categoryName` into the frontend `BroadcastCategory` type.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69607a3079e88324a7827c7819d5d334)