### PR TITLE
[FEAT] 일반회원 주문 조회 및 취소/환불 요청 플로우 완성

### DIFF
--- a/front/.env
+++ b/front/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8080

--- a/front/src/api/endpoints.ts
+++ b/front/src/api/endpoints.ts
@@ -10,4 +10,5 @@ export const endpoints = {
   orders: '/api/orders',
   orderDetail: (id: string | number) => `/api/orders/${id}`,
   orderStatus: (id: string | number) => `/api/orders/${id}/status`,
+  orderCancel: (id: string | number) => `/api/orders/${id}/cancel`,
 }

--- a/front/src/api/orders.ts
+++ b/front/src/api/orders.ts
@@ -10,6 +10,10 @@ import type {
 } from './types/orders'
 
 const withCredentials = { withCredentials: true }
+type OrderCancelResponse = {
+  order_id: number
+  status: string
+}
 
 export const createOrder = async (
   request: CreateOrderRequest,
@@ -35,6 +39,15 @@ export const updateOrderStatus = async (
   const response = await http.patch<OrderStatusUpdateResponse>(
     endpoints.orderStatus(orderId),
     request,
+    withCredentials,
+  )
+  return response.data
+}
+
+export const cancelOrder = async (orderId: number, reason: string): Promise<OrderCancelResponse> => {
+  const response = await http.patch<OrderCancelResponse>(
+    endpoints.orderCancel(orderId),
+    { reason },
     withCredentials,
   )
   return response.data

--- a/front/src/api/types/orders.ts
+++ b/front/src/api/types/orders.ts
@@ -22,6 +22,8 @@ export interface OrderSummaryResponse {
   status: OrderStatus
   order_amount: number
   created_at: string
+  cancel_reason?: string
+  cancel_requested_at?: string
 }
 
 export interface OrderItemResponse {

--- a/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
+++ b/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
     private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
     private final JWTUtil jwtUtil;
     private final RefreshRepository refreshRepository;
+
     public SecurityConfig(CustomOAuth2UserService customOAuth2UserService,
                           CustomSuccessHandler customSuccessHandler,
                           CustomOAuth2FailureHandler customOAuth2FailureHandler,
@@ -114,52 +115,53 @@ public class SecurityConfig {
                 );
 
         //경로별 인가 작업
-		http
-				.authorizeHttpRequests((auth) -> auth
-						.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-						.requestMatchers(HttpMethod.GET,
-								"/api/products/**",
-								"/api/setups/**",
-								"/api/setup/**",
-								"/api/products",
-								"/api/setups",
-								"/api/home/**",
-								"/livechats/**",
-								"/products/**",
-								"/setups/**"
-						).permitAll()
-						.requestMatchers(
-								"/",
-                "/chat",
-                "/chat/**",
-                "/reissue",
-                "/api/home/**",
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers(HttpMethod.PATCH, "/api/orders/**").hasAuthority("ROLE_MEMBER")
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/products/**",
+                                "/api/setups/**",
+                                "/api/setup/**",
+                                "/api/products",
+                                "/api/setups",
+                                "/api/home/**",
+                                "/livechats/**",
+                                "/products/**",
+                                "/setups/**"
+                        ).permitAll()
+                        .requestMatchers(
+                                "/",
+                                "/chat",
+                                "/chat/**",
+                                "/reissue",
+                                "/api/home/**",
                                 "/api/broadcasts/**",
                                 "/api/categories",
                                 "/api/vods/**",
                                 "/api/webhook/**",
-                "/api/admin/auth/**",
-                "/api/invitations/validate",
-                "/oauth/**",
-								"/login",
-								"/login/**",
-								"/login/oauth2/**",
+                                "/api/admin/auth/**",
+                                "/api/invitations/validate",
+                                "/oauth/**",
+                                "/login",
+                                "/login/**",
+                                "/login/oauth2/**",
                                 "/ws/**"
-						).permitAll()
-						.requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
-						.requestMatchers("/api/quit").hasAnyAuthority(
-								"ROLE_MEMBER",
-								"ROLE_SELLER_OWNER",
-								"ROLE_SELLER_MANAGER"
-						)
-						.requestMatchers("/my").hasAnyAuthority(
-								"ROLE_MEMBER",
-								"ROLE_SELLER",
-								"ROLE_SELLER_OWNER",
-								"ROLE_SELLER_MANAGER",
-								"ROLE_ADMIN"
-						)
-						.anyRequest().authenticated());
+                        ).permitAll()
+                        .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
+                        .requestMatchers("/api/quit").hasAnyAuthority(
+                                "ROLE_MEMBER",
+                                "ROLE_SELLER_OWNER",
+                                "ROLE_SELLER_MANAGER"
+                        )
+                        .requestMatchers("/my").hasAnyAuthority(
+                                "ROLE_MEMBER",
+                                "ROLE_SELLER",
+                                "ROLE_SELLER_OWNER",
+                                "ROLE_SELLER_MANAGER",
+                                "ROLE_ADMIN"
+                        )
+                        .anyRequest().authenticated());
 
         //세션 설정 : STATELESS -> IF_REQUIRED
         http

--- a/src/main/java/com/deskit/deskit/order/controller/OrderController.java
+++ b/src/main/java/com/deskit/deskit/order/controller/OrderController.java
@@ -8,8 +8,6 @@ import com.deskit.deskit.order.dto.CreateOrderResponse;
 import com.deskit.deskit.order.dto.OrderCancelRequest;
 import com.deskit.deskit.order.dto.OrderCancelResponse;
 import com.deskit.deskit.order.dto.OrderDetailResponse;
-import com.deskit.deskit.order.dto.OrderStatusUpdateRequest;
-import com.deskit.deskit.order.dto.OrderStatusUpdateResponse;
 import com.deskit.deskit.order.dto.OrderSummaryResponse;
 import com.deskit.deskit.order.service.OrderService;
 import jakarta.validation.Valid;
@@ -19,12 +17,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.server.ResponseStatusException;
 
 @RestController
@@ -63,16 +61,6 @@ public class OrderController {
   ) {
     Long memberId = resolveMemberId(user);
     return ResponseEntity.ok(orderService.getMyOrderDetail(memberId, orderId));
-  }
-
-  @PatchMapping("/{orderId}/status")
-  public ResponseEntity<OrderStatusUpdateResponse> updateOrderStatus(
-          @AuthenticationPrincipal CustomOAuth2User user,
-          @PathVariable("orderId") Long orderId,
-          @Valid @RequestBody OrderStatusUpdateRequest request
-  ) {
-    Long memberId = resolveMemberId(user);
-    return ResponseEntity.ok(orderService.updateOrderStatus(memberId, orderId, request));
   }
 
   @PatchMapping("/{orderId}/cancel")

--- a/src/main/java/com/deskit/deskit/order/controller/OrderController.java
+++ b/src/main/java/com/deskit/deskit/order/controller/OrderController.java
@@ -5,6 +5,8 @@ import com.deskit.deskit.account.oauth.CustomOAuth2User;
 import com.deskit.deskit.account.repository.MemberRepository;
 import com.deskit.deskit.order.dto.CreateOrderRequest;
 import com.deskit.deskit.order.dto.CreateOrderResponse;
+import com.deskit.deskit.order.dto.OrderCancelRequest;
+import com.deskit.deskit.order.dto.OrderCancelResponse;
 import com.deskit.deskit.order.dto.OrderDetailResponse;
 import com.deskit.deskit.order.dto.OrderStatusUpdateRequest;
 import com.deskit.deskit.order.dto.OrderStatusUpdateResponse;
@@ -71,6 +73,16 @@ public class OrderController {
   ) {
     Long memberId = resolveMemberId(user);
     return ResponseEntity.ok(orderService.updateOrderStatus(memberId, orderId, request));
+  }
+
+  @PatchMapping("/{orderId}/cancel")
+  public ResponseEntity<OrderCancelResponse> requestCancel(
+          @AuthenticationPrincipal CustomOAuth2User user,
+          @PathVariable("orderId") Long orderId,
+          @Valid @RequestBody OrderCancelRequest request
+  ) {
+    Long memberId = resolveMemberId(user);
+    return ResponseEntity.ok(orderService.requestCancel(memberId, orderId, request));
   }
 
   private Long resolveMemberId(CustomOAuth2User user) {

--- a/src/main/java/com/deskit/deskit/order/dto/OrderCancelRequest.java
+++ b/src/main/java/com/deskit/deskit/order/dto/OrderCancelRequest.java
@@ -1,0 +1,10 @@
+package com.deskit.deskit.order.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public record OrderCancelRequest(
+  @JsonProperty("reason")
+  @NotBlank
+  String reason
+) {}

--- a/src/main/java/com/deskit/deskit/order/dto/OrderCancelResponse.java
+++ b/src/main/java/com/deskit/deskit/order/dto/OrderCancelResponse.java
@@ -1,0 +1,12 @@
+package com.deskit.deskit.order.dto;
+
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OrderCancelResponse(
+  @JsonProperty("order_id")
+  Long orderId,
+
+  @JsonProperty("status")
+  OrderStatus status
+) {}

--- a/src/main/java/com/deskit/deskit/order/dto/OrderDetailResponse.java
+++ b/src/main/java/com/deskit/deskit/order/dto/OrderDetailResponse.java
@@ -22,12 +22,18 @@ public record OrderDetailResponse(
   @JsonProperty("created_at")
   LocalDateTime createdAt,
 
+  @JsonProperty("cancel_reason")
+  String cancelReason,
+
+  @JsonProperty("cancel_requested_at")
+  LocalDateTime cancelRequestedAt,
+
   @JsonProperty("items")
   List<OrderItemResponse> items
 ) {
   public static OrderDetailResponse from(Order order, List<OrderItemResponse> items) {
     if (order == null) {
-      return new OrderDetailResponse(null, null, null, null, null, items);
+      return new OrderDetailResponse(null, null, null, null, null, null, null, items);
     }
     return new OrderDetailResponse(
       order.getId(),
@@ -35,6 +41,8 @@ public record OrderDetailResponse(
       order.getStatus(),
       order.getOrderAmount(),
       order.getCreatedAt(),
+      order.getCancelReason(),
+      order.getUpdatedAt(),
       items
     );
   }

--- a/src/main/java/com/deskit/deskit/order/dto/OrderSummaryResponse.java
+++ b/src/main/java/com/deskit/deskit/order/dto/OrderSummaryResponse.java
@@ -19,18 +19,26 @@ public record OrderSummaryResponse(
   Integer orderAmount,
 
   @JsonProperty("created_at")
-  LocalDateTime createdAt
+  LocalDateTime createdAt,
+
+  @JsonProperty("cancel_reason")
+  String cancelReason,
+
+  @JsonProperty("cancel_requested_at")
+  LocalDateTime cancelRequestedAt
 ) {
   public static OrderSummaryResponse from(Order order) {
     if (order == null) {
-      return new OrderSummaryResponse(null, null, null, null, null);
+      return new OrderSummaryResponse(null, null, null, null, null, null, null);
     }
     return new OrderSummaryResponse(
       order.getId(),
       order.getOrderNumber(),
       order.getStatus(),
       order.getOrderAmount(),
-      order.getCreatedAt()
+      order.getCreatedAt(),
+      order.getCancelReason(),
+      order.getUpdatedAt()
     );
   }
 }

--- a/src/main/java/com/deskit/deskit/order/entity/Order.java
+++ b/src/main/java/com/deskit/deskit/order/entity/Order.java
@@ -142,4 +142,22 @@ public class Order extends BaseEntity {
   public void changeStatus(OrderStatus status) {
     this.status = status;
   }
+
+  public void requestCancel(String reason) {
+    if (this.status == OrderStatus.CREATED) {
+      if (this.cancelReason == null && reason != null) {
+        this.cancelReason = reason;
+      }
+      this.status = OrderStatus.CANCEL_REQUESTED;
+      return;
+    }
+    if (this.status == OrderStatus.PAID) {
+      if (this.cancelReason == null && reason != null) {
+        this.cancelReason = reason;
+      }
+      this.status = OrderStatus.REFUND_REQUESTED;
+      return;
+    }
+    throw new IllegalStateException("invalid status for cancel request");
+  }
 }

--- a/src/main/java/com/deskit/deskit/order/entity/Order.java
+++ b/src/main/java/com/deskit/deskit/order/entity/Order.java
@@ -114,6 +114,13 @@ public class Order extends BaseEntity {
   private LocalDateTime cancelledAt;
 
   /**
+   * 환불 완료 시각
+   * - refunded_at (nullable)
+   */
+  @Column(name = "refunded_at")
+  private LocalDateTime refundedAt;
+
+  /**
    * 주문 생성 팩토리 메서드
    *
    * - 엔티티 생성 시 필요한 핵심 값들을 한 곳에서 세팅하기 위해 제공
@@ -139,10 +146,6 @@ public class Order extends BaseEntity {
     return order;
   }
 
-  public void changeStatus(OrderStatus status) {
-    this.status = status;
-  }
-
   public void requestCancel(String reason) {
     if (this.status == OrderStatus.CREATED) {
       if (this.cancelReason == null && reason != null) {
@@ -160,4 +163,32 @@ public class Order extends BaseEntity {
     }
     throw new IllegalStateException("invalid status for cancel request");
   }
+
+  public void approveCancel() {
+    if (this.status != OrderStatus.CANCEL_REQUESTED) {
+      throw new IllegalStateException("invalid status for cancel approval");
+    }
+    this.status = OrderStatus.CANCELLED;
+    if (this.cancelledAt == null) {
+      this.cancelledAt = LocalDateTime.now();
+    }
+  }
+
+  public void approveRefund() {
+    if (this.status != OrderStatus.REFUND_REQUESTED) {
+      throw new IllegalStateException("invalid status for refund approval");
+    }
+    this.status = OrderStatus.REFUNDED;
+    if (this.refundedAt == null) {
+      this.refundedAt = LocalDateTime.now();
+    }
+  }
+
+  public void rejectRefund() {
+    if (this.status != OrderStatus.REFUND_REQUESTED) {
+      throw new IllegalStateException("invalid status for refund rejection");
+    }
+    this.status = OrderStatus.REFUND_REJECTED;
+  }
+
 }

--- a/src/main/java/com/deskit/deskit/order/enums/OrderStatus.java
+++ b/src/main/java/com/deskit/deskit/order/enums/OrderStatus.java
@@ -7,5 +7,6 @@ public enum OrderStatus {
   CANCELLED,
   COMPLETED,
   REFUND_REQUESTED,
+  REFUND_REJECTED,
   REFUNDED
 }

--- a/src/main/java/com/deskit/deskit/order/enums/OrderStatus.java
+++ b/src/main/java/com/deskit/deskit/order/enums/OrderStatus.java
@@ -3,6 +3,9 @@ package com.deskit.deskit.order.enums;
 public enum OrderStatus {
   CREATED,
   PAID,
+  CANCEL_REQUESTED,
   CANCELLED,
-  COMPLETED
+  COMPLETED,
+  REFUND_REQUESTED,
+  REFUNDED
 }

--- a/src/main/java/com/deskit/deskit/order/service/OrderService.java
+++ b/src/main/java/com/deskit/deskit/order/service/OrderService.java
@@ -8,8 +8,6 @@ import com.deskit.deskit.order.dto.CreateOrderRequest;
 import com.deskit.deskit.order.dto.CreateOrderResponse;
 import com.deskit.deskit.order.dto.OrderDetailResponse;
 import com.deskit.deskit.order.dto.OrderItemResponse;
-import com.deskit.deskit.order.dto.OrderStatusUpdateRequest;
-import com.deskit.deskit.order.dto.OrderStatusUpdateResponse;
 import com.deskit.deskit.order.dto.OrderSummaryResponse;
 import com.deskit.deskit.order.entity.Order;
 import com.deskit.deskit.order.entity.OrderItem;
@@ -182,36 +180,6 @@ public class OrderService {
       .collect(Collectors.toList());
 
     return OrderDetailResponse.from(order, items);
-  }
-
-  public OrderStatusUpdateResponse updateOrderStatus(Long memberId, Long orderId, OrderStatusUpdateRequest request) {
-    if (memberId == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "member_id required");
-    }
-    if (!memberRepository.existsById(memberId)) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found");
-    }
-    if (orderId == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "order_id required");
-    }
-    if (request == null || request.status() == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status required");
-    }
-
-    Order order = orderRepository.findById(orderId)
-      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "order not found"));
-    if (!order.getMemberId().equals(memberId)) {
-      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
-    }
-
-    OrderStatus newStatus = request.status();
-    if (newStatus == order.getStatus()) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "status unchanged");
-    }
-
-    order.changeStatus(newStatus);
-    orderRepository.save(order);
-    return new OrderStatusUpdateResponse(order.getId(), order.getStatus());
   }
 
   public OrderCancelResponse requestCancel(Long memberId, Long orderId, OrderCancelRequest request) {

--- a/src/main/resources/sql/livecommerce_create_table.sql
+++ b/src/main/resources/sql/livecommerce_create_table.sql
@@ -78,53 +78,60 @@ DROP TABLE IF EXISTS chat_info;
 -- ---------------------------------------------------------
 -- [User Group] Member, Seller, Admin
 -- ---------------------------------------------------------
-CREATE TABLE member (
-    member_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '회원 ID',
-    `name`        VARCHAR(20)     NOT NULL COMMENT '회원명',
-    login_id      VARCHAR(100)    NOT NULL COMMENT '로그인 아이디(이메일 등)',
-    `profile`     TEXT    NULL COMMENT '프로필',
-    phone         VARCHAR(15)     NOT NULL COMMENT '전화번호',
-    is_agreed     TINYINT         NOT NULL COMMENT '약관 동의 여부',
-    `status`      ENUM('ACTIVE', 'INACTIVE') NOT NULL DEFAULT 'ACTIVE' COMMENT '회원 상태',
-    created_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    mbti          ENUM('INTJ', 'INTP', 'ENTJ', 'ENTP',
-                       'INFJ', 'INFP', 'ENFJ', 'ENFP',
-                       'ISTJ', 'ISFJ', 'ESTJ', 'ESFJ',
-                       'ISTP', 'ISFP', 'ESTP', 'ESFP', 'NONE') NULL DEFAULT 'NONE',
-    `role`        VARCHAR(20)     NOT NULL DEFAULT 'ROLE_MEMBER',
-    job_category  ENUM('ADMIN_PLAN_TYPE', 'CREATIVE_TYPE', 'EDU_RES_TYPE', 'MED_PRO_TYPE', 'FLEXIBLE_TYPE', 'NONE') NULL DEFAULT 'NONE',
+CREATE TABLE member
+(
+    member_id    BIGINT UNSIGNED                                                                                    NOT NULL AUTO_INCREMENT COMMENT '회원 ID',
+    `name`       VARCHAR(20)                                                                                        NOT NULL COMMENT '회원명',
+    login_id     VARCHAR(100)                                                                                       NOT NULL COMMENT '로그인 아이디(이메일 등)',
+    `profile`    TEXT                                                                                               NULL COMMENT '프로필',
+    phone        VARCHAR(15)                                                                                        NOT NULL COMMENT '전화번호',
+    is_agreed    TINYINT                                                                                            NOT NULL COMMENT '약관 동의 여부',
+    `status`     ENUM ('ACTIVE', 'INACTIVE')                                                                        NOT NULL DEFAULT 'ACTIVE' COMMENT '회원 상태',
+    created_at   DATETIME                                                                                           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME                                                                                           NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    mbti         ENUM ('INTJ', 'INTP', 'ENTJ', 'ENTP',
+        'INFJ', 'INFP', 'ENFJ', 'ENFP',
+        'ISTJ', 'ISFJ', 'ESTJ', 'ESFJ',
+        'ISTP', 'ISFP', 'ESTP', 'ESFP', 'NONE')                                                                     NULL     DEFAULT 'NONE',
+    `role`       VARCHAR(20)                                                                                        NOT NULL DEFAULT 'ROLE_MEMBER',
+    job_category ENUM ('ADMIN_PLAN_TYPE', 'CREATIVE_TYPE', 'EDU_RES_TYPE', 'MED_PRO_TYPE', 'FLEXIBLE_TYPE', 'NONE') NULL     DEFAULT 'NONE',
     PRIMARY KEY (member_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='회원';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='회원';
 
-CREATE TABLE seller (
-    seller_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '판매자 ID',
-    `status`      ENUM('PENDING', 'ACTIVE', 'INACTIVE') NOT NULL DEFAULT 'PENDING' COMMENT '승인 상태',
-    created_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    `name`        VARCHAR(20)     NOT NULL COMMENT '판매자명(대표자명)',
-    login_id      VARCHAR(100)    NOT NULL COMMENT '로그인 아이디',
-    phone         VARCHAR(15)     NOT NULL COMMENT '전화번호',
-    `profile`     TEXT    NULL COMMENT '판매자 프로필',
-    `role`        ENUM('ROLE_SELLER_OWNER', 'ROLE_SELLER_MANAGER')     NOT NULL DEFAULT 'ROLE_SELLER_MANAGER',
-    `is_agreed`   TINYINT   NOT NULL COMMENT '약관 동의 여부',
+CREATE TABLE seller
+(
+    seller_id   BIGINT UNSIGNED                                   NOT NULL AUTO_INCREMENT COMMENT '판매자 ID',
+    `status`    ENUM ('PENDING', 'ACTIVE', 'INACTIVE')            NOT NULL DEFAULT 'PENDING' COMMENT '승인 상태',
+    created_at  DATETIME                                          NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME                                          NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `name`      VARCHAR(20)                                       NOT NULL COMMENT '판매자명(대표자명)',
+    login_id    VARCHAR(100)                                      NOT NULL COMMENT '로그인 아이디',
+    phone       VARCHAR(15)                                       NOT NULL COMMENT '전화번호',
+    `profile`   TEXT                                              NULL COMMENT '판매자 프로필',
+    `role`      ENUM ('ROLE_SELLER_OWNER', 'ROLE_SELLER_MANAGER') NOT NULL DEFAULT 'ROLE_SELLER_MANAGER',
+    `is_agreed` TINYINT                                           NOT NULL COMMENT '약관 동의 여부',
     PRIMARY KEY (seller_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='판매자';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='판매자';
 
-CREATE TABLE admin (
-    admin_id      BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    login_id      VARCHAR(100)    NOT NULL,
-    phone         VARCHAR(15)     NOT NULL,
-    `name`        VARCHAR(20)     NOT NULL,
-    `role`        VARCHAR(20)     NOT NULL DEFAULT 'ROLE_ADMIN',
-    created_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+CREATE TABLE admin
+(
+    admin_id   BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    login_id   VARCHAR(100)    NOT NULL,
+    phone      VARCHAR(15)     NOT NULL,
+    `name`     VARCHAR(20)     NOT NULL,
+    `role`     VARCHAR(20)     NOT NULL DEFAULT 'ROLE_ADMIN',
+    created_at DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (admin_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='관리자';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='관리자';
 
 -- ---------------------------------------------------------
 -- [Meta Data] Tag, Category
 -- ---------------------------------------------------------
-CREATE TABLE tag_category(
+CREATE TABLE tag_category
+(
     tag_category_id   BIGINT UNSIGNED                          NOT NULL AUTO_INCREMENT COMMENT '태그 카테고리 ID',
     tag_code          ENUM ('SPACE','TONE','SITUATION','MOOD') NOT NULL COMMENT '태그 카테고리 코드(공간/톤/상황/무드)',
     tag_category_name VARCHAR(30)                              NOT NULL COMMENT '태그 카테고리명(예: 공간, 톤, 상황, 무드)',
@@ -132,9 +139,11 @@ CREATE TABLE tag_category(
     updated_at        DATETIME                                 NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시각',
     deleted_at        DATETIME                                 NULL COMMENT '논리삭제 시각(NULL=활성)',
     PRIMARY KEY (tag_category_id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='태그 카테고리';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='태그 카테고리';
 
-CREATE TABLE tag(
+CREATE TABLE tag
+(
     tag_id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '태그 ID',
     tag_category_id BIGINT UNSIGNED NOT NULL COMMENT '태그 카테고리 ID(논리 FK: tag_category.tag_category_id)',
     tag_name        VARCHAR(50)     NOT NULL COMMENT '태그명(예: 미니멀, 화이트 등)',
@@ -142,20 +151,24 @@ CREATE TABLE tag(
     updated_at      DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시각',
     deleted_at      DATETIME        NULL COMMENT '논리삭제 시각(NULL=활성)',
     PRIMARY KEY (tag_id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='태그';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='태그';
 
-CREATE TABLE forbidden_word (
-    word_id       INT UNSIGNED NOT NULL AUTO_INCREMENT,
-    word          VARCHAR(50)  NOT NULL COMMENT '금지어',
-    replacement   VARCHAR(50)  NOT NULL COMMENT '대체어',
-    created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+CREATE TABLE forbidden_word
+(
+    word_id     INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    word        VARCHAR(50)  NOT NULL COMMENT '금지어',
+    replacement VARCHAR(50)  NOT NULL COMMENT '대체어',
+    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (word_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='금지어';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='금지어';
 
 -- ---------------------------------------------------------
 -- [Commerce Core] Product, Image, Setup
 -- ---------------------------------------------------------
-CREATE TABLE product(
+CREATE TABLE product
+(
     product_id   BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '상품 ID',
     seller_id    BIGINT UNSIGNED NOT NULL COMMENT '판매자 ID(논리 FK: seller/member)',
     product_name VARCHAR(100)    NOT NULL COMMENT '상품명',
@@ -172,16 +185,18 @@ CREATE TABLE product(
         'PAUSED',       -- 일시중지
         'HIDDEN',       -- 숨김
         'DELETED'       -- 논리삭제 상태(표시용 상태값)
-        ) NOT NULL DEFAULT 'DRAFT' COMMENT '상품 판매 상태',
+        )                        NOT NULL DEFAULT 'DRAFT' COMMENT '상품 판매 상태',
     stock_qty    INT UNSIGNED    NOT NULL DEFAULT 0 COMMENT '현재 재고 수량',
     safety_stock INT UNSIGNED    NOT NULL DEFAULT 5 COMMENT '안전 재고선(이하로 내려가면 알림 대상)',
     created_at   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 시각',
     updated_at   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시각',
     deleted_at   DATETIME        NULL COMMENT '논리삭제 시각(NULL=활성)',
     PRIMARY KEY (product_id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='상품';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='상품';
 
-CREATE TABLE product_image (
+CREATE TABLE product_image
+(
     product_image_id  BIGINT UNSIGNED              NOT NULL AUTO_INCREMENT COMMENT '상품 이미지 ID',
     product_id        BIGINT UNSIGNED              NOT NULL COMMENT '상품 ID(논리 FK: product.product_id)',
     product_image_url VARCHAR(500)                 NOT NULL COMMENT '이미지 URL(NCP Object Storage 등)',
@@ -192,17 +207,21 @@ CREATE TABLE product_image (
     deleted_at        DATETIME                     NULL COMMENT '논리삭제 시각(NULL=활성)',
     PRIMARY KEY (product_image_id),
     UNIQUE KEY uk_product_image_slot (product_id, image_type, slot_index)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='상품 이미지';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='상품 이미지';
 
-CREATE TABLE product_tag (
+CREATE TABLE product_tag
+(
     product_id BIGINT UNSIGNED NOT NULL COMMENT '상품 ID(논리 FK: product.product_id)',
     tag_id     BIGINT UNSIGNED NOT NULL COMMENT '태그 ID(논리 FK: tag.tag_id)',
     created_at DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '매핑 생성 시각',
     deleted_at DATETIME        NULL COMMENT '논리삭제 시각(NULL=활성)',
     PRIMARY KEY (product_id, tag_id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='상품-태그 매핑';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='상품-태그 매핑';
 
-CREATE TABLE setup (
+CREATE TABLE setup
+(
     setup_id        BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '셋업 ID',
     seller_id       BIGINT UNSIGNED NOT NULL COMMENT '판매자 ID(논리 FK: seller/member)',
     setup_name      VARCHAR(100)    NOT NULL COMMENT '셋업명',
@@ -213,28 +232,34 @@ CREATE TABLE setup (
     updated_at      DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시각',
     deleted_at      DATETIME        NULL COMMENT '논리삭제 시각(NULL=활성)',
     PRIMARY KEY (setup_id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='셋업';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='셋업';
 
-CREATE TABLE setup_tag (
+CREATE TABLE setup_tag
+(
     setup_id   BIGINT UNSIGNED NOT NULL COMMENT '셋업 ID(논리 FK: setup.setup_id)',
     tag_id     BIGINT UNSIGNED NOT NULL COMMENT '태그 ID(논리 FK: tag.tag_id)',
     created_at DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '매핑 생성 시각',
     deleted_at DATETIME        NULL COMMENT '논리삭제 시각(NULL=활성)',
     PRIMARY KEY (setup_id, tag_id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='셋업-태그 매핑';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='셋업-태그 매핑';
 
-CREATE TABLE setup_product (
+CREATE TABLE setup_product
+(
     setup_id   BIGINT UNSIGNED NOT NULL COMMENT '셋업 ID(논리 FK: setup.setup_id)',
     product_id BIGINT UNSIGNED NOT NULL COMMENT '상품 ID(논리 FK: product.product_id)',
     created_at DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '매핑 생성 시각',
     deleted_at DATETIME        NULL COMMENT '논리삭제 시각(NULL=활성)',
     PRIMARY KEY (setup_id, product_id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='셋업-상품 매핑';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='셋업-상품 매핑';
 
 -- ---------------------------------------------------------
 -- [Transactions] Cart, Order
 -- ---------------------------------------------------------
-CREATE TABLE cart (
+CREATE TABLE cart
+(
     cart_id    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '장바구니 ID',
     member_id  BIGINT UNSIGNED NOT NULL COMMENT '회원 ID(회원당 1개 장바구니)',
     created_at DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 시각',
@@ -242,9 +267,11 @@ CREATE TABLE cart (
     deleted_at DATETIME        NULL COMMENT '논리삭제 시각(NULL=활성)',
     PRIMARY KEY (cart_id),
     UNIQUE KEY uk_cart_member (member_id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='장바구니(회원 1:1)';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='장바구니(회원 1:1)';
 
-CREATE TABLE cart_item (
+CREATE TABLE cart_item
+(
     cart_item_id   BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '장바구니 아이템 ID',
     cart_id        BIGINT UNSIGNED NOT NULL COMMENT '장바구니 ID(논리 FK: cart.cart_id)',
     product_id     BIGINT UNSIGNED NOT NULL COMMENT '상품 ID(논리 FK: product.product_id)',
@@ -255,28 +282,41 @@ CREATE TABLE cart_item (
     deleted_at     DATETIME        NULL COMMENT '논리삭제 시각(NULL=활성)',
     PRIMARY KEY (cart_item_id),
     UNIQUE KEY uk_cart_item (cart_id, product_id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='장바구니 아이템';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='장바구니 아이템';
 
 -- [주의] order는 예약어이므로 백틱(`) 필수 사용
-CREATE TABLE `order` (
-    order_id             BIGINT UNSIGNED                                 NOT NULL AUTO_INCREMENT COMMENT '주문 ID',
-    member_id            BIGINT UNSIGNED                                 NOT NULL COMMENT '회원 ID(논리 FK: member)',
-    order_number         VARCHAR(50)                                     NOT NULL COMMENT '구매자 노출 주문번호(유니크)',
-    total_product_amount INT UNSIGNED                                    NOT NULL COMMENT '상품 총액(상품가 합)',
-    shipping_fee         INT UNSIGNED                                    NOT NULL DEFAULT 0 COMMENT '배송비(추후 확장)',
-    discount_fee         INT UNSIGNED                                    NOT NULL DEFAULT 0 COMMENT '할인 금액(쿠폰/프로모션 등)',
-    order_amount         INT UNSIGNED                                    NOT NULL COMMENT '최종 금액(=상품총액-할인+배송비)',
-    `status`             ENUM ('CREATED','PAID','CANCELLED','COMPLETED') NOT NULL DEFAULT 'CREATED' COMMENT '주문 상태',
-    cancel_reason        VARCHAR(500)                                    NULL COMMENT '주문 취소 사유',
-    created_at           DATETIME                                        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 시각',
-    paid_at              DATETIME                                        NULL COMMENT '결제 완료 시각(결제 담당이 채움)',
-    cancelled_at         DATETIME                                        NULL COMMENT '취소 시각',
-    updated_at           DATETIME                                        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시각',
-    deleted_at           DATETIME                                        NULL COMMENT '논리삭제 시각(NULL=활성)',
+CREATE TABLE `order`
+(
+    order_id             BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '주문 ID',
+    member_id            BIGINT UNSIGNED NOT NULL COMMENT '회원 ID(논리 FK: member)',
+    order_number         VARCHAR(50)     NOT NULL COMMENT '구매자 노출 주문번호(유니크)',
+    total_product_amount INT UNSIGNED    NOT NULL COMMENT '상품 총액(상품가 합)',
+    shipping_fee         INT UNSIGNED    NOT NULL DEFAULT 0 COMMENT '배송비(추후 확장)',
+    discount_fee         INT UNSIGNED    NOT NULL DEFAULT 0 COMMENT '할인 금액(쿠폰/프로모션 등)',
+    order_amount         INT UNSIGNED    NOT NULL COMMENT '최종 금액(=상품총액-할인+배송비)',
+    `status`             ENUM (
+        'CREATED',          -- 주문 생성 (결제 전)
+        'PAID',             -- 결제 완료
+        'CANCEL_REQUESTED', -- 사용자 취소 요청
+        'CANCELLED',        -- 주문 취소 완료
+        'COMPLETED',        -- 구매 확정 (배송/서비스 완료)
+        'REFUND_REQUESTED', -- 환불 요청
+        'REFUNDED'          -- 환불 완료
+        )                                NOT NULL DEFAULT 'CREATED' COMMENT '주문 상태',
+    cancel_reason        VARCHAR(500)    NULL COMMENT '주문 취소 사유',
+    created_at           DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 시각',
+    paid_at              DATETIME        NULL COMMENT '결제 완료 시각(결제 담당이 채움)',
+    cancel_requested_at  DATETIME        NULL COMMENT '취소 요청 시각',
+    refund_requested_at  DATETIME        NULL COMMENT '환불 요청 시각',
+    cancelled_at         DATETIME        NULL COMMENT '취소 시각',
+    updated_at           DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시각',
     PRIMARY KEY (order_id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='주문';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='주문';
 
-CREATE TABLE order_item (
+CREATE TABLE order_item
+(
     order_item_id  BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '주문 아이템 ID',
     order_id       BIGINT UNSIGNED NOT NULL COMMENT '주문 ID(논리 FK: `order`.order_id)',
     product_id     BIGINT UNSIGNED NOT NULL COMMENT '상품 ID(논리 FK: product.product_id)',
@@ -289,78 +329,90 @@ CREATE TABLE order_item (
     updated_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시각',
     deleted_at     DATETIME        NULL COMMENT '논리삭제 시각(NULL=활성)',
     PRIMARY KEY (order_item_id)
-) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COMMENT ='주문 아이템';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='주문 아이템';
 
 -- ---------------------------------------------------------
 -- [Live Commerce] Broadcast, VOD, Chat
 -- ---------------------------------------------------------
-CREATE TABLE broadcast (
-    broadcast_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    seller_id        BIGINT UNSIGNED NOT NULL COMMENT 'FK: seller',
-    tag_category_id  BIGINT UNSIGNED NOT NULL COMMENT 'FK: tag_category (옵션)',
-    broadcast_title  VARCHAR(30)     NOT NULL,
-    broadcast_notice VARCHAR(100)    NULL,
-    `status`         ENUM('RESERVED','READY','ON_AIR','ENDED','VOD','DELETED','CANCELED','STOPPED') NOT NULL DEFAULT 'RESERVED',
-    scheduled_at     DATETIME        NOT NULL COMMENT '예약 시간',
-    started_at       DATETIME        NULL,
-    ended_at         DATETIME        NULL,
-    broadcast_thumb_url VARCHAR(255) NOT NULL,
-    broadcast_wait_url  VARCHAR(255) NULL,
-    stream_key       VARCHAR(100)    NULL,
-    broadcast_layout ENUM('FULL', 'LAYOUT_2', 'LAYOUT_3', 'LAYOUT_4') NOT NULL DEFAULT 'LAYOUT_4',
-    broadcast_stopped_reason VARCHAR(50) NULL,
-    created_at       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+CREATE TABLE broadcast
+(
+    broadcast_id             BIGINT UNSIGNED                                                                 NOT NULL AUTO_INCREMENT,
+    seller_id                BIGINT UNSIGNED                                                                 NOT NULL COMMENT 'FK: seller',
+    tag_category_id          BIGINT UNSIGNED                                                                 NOT NULL COMMENT 'FK: tag_category (옵션)',
+    broadcast_title          VARCHAR(30)                                                                     NOT NULL,
+    broadcast_notice         VARCHAR(100)                                                                    NULL,
+    `status`                 ENUM ('RESERVED','READY','ON_AIR','ENDED','VOD','DELETED','CANCELED','STOPPED') NOT NULL DEFAULT 'RESERVED',
+    scheduled_at             DATETIME                                                                        NOT NULL COMMENT '예약 시간',
+    started_at               DATETIME                                                                        NULL,
+    ended_at                 DATETIME                                                                        NULL,
+    broadcast_thumb_url      VARCHAR(255)                                                                    NOT NULL,
+    broadcast_wait_url       VARCHAR(255)                                                                    NULL,
+    stream_key               VARCHAR(100)                                                                    NULL,
+    broadcast_layout         ENUM ('FULL', 'LAYOUT_2', 'LAYOUT_3', 'LAYOUT_4')                               NOT NULL DEFAULT 'LAYOUT_4',
+    broadcast_stopped_reason VARCHAR(50)                                                                     NULL,
+    created_at               DATETIME                                                                        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at               DATETIME                                                                        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (broadcast_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='라이브 방송';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='라이브 방송';
 
-CREATE TABLE broadcast_product (
-    bp_id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    broadcast_id  BIGINT UNSIGNED NOT NULL COMMENT 'FK: broadcast',
-    product_id    BIGINT UNSIGNED NOT NULL COMMENT 'FK: product',
-    display_order INT             NOT NULL,
-    bp_price      INT             NULL COMMENT '방송 특가',
-    bp_quantity   INT             NOT NULL COMMENT '방송용 재고',
-    is_pinned     CHAR(1)         NOT NULL DEFAULT 'N' COMMENT 'N/Y',
-    `status`      ENUM('SELLING','SOLDOUT','DELETED') NOT NULL DEFAULT 'SELLING',
-    created_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+CREATE TABLE broadcast_product
+(
+    bp_id         BIGINT UNSIGNED                      NOT NULL AUTO_INCREMENT,
+    broadcast_id  BIGINT UNSIGNED                      NOT NULL COMMENT 'FK: broadcast',
+    product_id    BIGINT UNSIGNED                      NOT NULL COMMENT 'FK: product',
+    display_order INT                                  NOT NULL,
+    bp_price      INT                                  NULL COMMENT '방송 특가',
+    bp_quantity   INT                                  NOT NULL COMMENT '방송용 재고',
+    is_pinned     CHAR(1)                              NOT NULL DEFAULT 'N' COMMENT 'N/Y',
+    `status`      ENUM ('SELLING','SOLDOUT','DELETED') NOT NULL DEFAULT 'SELLING',
+    created_at    DATETIME                             NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME                             NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (bp_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='방송-상품 매핑';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='방송-상품 매핑';
 
-CREATE TABLE vod (
-    vod_id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    broadcast_id   BIGINT UNSIGNED NOT NULL COMMENT 'FK: broadcast',
-    vod_url        VARCHAR(255)    NULL,
-    vod_size       BIGINT          NOT NULL DEFAULT 0,
-    `status`       ENUM('PUBLIC','PRIVATE','DELETED') NOT NULL DEFAULT 'PUBLIC',
-    vod_report_count INT           NOT NULL DEFAULT 0,
-    vod_duration   INT             NULL COMMENT '초 단위',
-    vod_admin_lock CHAR(1)         NOT NULL DEFAULT 'N' COMMENT 'Y/N',
-    created_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+CREATE TABLE vod
+(
+    vod_id           BIGINT UNSIGNED                     NOT NULL AUTO_INCREMENT,
+    broadcast_id     BIGINT UNSIGNED                     NOT NULL COMMENT 'FK: broadcast',
+    vod_url          VARCHAR(255)                        NULL,
+    vod_size         BIGINT                              NOT NULL DEFAULT 0,
+    `status`         ENUM ('PUBLIC','PRIVATE','DELETED') NOT NULL DEFAULT 'PUBLIC',
+    vod_report_count INT                                 NOT NULL DEFAULT 0,
+    vod_duration     INT                                 NULL COMMENT '초 단위',
+    vod_admin_lock   CHAR(1)                             NOT NULL DEFAULT 'N' COMMENT 'Y/N',
+    created_at       DATETIME                            NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       DATETIME                            NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (vod_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='다시보기(VOD)';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='다시보기(VOD)';
 
-CREATE TABLE qcard (
+CREATE TABLE qcard
+(
     qcard_id       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     broadcast_id   BIGINT UNSIGNED NOT NULL,
     qcard_question VARCHAR(50)     NOT NULL,
     sort_order     INT             NOT NULL DEFAULT 0,
     created_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (qcard_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='큐카드(질문)';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='큐카드(질문)';
 
-CREATE TABLE view_history (
-    history_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    broadcast_id   BIGINT UNSIGNED NOT NULL,
-    viewer_id      VARCHAR(100)    NOT NULL,
-    created_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+CREATE TABLE view_history
+(
+    history_id   BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    broadcast_id BIGINT UNSIGNED NOT NULL,
+    viewer_id    VARCHAR(100)    NOT NULL,
+    created_at   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (history_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='시청 기록';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='시청 기록';
 
-CREATE TABLE broadcast_result (
+CREATE TABLE broadcast_result
+(
     broadcast_id   BIGINT UNSIGNED NOT NULL COMMENT 'PK이자 FK',
     total_views    INT             NOT NULL DEFAULT 0,
     max_views      INT             NOT NULL DEFAULT 0,
@@ -373,294 +425,375 @@ CREATE TABLE broadcast_result (
     created_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (broadcast_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='방송 결과 통계';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='방송 결과 통계';
 
-CREATE TABLE live_chat (
-    message_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    broadcast_id   BIGINT UNSIGNED NOT NULL,
-    member_id      BIGINT UNSIGNED NOT NULL,
-    msg_type       ENUM('TALK','ENTER','EXIT','PURCHASE','NOTICE') NOT NULL COMMENT '채팅 메시지 유형',
-    content        VARCHAR(500)    NOT NULL,
-    send_nick      VARCHAR(50)     NOT NULL,
-    is_world       BOOLEAN         NOT NULL DEFAULT FALSE,
-    is_hidden      BOOLEAN         NOT NULL DEFAULT FALSE COMMENT '숨김 처리 여부',
-    send_lchat     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    vod_play_time  INT             NOT NULL DEFAULT 0 COMMENT '방송 시작 후 경과 시간(초)',
+CREATE TABLE live_chat
+(
+    message_id    BIGINT UNSIGNED                                  NOT NULL AUTO_INCREMENT,
+    broadcast_id  BIGINT UNSIGNED                                  NOT NULL,
+    member_id     BIGINT UNSIGNED                                  NOT NULL,
+    msg_type      ENUM ('TALK','ENTER','EXIT','PURCHASE','NOTICE') NOT NULL COMMENT '채팅 메시지 유형',
+    content       VARCHAR(500)                                     NOT NULL,
+    send_nick     VARCHAR(50)                                      NOT NULL,
+    is_world      BOOLEAN                                          NOT NULL DEFAULT FALSE,
+    is_hidden     BOOLEAN                                          NOT NULL DEFAULT FALSE COMMENT '숨김 처리 여부',
+    send_lchat    DATETIME                                         NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    vod_play_time INT                                              NOT NULL DEFAULT 0 COMMENT '방송 시작 후 경과 시간(초)',
     PRIMARY KEY (message_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='라이브 채팅';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='라이브 채팅';
 
-CREATE TABLE sanction (
-    sanction_id    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    broadcast_id   BIGINT UNSIGNED NOT NULL,
-    member_id      BIGINT UNSIGNED NOT NULL,
-    actor_type     ENUM('ADMIN','SELLER') NOT NULL DEFAULT 'SELLER',
-    seller_id      BIGINT UNSIGNED NULL,
-    admin_id       BIGINT UNSIGNED NULL,
-    `status`       ENUM('MUTE','OUT') NOT NULL DEFAULT 'MUTE',
-    sanction_reason VARCHAR(50)    NULL,
-    created_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+CREATE TABLE sanction
+(
+    sanction_id     BIGINT UNSIGNED         NOT NULL AUTO_INCREMENT,
+    broadcast_id    BIGINT UNSIGNED         NOT NULL,
+    member_id       BIGINT UNSIGNED         NOT NULL,
+    actor_type      ENUM ('ADMIN','SELLER') NOT NULL DEFAULT 'SELLER',
+    seller_id       BIGINT UNSIGNED         NULL,
+    admin_id        BIGINT UNSIGNED         NULL,
+    `status`        ENUM ('MUTE','OUT')     NOT NULL DEFAULT 'MUTE',
+    sanction_reason VARCHAR(50)             NULL,
+    created_at      DATETIME                NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (sanction_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='제재(강퇴/채금)';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='제재(강퇴/채금)';
 
 -- ---------------------------------------------------------
 -- [Social & Notifications]
 -- ---------------------------------------------------------
-CREATE TABLE follow (
-    follow_id      BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    follower_id    BIGINT UNSIGNED NOT NULL COMMENT '팔로우하는 멤버 ID',
-    following_id   BIGINT UNSIGNED NOT NULL COMMENT '팔로우 받는 판매자 ID',
-    created_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+CREATE TABLE follow
+(
+    follow_id    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    follower_id  BIGINT UNSIGNED NOT NULL COMMENT '팔로우하는 멤버 ID',
+    following_id BIGINT UNSIGNED NOT NULL COMMENT '팔로우 받는 판매자 ID',
+    created_at   DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (follow_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='팔로우';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='팔로우';
 
-CREATE TABLE notification (
-    noti_id        BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    member_id      BIGINT UNSIGNED NOT NULL,
-    noti_type      ENUM('LIVE_START','FOLLOW','NOTICE','EVENT','SYSTEM') NOT NULL COMMENT '알림 유형',
-    noti_content   VARCHAR(255)    NOT NULL,
-    created_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+CREATE TABLE notification
+(
+    noti_id      BIGINT UNSIGNED                                        NOT NULL AUTO_INCREMENT,
+    member_id    BIGINT UNSIGNED                                        NOT NULL,
+    noti_type    ENUM ('LIVE_START','FOLLOW','NOTICE','EVENT','SYSTEM') NOT NULL COMMENT '알림 유형',
+    noti_content VARCHAR(255)                                           NOT NULL,
+    created_at   DATETIME                                               NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (noti_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='알림';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='알림';
 
 -- ---------------------------------------------------------
 -- [Seller Onboarding & Evaluation (AI/Admin)]
 -- ---------------------------------------------------------
-CREATE TABLE seller_register (
-    register_id    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    plan_file      LONGBLOB        NOT NULL COMMENT '사업계획서 등',
-    description    TEXT            NULL COMMENT '설명',
-    seller_id      BIGINT UNSIGNED NOT NULL COMMENT 'FK: seller',
-    company_name   VARCHAR(100)    NOT NULL,
+CREATE TABLE seller_register
+(
+    register_id  BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    plan_file    LONGBLOB        NOT NULL COMMENT '사업계획서 등',
+    description  TEXT            NULL COMMENT '설명',
+    seller_id    BIGINT UNSIGNED NOT NULL COMMENT 'FK: seller',
+    company_name VARCHAR(100)    NOT NULL,
     PRIMARY KEY (register_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='입점 신청서';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='입점 신청서';
 
-CREATE TABLE ai_evaluation (
-    ai_eval_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    business_stability INT         NOT NULL,
-    product_competency INT         NOT NULL,
-    live_suitability   INT         NOT NULL,
-    operation_coop     INT         NOT NULL,
-    growth_potential   INT         NOT NULL,
-    total_score        INT         NOT NULL,
-    grade_recommended ENUM('A','B','C','REJECTED') NOT NULL DEFAULT 'C',
-    summary            TEXT        NOT NULL,
-    created_at         DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    seller_id          BIGINT UNSIGNED NOT NULL,
-    register_id        BIGINT UNSIGNED NOT NULL COMMENT 'FK: seller_register',
+CREATE TABLE ai_evaluation
+(
+    ai_eval_id         BIGINT UNSIGNED               NOT NULL AUTO_INCREMENT,
+    business_stability INT                           NOT NULL,
+    product_competency INT                           NOT NULL,
+    live_suitability   INT                           NOT NULL,
+    operation_coop     INT                           NOT NULL,
+    growth_potential   INT                           NOT NULL,
+    total_score        INT                           NOT NULL,
+    grade_recommended  ENUM ('A','B','C','REJECTED') NOT NULL DEFAULT 'C',
+    summary            TEXT                          NOT NULL,
+    created_at         DATETIME                      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    seller_id          BIGINT UNSIGNED               NOT NULL,
+    register_id        BIGINT UNSIGNED               NOT NULL COMMENT 'FK: seller_register',
     PRIMARY KEY (ai_eval_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='AI 입점 평가';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='AI 입점 평가';
 
-CREATE TABLE admin_evaluation (
-    admin_eval_id      BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    business_stability INT         NOT NULL,
-    product_competency INT         NOT NULL,
-    live_suitability   INT         NOT NULL,
-    operation_coop     INT         NOT NULL,
-    growth_potential   INT         NOT NULL,
-    total_score        INT         NOT NULL,
-    grade_recommended  ENUM('A','B','C','REJECTED') NOT NULL DEFAULT 'C',
-    admin_comment      VARCHAR(250) NULL,
-    created_at         DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    ai_eval_id         BIGINT UNSIGNED NOT NULL COMMENT 'FK: ai_evaluation',
+CREATE TABLE admin_evaluation
+(
+    admin_eval_id      BIGINT UNSIGNED               NOT NULL AUTO_INCREMENT,
+    business_stability INT                           NOT NULL,
+    product_competency INT                           NOT NULL,
+    live_suitability   INT                           NOT NULL,
+    operation_coop     INT                           NOT NULL,
+    growth_potential   INT                           NOT NULL,
+    total_score        INT                           NOT NULL,
+    grade_recommended  ENUM ('A','B','C','REJECTED') NOT NULL DEFAULT 'C',
+    admin_comment      VARCHAR(250)                  NULL,
+    created_at         DATETIME                      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ai_eval_id         BIGINT UNSIGNED               NOT NULL COMMENT 'FK: ai_evaluation',
     PRIMARY KEY (admin_eval_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='관리자 최종 평가';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='관리자 최종 평가';
 
-CREATE TABLE company_registered (
-    company_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    company_name   VARCHAR(100)    NOT NULL,
-    business_number VARCHAR(15)    NOT NULL,
-    seller_id      BIGINT UNSIGNED NOT NULL COMMENT 'FK: seller',
-    created_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    `status`       ENUM('ACTIVE', 'DELETED') NOT NULL DEFAULT 'ACTIVE',
+CREATE TABLE company_registered
+(
+    company_id      BIGINT UNSIGNED            NOT NULL AUTO_INCREMENT,
+    company_name    VARCHAR(100)               NOT NULL,
+    business_number VARCHAR(15)                NOT NULL,
+    seller_id       BIGINT UNSIGNED            NOT NULL COMMENT 'FK: seller',
+    created_at      DATETIME                   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `status`        ENUM ('ACTIVE', 'DELETED') NOT NULL DEFAULT 'ACTIVE',
     PRIMARY KEY (company_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='등록된 기업 정보';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='등록된 기업 정보';
 
-CREATE TABLE seller_grade (
-    grade_id       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    grade          ENUM('A', 'B', 'C', 'REJECTED') NOT NULL DEFAULT 'C',
-    `status`       ENUM('ACTIVE', 'TEMP', 'REVIEW') NOT NULL DEFAULT 'ACTIVE',
-    created_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    expired_at     DATETIME        NULL,
-    company_id     BIGINT UNSIGNED NOT NULL COMMENT 'FK: company_registered',
+CREATE TABLE seller_grade
+(
+    grade_id   BIGINT UNSIGNED                   NOT NULL AUTO_INCREMENT,
+    grade      ENUM ('A', 'B', 'C', 'REJECTED')  NOT NULL DEFAULT 'C',
+    `status`   ENUM ('ACTIVE', 'TEMP', 'REVIEW') NOT NULL DEFAULT 'ACTIVE',
+    created_at DATETIME                          NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME                          NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    expired_at DATETIME                          NULL,
+    company_id BIGINT UNSIGNED                   NOT NULL COMMENT 'FK: company_registered',
     PRIMARY KEY (grade_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='판매자 등급';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='판매자 등급';
 
-CREATE TABLE invitation (
-    invitation_id  BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    email          VARCHAR(100)    NOT NULL,
-    created_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at     DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    expired_at     DATETIME        NOT NULL,
-    `status`       ENUM('PENDING','ACCEPTED','EXPIRED') NOT NULL DEFAULT 'PENDING',
-    token          VARCHAR(255)    NOT NULL,
-    seller_id      BIGINT UNSIGNED NOT NULL COMMENT '초대자',
+CREATE TABLE invitation
+(
+    invitation_id BIGINT UNSIGNED                       NOT NULL AUTO_INCREMENT,
+    email         VARCHAR(100)                          NOT NULL,
+    created_at    DATETIME                              NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME                              NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    expired_at    DATETIME                              NOT NULL,
+    `status`      ENUM ('PENDING','ACCEPTED','EXPIRED') NOT NULL DEFAULT 'PENDING',
+    token         VARCHAR(255)                          NOT NULL,
+    seller_id     BIGINT UNSIGNED                       NOT NULL COMMENT '초대자',
     PRIMARY KEY (invitation_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='초대장';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='초대장';
 
 -- ---------------------------------------------------------
 -- [Payment (Toss)]
 -- ---------------------------------------------------------
 -- [수정완료] AUTO_INCREMENT를 사용하기 위해 payment_id를 BIGINT UNSIGNED로 변경
-CREATE TABLE toss_payment (
-    payment_id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    toss_payment_key    VARCHAR(64)     NOT NULL UNIQUE,
-    toss_order_id       VARCHAR(255)    NOT NULL,
-    toss_payment_method ENUM('계좌이체','신용/체크카드') NOT NULL,
-    `status`            ENUM('ABORTED','CANCELED','DONE','EXPIRED','IN_PROGRESS','PARTIAL_CANCELED','READY','WAITING_FOR_DEPOSIT') NOT NULL,
-    request_date        DATETIME        NOT NULL,
-    approved_date       DATETIME        NULL DEFAULT NULL,
-    total_amount        BIGINT          NOT NULL,
-    created_at          DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at          DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    order_id            VARCHAR(36)     NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='토스 결제 정보';
+CREATE TABLE toss_payment
+(
+    payment_id          BIGINT UNSIGNED                                                                                             NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    toss_payment_key    VARCHAR(64)                                                                                                 NOT NULL UNIQUE,
+    toss_order_id       VARCHAR(255)                                                                                                NOT NULL,
+    toss_payment_method ENUM ('계좌이체','신용/체크카드')                                                                                     NOT NULL,
+    `status`            ENUM ('ABORTED','CANCELED','DONE','EXPIRED','IN_PROGRESS','PARTIAL_CANCELED','READY','WAITING_FOR_DEPOSIT') NOT NULL,
+    request_date        DATETIME                                                                                                    NOT NULL,
+    approved_date       DATETIME                                                                                                    NULL     DEFAULT NULL,
+    total_amount        BIGINT                                                                                                      NOT NULL,
+    created_at          DATETIME                                                                                                    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME                                                                                                    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    order_id            VARCHAR(36)                                                                                                 NOT NULL
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='토스 결제 정보';
 
-CREATE TABLE toss_refund (
-    refund_id           BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    refund_key          VARCHAR(100)    NOT NULL,
-    refund_amount       BIGINT          NOT NULL,
-    refund_reason       VARCHAR(255)    NULL,
-    refund_status       VARCHAR(255)    NOT NULL,
-    requested_at        DATETIME        NOT NULL,
-    approved_at         DATETIME        NULL,
-    created_at          DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    payment_id          BIGINT UNSIGNED NOT NULL COMMENT 'toss_payment의 PK와 타입 일치시킴',
-    toss_payment_key    VARCHAR(64)     NOT NULL UNIQUE COMMENT 'FK: toss_payment (UNIQUE Key 참조)',
+CREATE TABLE toss_refund
+(
+    refund_id        BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    refund_key       VARCHAR(100)    NOT NULL,
+    refund_amount    BIGINT          NOT NULL,
+    refund_reason    VARCHAR(255)    NULL,
+    refund_status    VARCHAR(255)    NOT NULL,
+    requested_at     DATETIME        NOT NULL,
+    approved_at      DATETIME        NULL,
+    created_at       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    payment_id       BIGINT UNSIGNED NOT NULL COMMENT 'toss_payment의 PK와 타입 일치시킴',
+    toss_payment_key VARCHAR(64)     NOT NULL UNIQUE COMMENT 'FK: toss_payment (UNIQUE Key 참조)',
     PRIMARY KEY (refund_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='토스 환불 정보';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='토스 환불 정보';
 
-CREATE TABLE toss_webhook_log (
-    webhook_id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    event_type          VARCHAR(50)     NOT NULL,
-    raw_body            JSON            NOT NULL,
-    created_at          DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    toss_payment_key    VARCHAR(64)     NOT NULL UNIQUE,
-    order_id            VARCHAR(36)     NOT NULL,
+CREATE TABLE toss_webhook_log
+(
+    webhook_id       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    event_type       VARCHAR(50)     NOT NULL,
+    raw_body         JSON            NOT NULL,
+    created_at       DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    toss_payment_key VARCHAR(64)     NOT NULL UNIQUE,
+    order_id         VARCHAR(36)     NOT NULL,
     PRIMARY KEY (webhook_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='토스 웹훅 로그';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='토스 웹훅 로그';
 
 -- ---------------------------------------------------------
 -- [CS / Chatbot Support]
 -- ---------------------------------------------------------
-CREATE TABLE chat_info (
-    chat_id       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    `status`      ENUM('BOT_ACTIVE', 'ADMIN_ACTIVE', 'ESCALATED', 'CLOSED') NOT NULL DEFAULT 'BOT_ACTIVE',
-    created_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    member_id     BIGINT UNSIGNED NOT NULL COMMENT 'FK: member',
+CREATE TABLE chat_info
+(
+    chat_id    BIGINT UNSIGNED                                            NOT NULL AUTO_INCREMENT,
+    `status`   ENUM ('BOT_ACTIVE', 'ADMIN_ACTIVE', 'ESCALATED', 'CLOSED') NOT NULL DEFAULT 'BOT_ACTIVE',
+    created_at DATETIME                                                   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME                                                   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    member_id  BIGINT UNSIGNED                                            NOT NULL COMMENT 'FK: member',
     PRIMARY KEY (chat_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='CS 채팅방';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='CS 채팅방';
 
-CREATE TABLE chat_message (
-    message_id    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    content       TEXT            NOT NULL,
-    sender        ENUM('ASSISTANT', 'SYSTEM', 'USER') NOT NULL,
-    created_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    chat_id       BIGINT UNSIGNED NOT NULL COMMENT 'FK: chat_info',
+CREATE TABLE chat_message
+(
+    message_id BIGINT UNSIGNED                      NOT NULL AUTO_INCREMENT,
+    content    TEXT                                 NOT NULL,
+    sender     ENUM ('ASSISTANT', 'SYSTEM', 'USER') NOT NULL,
+    created_at DATETIME                             NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    chat_id    BIGINT UNSIGNED                      NOT NULL COMMENT 'FK: chat_info',
     PRIMARY KEY (message_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='CS 메시지';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='CS 메시지';
 
-CREATE TABLE chat_handoff (
-    handoff_id    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    assigned_admin_id BIGINT UNSIGNED NULL COMMENT 'FK: admin',
-    `status`      ENUM('ADMIN_WAITING', 'ADMIN_CHECKED', 'ADMIN_ANSWERED') NOT NULL DEFAULT 'ADMIN_WAITING',
-    created_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    chat_id       BIGINT UNSIGNED NOT NULL COMMENT 'FK: chat_info',
+CREATE TABLE chat_handoff
+(
+    handoff_id        BIGINT UNSIGNED                                           NOT NULL AUTO_INCREMENT,
+    assigned_admin_id BIGINT UNSIGNED                                           NULL COMMENT 'FK: admin',
+    `status`          ENUM ('ADMIN_WAITING', 'ADMIN_CHECKED', 'ADMIN_ANSWERED') NOT NULL DEFAULT 'ADMIN_WAITING',
+    created_at        DATETIME                                                  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        DATETIME                                                  NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    chat_id           BIGINT UNSIGNED                                           NOT NULL COMMENT 'FK: chat_info',
     PRIMARY KEY (handoff_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='상담원 연결 요청';
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='상담원 연결 요청';
 
-CREATE TABLE spring_ai_chat_memory (
-   id BIGINT AUTO_INCREMENT PRIMARY KEY,
-   conversation_id VARCHAR(255) NOT NULL,
-   type ENUM('USER', 'ASSISTANT', 'SYSTEM', 'TOOL') NOT NULL,
-   content TEXT NOT NULL,
-   timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='채팅 메모리';
+CREATE TABLE spring_ai_chat_memory
+(
+    id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    conversation_id VARCHAR(255)                                 NOT NULL,
+    type            ENUM ('USER', 'ASSISTANT', 'SYSTEM', 'TOOL') NOT NULL,
+    content         TEXT                                         NOT NULL,
+    timestamp       TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='채팅 메모리';
 
 -- =========================================================
 -- 3. ALTER TABLE (FOREIGN KEYS)
 -- =========================================================
 
 -- [Tag & Category]
-ALTER TABLE tag ADD CONSTRAINT FK_tag_category FOREIGN KEY (tag_category_id) REFERENCES tag_category (tag_category_id);
+ALTER TABLE tag
+    ADD CONSTRAINT FK_tag_category FOREIGN KEY (tag_category_id) REFERENCES tag_category (tag_category_id);
 
 -- [Product Relations]
-ALTER TABLE product ADD CONSTRAINT FK_product_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
-ALTER TABLE product_image ADD CONSTRAINT FK_product_image_product FOREIGN KEY (product_id) REFERENCES product (product_id);
-ALTER TABLE product_tag ADD CONSTRAINT FK_pt_product FOREIGN KEY (product_id) REFERENCES product (product_id);
-ALTER TABLE product_tag ADD CONSTRAINT FK_pt_tag FOREIGN KEY (tag_id) REFERENCES tag (tag_id);
+ALTER TABLE product
+    ADD CONSTRAINT FK_product_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
+ALTER TABLE product_image
+    ADD CONSTRAINT FK_product_image_product FOREIGN KEY (product_id) REFERENCES product (product_id);
+ALTER TABLE product_tag
+    ADD CONSTRAINT FK_pt_product FOREIGN KEY (product_id) REFERENCES product (product_id);
+ALTER TABLE product_tag
+    ADD CONSTRAINT FK_pt_tag FOREIGN KEY (tag_id) REFERENCES tag (tag_id);
 
 -- [Setup Relations]
-ALTER TABLE setup ADD CONSTRAINT FK_setup_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
-ALTER TABLE setup_tag ADD CONSTRAINT FK_st_setup FOREIGN KEY (setup_id) REFERENCES setup (setup_id);
-ALTER TABLE setup_tag ADD CONSTRAINT FK_st_tag FOREIGN KEY (tag_id) REFERENCES tag (tag_id);
-ALTER TABLE setup_product ADD CONSTRAINT FK_sp_setup FOREIGN KEY (setup_id) REFERENCES setup (setup_id);
-ALTER TABLE setup_product ADD CONSTRAINT FK_sp_product FOREIGN KEY (product_id) REFERENCES product (product_id);
+ALTER TABLE setup
+    ADD CONSTRAINT FK_setup_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
+ALTER TABLE setup_tag
+    ADD CONSTRAINT FK_st_setup FOREIGN KEY (setup_id) REFERENCES setup (setup_id);
+ALTER TABLE setup_tag
+    ADD CONSTRAINT FK_st_tag FOREIGN KEY (tag_id) REFERENCES tag (tag_id);
+ALTER TABLE setup_product
+    ADD CONSTRAINT FK_sp_setup FOREIGN KEY (setup_id) REFERENCES setup (setup_id);
+ALTER TABLE setup_product
+    ADD CONSTRAINT FK_sp_product FOREIGN KEY (product_id) REFERENCES product (product_id);
 
 -- [Cart Relations]
-ALTER TABLE cart ADD CONSTRAINT FK_cart_member FOREIGN KEY (member_id) REFERENCES member (member_id);
-ALTER TABLE cart_item ADD CONSTRAINT FK_cart_item_cart FOREIGN KEY (cart_id) REFERENCES cart (cart_id);
-ALTER TABLE cart_item ADD CONSTRAINT FK_cart_item_product FOREIGN KEY (product_id) REFERENCES product (product_id);
+ALTER TABLE cart
+    ADD CONSTRAINT FK_cart_member FOREIGN KEY (member_id) REFERENCES member (member_id);
+ALTER TABLE cart_item
+    ADD CONSTRAINT FK_cart_item_cart FOREIGN KEY (cart_id) REFERENCES cart (cart_id);
+ALTER TABLE cart_item
+    ADD CONSTRAINT FK_cart_item_product FOREIGN KEY (product_id) REFERENCES product (product_id);
 
 -- [Order Relations] (테이블명 `order`에 백틱 사용)
-ALTER TABLE `order` ADD CONSTRAINT FK_order_member FOREIGN KEY (member_id) REFERENCES member (member_id);
-ALTER TABLE order_item ADD CONSTRAINT FK_order_item_order FOREIGN KEY (order_id) REFERENCES `order` (order_id);
-ALTER TABLE order_item ADD CONSTRAINT FK_order_item_product FOREIGN KEY (product_id) REFERENCES product (product_id);
-ALTER TABLE order_item ADD CONSTRAINT FK_order_item_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
+ALTER TABLE `order`
+    ADD CONSTRAINT FK_order_member FOREIGN KEY (member_id) REFERENCES member (member_id);
+ALTER TABLE order_item
+    ADD CONSTRAINT FK_order_item_order FOREIGN KEY (order_id) REFERENCES `order` (order_id);
+ALTER TABLE order_item
+    ADD CONSTRAINT FK_order_item_product FOREIGN KEY (product_id) REFERENCES product (product_id);
+ALTER TABLE order_item
+    ADD CONSTRAINT FK_order_item_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
 
 -- [Broadcast Relations]
-ALTER TABLE broadcast ADD CONSTRAINT FK_broadcast_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
+ALTER TABLE broadcast
+    ADD CONSTRAINT FK_broadcast_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
 -- ALTER TABLE broadcast ADD CONSTRAINT FK_broadcast_tag_cat FOREIGN KEY (tag_category_id) REFERENCES tag_category (tag_category_id); 
 
-ALTER TABLE broadcast_product ADD CONSTRAINT FK_bp_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
-ALTER TABLE broadcast_product ADD CONSTRAINT FK_bp_product FOREIGN KEY (product_id) REFERENCES product (product_id);
+ALTER TABLE broadcast_product
+    ADD CONSTRAINT FK_bp_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
+ALTER TABLE broadcast_product
+    ADD CONSTRAINT FK_bp_product FOREIGN KEY (product_id) REFERENCES product (product_id);
 
-ALTER TABLE vod ADD CONSTRAINT FK_vod_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
-ALTER TABLE qcard ADD CONSTRAINT FK_qcard_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
-ALTER TABLE broadcast_result ADD CONSTRAINT FK_br_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
+ALTER TABLE vod
+    ADD CONSTRAINT FK_vod_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
+ALTER TABLE qcard
+    ADD CONSTRAINT FK_qcard_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
+ALTER TABLE broadcast_result
+    ADD CONSTRAINT FK_br_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
 
 -- [Live Interaction Relations]
-ALTER TABLE view_history ADD CONSTRAINT FK_vh_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
+ALTER TABLE view_history
+    ADD CONSTRAINT FK_vh_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
 # ALTER TABLE view_history ADD CONSTRAINT FK_vh_member FOREIGN KEY (member_id) REFERENCES member (member_id);
 
-ALTER TABLE live_chat ADD CONSTRAINT FK_lc_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
-ALTER TABLE live_chat ADD CONSTRAINT FK_lc_member FOREIGN KEY (member_id) REFERENCES member (member_id);
+ALTER TABLE live_chat
+    ADD CONSTRAINT FK_lc_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
+ALTER TABLE live_chat
+    ADD CONSTRAINT FK_lc_member FOREIGN KEY (member_id) REFERENCES member (member_id);
 
-ALTER TABLE sanction ADD CONSTRAINT FK_sanction_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
-ALTER TABLE sanction ADD CONSTRAINT FK_sanction_member FOREIGN KEY (member_id) REFERENCES member (member_id);
-ALTER TABLE sanction ADD CONSTRAINT FK_sanction_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
-ALTER TABLE sanction ADD CONSTRAINT FK_sanction_admin FOREIGN KEY (admin_id) REFERENCES admin (admin_id);
+ALTER TABLE sanction
+    ADD CONSTRAINT FK_sanction_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
+ALTER TABLE sanction
+    ADD CONSTRAINT FK_sanction_member FOREIGN KEY (member_id) REFERENCES member (member_id);
+ALTER TABLE sanction
+    ADD CONSTRAINT FK_sanction_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
+ALTER TABLE sanction
+    ADD CONSTRAINT FK_sanction_admin FOREIGN KEY (admin_id) REFERENCES admin (admin_id);
 
 -- [Social Relations]
-ALTER TABLE follow ADD CONSTRAINT FK_follow_follower FOREIGN KEY (follower_id) REFERENCES member (member_id);
-ALTER TABLE follow ADD CONSTRAINT FK_follow_following FOREIGN KEY (following_id) REFERENCES seller (seller_id);
-ALTER TABLE notification ADD CONSTRAINT FK_noti_member FOREIGN KEY (member_id) REFERENCES member (member_id);
+ALTER TABLE follow
+    ADD CONSTRAINT FK_follow_follower FOREIGN KEY (follower_id) REFERENCES member (member_id);
+ALTER TABLE follow
+    ADD CONSTRAINT FK_follow_following FOREIGN KEY (following_id) REFERENCES seller (seller_id);
+ALTER TABLE notification
+    ADD CONSTRAINT FK_noti_member FOREIGN KEY (member_id) REFERENCES member (member_id);
 
 -- [Seller Evaluation Relations]
-ALTER TABLE seller_register ADD CONSTRAINT FK_sr_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
+ALTER TABLE seller_register
+    ADD CONSTRAINT FK_sr_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
 
-ALTER TABLE ai_evaluation ADD CONSTRAINT FK_ai_reg FOREIGN KEY (register_id) REFERENCES seller_register (register_id);
-ALTER TABLE ai_evaluation ADD CONSTRAINT FK_ai_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
+ALTER TABLE ai_evaluation
+    ADD CONSTRAINT FK_ai_reg FOREIGN KEY (register_id) REFERENCES seller_register (register_id);
+ALTER TABLE ai_evaluation
+    ADD CONSTRAINT FK_ai_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
 
-ALTER TABLE admin_evaluation ADD CONSTRAINT FK_ae_ai FOREIGN KEY (ai_eval_id) REFERENCES ai_evaluation (ai_eval_id);
+ALTER TABLE admin_evaluation
+    ADD CONSTRAINT FK_ae_ai FOREIGN KEY (ai_eval_id) REFERENCES ai_evaluation (ai_eval_id);
 
-ALTER TABLE company_registered ADD CONSTRAINT FK_cr_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
-ALTER TABLE seller_grade ADD CONSTRAINT FK_sg_company FOREIGN KEY (company_id) REFERENCES company_registered (company_id);
+ALTER TABLE company_registered
+    ADD CONSTRAINT FK_cr_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
+ALTER TABLE seller_grade
+    ADD CONSTRAINT FK_sg_company FOREIGN KEY (company_id) REFERENCES company_registered (company_id);
 
-ALTER TABLE invitation ADD CONSTRAINT FK_invitation_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
+ALTER TABLE invitation
+    ADD CONSTRAINT FK_invitation_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
 
 -- [Payment Relations]
 -- toss_refund의 FK를 toss_payment_key(UNIQUE)에 연결
-ALTER TABLE toss_refund ADD CONSTRAINT FK_refund_payment_key FOREIGN KEY (toss_payment_key) REFERENCES toss_payment (toss_payment_key);
+ALTER TABLE toss_refund
+    ADD CONSTRAINT FK_refund_payment_key FOREIGN KEY (toss_payment_key) REFERENCES toss_payment (toss_payment_key);
 -- toss_webhook_log의 FK를 toss_payment_key(UNIQUE)에 연결
-ALTER TABLE toss_webhook_log ADD CONSTRAINT FK_webhook_payment_key FOREIGN KEY (toss_payment_key) REFERENCES toss_payment (toss_payment_key);
+ALTER TABLE toss_webhook_log
+    ADD CONSTRAINT FK_webhook_payment_key FOREIGN KEY (toss_payment_key) REFERENCES toss_payment (toss_payment_key);
 
 -- [CS Relations]
-ALTER TABLE chat_info ADD CONSTRAINT FK_chat_member FOREIGN KEY (member_id) REFERENCES member (member_id);
-ALTER TABLE chat_message ADD CONSTRAINT FK_msg_chat FOREIGN KEY (chat_id) REFERENCES chat_info (chat_id);
-ALTER TABLE chat_handoff ADD CONSTRAINT FK_handoff_chat FOREIGN KEY (chat_id) REFERENCES chat_info (chat_id);
-ALTER TABLE chat_handoff ADD CONSTRAINT FK_handoff_admin FOREIGN KEY (assigned_admin_id) REFERENCES admin (admin_id);
+ALTER TABLE chat_info
+    ADD CONSTRAINT FK_chat_member FOREIGN KEY (member_id) REFERENCES member (member_id);
+ALTER TABLE chat_message
+    ADD CONSTRAINT FK_msg_chat FOREIGN KEY (chat_id) REFERENCES chat_info (chat_id);
+ALTER TABLE chat_handoff
+    ADD CONSTRAINT FK_handoff_chat FOREIGN KEY (chat_id) REFERENCES chat_info (chat_id);
+ALTER TABLE chat_handoff
+    ADD CONSTRAINT FK_handoff_admin FOREIGN KEY (assigned_admin_id) REFERENCES admin (admin_id);
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/src/main/resources/sql/livecommerce_create_table.sql
+++ b/src/main/resources/sql/livecommerce_create_table.sql
@@ -302,6 +302,7 @@ CREATE TABLE `order`
         'CANCELLED',        -- 주문 취소 완료
         'COMPLETED',        -- 구매 확정 (배송/서비스 완료)
         'REFUND_REQUESTED', -- 환불 요청
+        'REFUND_REJECTED',
         'REFUNDED'          -- 환불 완료
         )                                NOT NULL DEFAULT 'CREATED' COMMENT '주문 상태',
     cancel_reason        VARCHAR(500)    NULL COMMENT '주문 취소 사유',


### PR DESCRIPTION
## 📌 관련 이슈
- closes #139 

## 📝 작업 내용
- 일반회원 주문 조회 API 응답 DTO 기준으로 프론트 ViewModel 구조 정리
- 주문 상태(OrderStatus)별 UI 노출 정책 고정 (버튼/사유 영역/문구)
- 주문 상품 preload + details toggle 기반 상세 로딩 구조 안정화
- 주문 취소/환불 요청 PATCH API 연동 및 상태 분기 처리
- 취소/환불 사유 조회 시 상세 API 기반 지연 로딩 처리