### PR TITLE
Tie live draft to resolved viewer ID, unify viewer ID resolution, filter STOPPED broadcasts, and rework SSE emitters

### DIFF
--- a/front/src/lib/live/viewer.ts
+++ b/front/src/lib/live/viewer.ts
@@ -1,0 +1,38 @@
+import type { AuthUser } from '../auth'
+
+export const resolveViewerId = (user: AuthUser | null): string | null => {
+  const directId =
+    user?.id ??
+    user?.userId ??
+    user?.user_id ??
+    (user as { memberId?: number | string })?.memberId ??
+    (user as { member_id?: number | string })?.member_id ??
+    user?.sellerId ??
+    user?.seller_id
+  if (directId !== null && directId !== undefined) {
+    return String(directId)
+  }
+
+  const access = localStorage.getItem('access') || sessionStorage.getItem('access')
+  if (!access) return null
+  const tokenParts = access.split('.')
+  if (tokenParts.length < 2) return null
+  try {
+    const normalized = tokenParts[1].replace(/-/g, '+').replace(/_/g, '/')
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=')
+    const payload = JSON.parse(atob(padded))
+    const tokenId =
+      payload?.memberId ??
+      payload?.member_id ??
+      payload?.id ??
+      payload?.userId ??
+      payload?.user_id ??
+      payload?.sellerId ??
+      payload?.seller_id ??
+      payload?.sub
+    if (tokenId === null || tokenId === undefined) return null
+    return String(tokenId)
+  } catch {
+    return null
+  }
+}

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -9,6 +9,7 @@ import ConfirmModal from '../components/ConfirmModal.vue'
 import { getLiveStatus, parseLiveDate } from '../lib/live/utils'
 import { useNow } from '../lib/live/useNow'
 import { getAuthUser } from '../lib/auth'
+import { resolveViewerId } from '../lib/live/viewer'
 import { fetchBroadcastProducts, fetchBroadcastStats, fetchPublicBroadcastDetail, type BroadcastProductItem } from '../lib/live/api'
 import type { LiveItem } from '../lib/live/types'
 import { computeLifecycleStatus, getScheduledEndMs, normalizeBroadcastStatus } from '../lib/broadcastStatus'
@@ -348,8 +349,8 @@ const scheduleReconnect = (id: number) => {
 const connectSse = (id: number) => {
   sseSource.value?.close()
   const user = getAuthUser()
-  const viewerId = user?.id ?? user?.userId ?? user?.user_id ?? user?.userId
-  const query = viewerId ? `?viewerId=${encodeURIComponent(String(viewerId))}` : ''
+  const viewerId = resolveViewerId(user)
+  const query = viewerId ? `?viewerId=${encodeURIComponent(viewerId)}` : ''
   const source = new EventSource(`${apiBase}/api/broadcasts/${id}/subscribe${query}`)
   const events = [
     'BROADCAST_READY',
@@ -382,10 +383,8 @@ const connectSse = (id: number) => {
 const startStatsPolling = () => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
-    if (!sseConnected.value) {
-      void loadStats()
-      void loadProducts()
-    }
+    void loadStats()
+    void loadProducts()
   }, 30000)
 }
 

--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -12,6 +12,7 @@ import {useInfiniteScroll} from '../../composables/useInfiniteScroll'
 import {parseLiveDate} from '../../lib/live/utils'
 import {type BroadcastCategory, fetchAdminBroadcasts, fetchCategories} from '../../lib/live/api'
 import { getAuthUser } from '../../lib/auth'
+import { resolveViewerId } from '../../lib/live/viewer'
 
 type LiveTab = 'all' | 'scheduled' | 'live' | 'vod'
 type LoopKind = 'live' | 'scheduled' | 'vod'
@@ -403,8 +404,8 @@ const scheduleReconnect = () => {
 const connectSse = () => {
   sseSource.value?.close()
   const user = getAuthUser()
-  const viewerId = user?.id ?? user?.userId ?? user?.user_id ?? user?.adminId
-  const query = viewerId ? `?viewerId=${encodeURIComponent(String(viewerId))}` : ''
+  const viewerId = resolveViewerId(user)
+  const query = viewerId ? `?viewerId=${encodeURIComponent(viewerId)}` : ''
   const source = new EventSource(`${apiBase}/api/broadcasts/subscribe/all${query}`)
   const events = [
     'BROADCAST_READY',

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -365,10 +365,8 @@ const connectSse = (broadcastId: number) => {
 const startStatsPolling = (broadcastId: number) => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
-    if (!sseConnected.value) {
-      void refreshStats(broadcastId)
-      void refreshProducts(broadcastId)
-    }
+    void refreshStats(broadcastId)
+    void refreshProducts(broadcastId)
   }, 30000)
 }
 

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -15,6 +15,7 @@ import {
 } from '../../lib/live/api'
 import { parseLiveDate } from '../../lib/live/utils'
 import { getAuthUser } from '../../lib/auth'
+import { resolveViewerId } from '../../lib/live/viewer'
 import { computeLifecycleStatus, getScheduledEndMs, normalizeBroadcastStatus, type BroadcastStatus } from '../../lib/broadcastStatus'
 
 type StreamProduct = {
@@ -482,8 +483,8 @@ const connectSse = (broadcastId: number) => {
     sseSource.value.close()
   }
   const user = getAuthUser()
-  const viewerId = user?.id ?? user?.userId ?? user?.user_id ?? user?.sellerId
-  const query = viewerId ? `?viewerId=${encodeURIComponent(String(viewerId))}` : ''
+  const viewerId = resolveViewerId(user)
+  const query = viewerId ? `?viewerId=${encodeURIComponent(viewerId)}` : ''
   const source = new EventSource(`${apiBase}/api/broadcasts/${broadcastId}/subscribe${query}`)
   const events = [
     'BROADCAST_READY',
@@ -518,10 +519,8 @@ const connectSse = (broadcastId: number) => {
 const startStatsPolling = (broadcastId: number) => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
-    if (!sseConnected.value) {
-      void refreshStats(broadcastId)
-      void refreshProducts(broadcastId)
-    }
+    void refreshStats(broadcastId)
+    void refreshProducts(broadcastId)
   }, 30000)
 }
 

--- a/src/main/java/com/deskit/deskit/livehost/repository/BroadcastRepositoryImpl.java
+++ b/src/main/java/com/deskit/deskit/livehost/repository/BroadcastRepositoryImpl.java
@@ -208,6 +208,8 @@ public class BroadcastRepositoryImpl implements BroadcastRepositoryCustom {
         return broadcastStatus.in(
                         BroadcastStatus.ON_AIR.name(),
                         BroadcastStatus.READY.name(),
+                        BroadcastStatus.ENDED.name(),
+                        BroadcastStatus.STOPPED.name(),
                         BroadcastStatus.RESERVED.name()
                 )
                 .or(vodStatus.eq(VodStatus.PUBLIC.name()));
@@ -236,13 +238,18 @@ public class BroadcastRepositoryImpl implements BroadcastRepositoryCustom {
             return trueCondition();
         }
         if ("LIVE".equalsIgnoreCase(tab)) {
-            return broadcastStatus.in(BroadcastStatus.ON_AIR.name(), BroadcastStatus.READY.name());
+            return broadcastStatus.in(
+                    BroadcastStatus.ON_AIR.name(),
+                    BroadcastStatus.READY.name(),
+                    BroadcastStatus.ENDED.name(),
+                    BroadcastStatus.STOPPED.name()
+            );
         }
         if ("RESERVED".equalsIgnoreCase(tab)) {
             return broadcastStatus.in(BroadcastStatus.RESERVED.name(), BroadcastStatus.CANCELED.name());
         }
         if ("VOD".equalsIgnoreCase(tab)) {
-            return broadcastStatus.in(BroadcastStatus.VOD.name(), BroadcastStatus.ENDED.name(), BroadcastStatus.STOPPED.name());
+            return broadcastStatus.in(BroadcastStatus.VOD.name());
         }
         return trueCondition();
     }

--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -1170,19 +1170,19 @@ public class BroadcastService {
     private BroadcastAllResponse getOverview(Long sellerId, boolean isAdmin) {
         List<BroadcastListResponse> onAir = broadcastRepository.findTop5ByStatus(
                 sellerId,
-                List.of(BroadcastStatus.ON_AIR, BroadcastStatus.READY),
+                List.of(BroadcastStatus.ON_AIR, BroadcastStatus.READY, BroadcastStatus.ENDED, BroadcastStatus.STOPPED),
                 BroadcastRepositoryCustom.BroadcastSortOrder.STARTED_AT_DESC,
                 isAdmin
         );
         List<BroadcastListResponse> reserved = broadcastRepository.findTop5ByStatus(
                 sellerId,
-                List.of(BroadcastStatus.RESERVED),
+                isAdmin ? List.of(BroadcastStatus.RESERVED, BroadcastStatus.CANCELED) : List.of(BroadcastStatus.RESERVED),
                 BroadcastRepositoryCustom.BroadcastSortOrder.SCHEDULED_AT_ASC,
                 isAdmin
         );
         List<BroadcastListResponse> vod = broadcastRepository.findTop5ByStatus(
                 sellerId,
-                List.of(BroadcastStatus.VOD, BroadcastStatus.ENDED, BroadcastStatus.STOPPED),
+                List.of(BroadcastStatus.VOD),
                 BroadcastRepositoryCustom.BroadcastSortOrder.ENDED_AT_DESC,
                 isAdmin
         );


### PR DESCRIPTION
### Motivation
- Ensure live broadcast drafts are persisted per current seller identity by deriving ownership from the resolved viewer id (including token claims) and avoid cross-user draft restoration.
- Centralize viewer id resolution to handle varied auth payload shapes and base64url JWT payloads for SSE subscription queries.
- Prevent irrelevant STOPPED broadcasts from appearing in public schedules after their scheduled end while keeping lifecycle grouping consistent.
- Make SSE emitter management more robust and enable per-connection semantics for targeted and global notifications.

### Description
- Frontend: added `front/src/lib/live/viewer.ts` with `resolveViewerId()` and replaced ad-hoc viewer id extraction with `resolveViewerId()` across `Live.vue`, `LiveDetail.vue`, `admin/AdminLive.vue`, `admin/live/LiveDetail.vue`, `seller/Live.vue`, and `seller/LiveStream.vue` to build SSE query strings.
- Frontend: updated `front/src/composables/useLiveCreateDraft.ts` to use the resolved viewer id for `DRAFT_KEY` ownership and to clear stored drafts when the logged-in seller identity changes.
- Frontend: filter logic in `front/src/pages/Live.vue` (and related views) now hides items whose lifecycle is `CANCELED` or `STOPPED` when their scheduled end has passed by using a new `isPastScheduledEnd()` check, and several places were simplified to always poll stats instead of conditionally polling when SSE is disconnected.
- Backend: updated `BroadcastRepositoryImpl.java` and `BroadcastService.java` to include `ENDED`/`STOPPED` in live/on-air result sets and to restrict `VOD` tab/filtering to `VOD` status only; and reworked `SseService.java` to use unique per-connection keys (UUID-backed), send an initial `connect` event, remove emitters on completion/timeout/error, and perform prefix-based fan-out for per-broadcast and per-user notifications with helper builders `buildBroadcastKey()` and `buildAllKey()`.

### Testing
- No automated tests were executed for these changes.
- Recommend running the frontend dev server (`npm run dev -- --host`) and backend (`./gradlew bootRun`) and CI build pipelines to validate integration, SSE behavior, and lifecycle visibility after merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960a0e826248324b1388aafa78d83ae)