### PR TITLE
Mark products sold out at safetyStock and push sold-out items to bottom of admin panel

### DIFF
--- a/front/src/composables/useLiveCreateDraft.ts
+++ b/front/src/composables/useLiveCreateDraft.ts
@@ -1,4 +1,4 @@
-import { getAuthUser } from '../lib/auth'
+import { getAuthUser, isSeller } from '../lib/auth'
 import { resolveViewerId } from '../lib/live/viewer'
 import { fetchSellerBroadcastDetail, type BroadcastDetailResponse } from '../lib/live/api'
 
@@ -40,6 +40,7 @@ type StoredDraft = {
 
 const resolveSellerKey = () => {
   const user = getAuthUser()
+  if (!user || !isSeller()) return ''
   return resolveViewerId(user) ?? ''
 }
 

--- a/front/src/pages/Live.vue
+++ b/front/src/pages/Live.vue
@@ -348,6 +348,7 @@ const handleSseEvent = (event: MessageEvent) => {
     case 'BROADCAST_UPDATED':
     case 'BROADCAST_STARTED':
     case 'PRODUCT_PINNED':
+    case 'PRODUCT_SOLD_OUT':
     case 'SANCTION_UPDATED':
     case 'BROADCAST_CANCELED':
     case 'BROADCAST_ENDED':
@@ -381,6 +382,7 @@ const connectSse = () => {
     'BROADCAST_UPDATED',
     'BROADCAST_STARTED',
     'PRODUCT_PINNED',
+    'PRODUCT_SOLD_OUT',
     'SANCTION_UPDATED',
     'BROADCAST_CANCELED',
     'BROADCAST_ENDED',

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -307,6 +307,7 @@ const handleSseEvent = (event: MessageEvent) => {
       scheduleRefresh()
       break
     case 'PRODUCT_PINNED':
+    case 'PRODUCT_SOLD_OUT':
       scheduleRefresh()
       break
     case 'SANCTION_ALERT':
@@ -327,6 +328,13 @@ const handleSseEvent = (event: MessageEvent) => {
       }
       break
     case 'BROADCAST_STOPPED':
+      if (liveItem.value) {
+        liveItem.value = {
+          ...liveItem.value,
+          status: 'STOPPED',
+        }
+      }
+      scheduleRefresh()
       if (window.confirm(typeof data === 'string' ? data : '관리자에 의해 방송이 중지되었습니다.')) {
         router.push({ name: 'live' }).catch(() => {})
       }
@@ -357,6 +365,7 @@ const connectSse = (id: number) => {
     'BROADCAST_UPDATED',
     'BROADCAST_STARTED',
     'PRODUCT_PINNED',
+    'PRODUCT_SOLD_OUT',
     'SANCTION_ALERT',
     'BROADCAST_ENDING_SOON',
     'BROADCAST_CANCELED',

--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -379,6 +379,7 @@ const handleSseEvent = (event: MessageEvent) => {
     case 'BROADCAST_UPDATED':
     case 'BROADCAST_STARTED':
     case 'PRODUCT_PINNED':
+    case 'PRODUCT_SOLD_OUT':
     case 'SANCTION_UPDATED':
     case 'BROADCAST_CANCELED':
     case 'BROADCAST_ENDED':
@@ -412,6 +413,7 @@ const connectSse = () => {
     'BROADCAST_UPDATED',
     'BROADCAST_STARTED',
     'PRODUCT_PINNED',
+    'PRODUCT_SOLD_OUT',
     'SANCTION_UPDATED',
     'BROADCAST_CANCELED',
     'BROADCAST_ENDED',

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -141,6 +141,15 @@ const mapLiveProduct = (item: {
   }
 }
 
+const sortedLiveProducts = computed(() => {
+  return [...liveProducts.value].sort((a, b) => {
+    const aSoldOut = a.status === '품절'
+    const bSoldOut = b.status === '품절'
+    if (aSoldOut !== bSoldOut) return aSoldOut ? 1 : -1
+    return 0
+  })
+})
+
 const loadDetail = async () => {
   if (!liveId.value) {
     detail.value = null
@@ -288,6 +297,7 @@ const handleSseEvent = (event: MessageEvent) => {
       scheduleRefresh(idValue)
       break
     case 'PRODUCT_PINNED':
+    case 'PRODUCT_SOLD_OUT':
       scheduleRefresh(idValue)
       break
     case 'SANCTION_UPDATED':
@@ -310,6 +320,7 @@ const handleSseEvent = (event: MessageEvent) => {
       if (detail.value) {
         detail.value.status = 'STOPPED'
       }
+      scheduleRefresh(idValue)
       if (window.confirm(typeof data === 'string' ? data : '관리자에 의해 방송이 중지되었습니다.')) {
         goToList()
       }
@@ -339,6 +350,7 @@ const connectSse = (broadcastId: number) => {
     'BROADCAST_UPDATED',
     'BROADCAST_STARTED',
     'PRODUCT_PINNED',
+    'PRODUCT_SOLD_OUT',
     'SANCTION_UPDATED',
     'BROADCAST_ENDING_SOON',
     'BROADCAST_CANCELED',
@@ -675,7 +687,7 @@ watch(
             <span class="pill">총 {{ liveProducts.length }}개</span>
           </header>
           <div class="product-list">
-            <article v-for="product in liveProducts" :key="product.id" class="product-row">
+            <article v-for="product in sortedLiveProducts" :key="product.id" class="product-row">
               <div class="product-thumb">
                 <img :src="product.thumb" :alt="product.name" loading="lazy" @error="handleImageError" />
               </div>

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -390,6 +390,7 @@ const handleSseEvent = (event: MessageEvent) => {
     case 'BROADCAST_UPDATED':
     case 'BROADCAST_STARTED':
     case 'PRODUCT_PINNED':
+    case 'PRODUCT_SOLD_OUT':
     case 'SANCTION_UPDATED':
     case 'BROADCAST_CANCELED':
     case 'BROADCAST_ENDED':
@@ -423,6 +424,7 @@ const connectSse = () => {
     'BROADCAST_UPDATED',
     'BROADCAST_STARTED',
     'PRODUCT_PINNED',
+    'PRODUCT_SOLD_OUT',
     'SANCTION_UPDATED',
     'BROADCAST_CANCELED',
     'BROADCAST_ENDED',

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -439,6 +439,9 @@ const handleSseEvent = (event: MessageEvent) => {
       pinnedProductId.value = typeof data === 'number' ? String(data) : pinnedProductId.value
       scheduleRefresh(id)
       break
+    case 'PRODUCT_SOLD_OUT':
+      scheduleRefresh(id)
+      break
     case 'SANCTION_UPDATED':
       scheduleRefresh(id)
       break
@@ -459,7 +462,9 @@ const handleSseEvent = (event: MessageEvent) => {
       }
       break
     case 'BROADCAST_STOPPED':
-      if (window.confirm('관리자에 의해 방송이 중지되었습니다.')) {
+      streamStatus.value = 'STOPPED'
+      scheduleRefresh(id)
+      if (window.confirm(typeof data === 'string' ? data : '관리자에 의해 방송이 중지되었습니다.')) {
         handleGoToList()
       }
       break
@@ -491,6 +496,7 @@ const connectSse = (broadcastId: number) => {
     'BROADCAST_UPDATED',
     'BROADCAST_STARTED',
     'PRODUCT_PINNED',
+    'PRODUCT_SOLD_OUT',
     'SANCTION_UPDATED',
     'BROADCAST_ENDING_SOON',
     'BROADCAST_CANCELED',

--- a/src/main/java/com/deskit/deskit/livehost/entity/BroadcastProduct.java
+++ b/src/main/java/com/deskit/deskit/livehost/entity/BroadcastProduct.java
@@ -56,5 +56,17 @@ public class BroadcastProduct {
     @Column(name = "updated_at", nullable = false)
     @UpdateTimestamp
     private LocalDateTime updatedAt;
-}
 
+    public boolean markSoldOutIfNeeded(Integer stockQty, Integer safetyStock) {
+        int safeStock = safetyStock == null ? 0 : safetyStock;
+        int remaining = stockQty == null ? 0 : stockQty;
+        if (remaining > safeStock) {
+            return false;
+        }
+        if (status == BroadcastProductStatus.SOLDOUT) {
+            return false;
+        }
+        status = BroadcastProductStatus.SOLDOUT;
+        return true;
+    }
+}


### PR DESCRIPTION
### Motivation
- Treat a product as sold-out when its `stockQty` reaches the `safetyStock` threshold so near-empty items are considered unavailable earlier.
- Notify connected clients of sold-out transitions so UIs can refresh immediately via existing SSE channels.
- Improve admin product UX by moving sold-out items to the end of the products list for better prioritization.

### Description
- Updated `BroadcastProduct.markSoldOutIfNeeded` to accept `stockQty` and `safetyStock` and mark a product sold out when `stockQty <= safetyStock`.
- Changed `BroadcastService.getBroadcastProducts` to call the new method, collect affected product IDs, and emit `PRODUCT_SOLD_OUT` via `sseService.notifyBroadcastUpdate` when applicable.
- Wired `PRODUCT_SOLD_OUT` SSE handling into multiple frontend pages (`Live.vue`, `LiveDetail.vue`, `AdminLive.vue`, `seller/Live.vue`, `seller/LiveStream.vue`) to trigger `scheduleRefresh()` for affected views.
- In the admin broadcast detail page (`front/src/pages/admin/live/LiveDetail.vue`) added `sortedLiveProducts` and render that list so sold-out items are shown after active products.

### Testing
- No automated unit or integration tests were executed for these changes.
- No CI build or local `./gradlew build` / `npm run dev` runs were executed to verify the runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960aad28fd0832a80c3b7f20081653b)