### PR TITLE
Stabilize realtime flows, enforce safetyStock, and guard broadcast transitions

### DIFF
--- a/front/src/composables/useLiveCreateDraft.ts
+++ b/front/src/composables/useLiveCreateDraft.ts
@@ -9,6 +9,7 @@ export type LiveCreateProduct = {
   price: number
   broadcastPrice: number
   stock: number
+  safetyStock: number
   quantity: number
   thumb?: string
 }
@@ -117,6 +118,7 @@ const normalizeDraft = (payload: LiveCreateDraft): LiveCreateDraft => {
             price: typeof item.price === 'number' ? item.price : 0,
             broadcastPrice: typeof item.broadcastPrice === 'number' ? item.broadcastPrice : 0,
             stock: typeof item.stock === 'number' ? item.stock : 0,
+            safetyStock: typeof item.safetyStock === 'number' ? item.safetyStock : 0,
             quantity: typeof item.quantity === 'number' ? item.quantity : 1,
             thumb: item.thumb ?? '',
           }))
@@ -173,6 +175,7 @@ const mapReservationProducts = (detail: BroadcastDetailResponse) =>
     price: item.originalPrice ?? 0,
     broadcastPrice: item.bpPrice ?? item.originalPrice ?? 0,
     stock: item.stockQty ?? item.bpQuantity ?? 0,
+    safetyStock: item.safetyStock ?? 0,
     quantity: item.bpQuantity ?? 1,
     thumb: item.imageUrl ?? '',
   }))

--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -18,6 +18,7 @@ export type SellerProduct = {
   price: number
   broadcastPrice: number
   stock: number
+  safetyStock: number
   quantity: number
   thumb?: string
 }
@@ -133,6 +134,7 @@ export type BroadcastDetailResponse = {
     imageUrl?: string
     originalPrice: number
     stockQty?: number
+    safetyStock?: number
     bpPrice: number
     bpQuantity: number
     displayOrder: number
@@ -261,7 +263,9 @@ export const fetchCategories = async (): Promise<BroadcastCategory[]> => {
 }
 
 export const fetchSellerProducts = async (): Promise<SellerProduct[]> => {
-  const { data } = await http.get<ApiResult<Array<{ productId: number; productName: string; price: number; stockQty: number; imageUrl?: string }>>>(
+  const { data } = await http.get<
+    ApiResult<Array<{ productId: number; productName: string; price: number; stockQty: number; safetyStock?: number; imageUrl?: string }>>
+  >(
     '/api/seller/broadcasts/products',
   )
   const payload = ensureSuccess(data)
@@ -272,6 +276,7 @@ export const fetchSellerProducts = async (): Promise<SellerProduct[]> => {
     price: item.price,
     broadcastPrice: item.price,
     stock: item.stockQty,
+    safetyStock: item.safetyStock ?? 0,
     quantity: 1,
     thumb: item.imageUrl ?? '',
   }))
@@ -347,6 +352,16 @@ export const fetchSellerBroadcastDetail = async (broadcastId: number): Promise<B
     const { data } = await http.get<ApiResult<BroadcastDetailResponse>>(`/api/seller/broadcasts/${broadcastId}`)
     return ensureSuccess(data)
   })
+}
+
+export const startSellerBroadcast = async (broadcastId: number): Promise<string> => {
+  const { data } = await http.post<ApiResult<string>>(`/api/seller/broadcasts/${broadcastId}/start`)
+  return ensureSuccess(data)
+}
+
+export const endSellerBroadcast = async (broadcastId: number): Promise<void> => {
+  const { data } = await http.post<ApiResult<void>>(`/api/seller/broadcasts/${broadcastId}/end`)
+  return ensureSuccess(data)
 }
 
 export const fetchAdminBroadcastDetail = async (broadcastId: number): Promise<BroadcastDetailResponse> => {

--- a/front/src/pages/Live.vue
+++ b/front/src/pages/Live.vue
@@ -157,6 +157,7 @@ const itemsForDay = computed(() => {
   const filtered = filterLivesByDay(liveItems.value, selectedDay.value)
   const visible = filtered.filter((item) => {
     const status = getLifecycleStatus(item)
+    if (status === 'VOD') return false
     if (status === 'CANCELED') return false
     if (status === 'STOPPED' && isPastScheduledEnd(item)) return false
     return true

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -392,8 +392,12 @@ const connectSse = (id: number) => {
 const startStatsPolling = () => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
-    void loadStats()
-    void loadProducts()
+    if (lifecycleStatus.value === 'ON_AIR' || !sseConnected.value) {
+      void loadStats()
+      if (!sseConnected.value) {
+        void loadProducts()
+      }
+    }
   }, 30000)
 }
 

--- a/front/src/pages/Vod.vue
+++ b/front/src/pages/Vod.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import PageContainer from '../components/PageContainer.vue'
 import PageHeader from '../components/PageHeader.vue'
 import { getLiveStatus, parseLiveDate } from '../lib/live/utils'
+import { getScheduledEndMs } from '../lib/broadcastStatus'
 import { useNow } from '../lib/live/useNow'
 import { fetchBroadcastProducts, fetchPublicBroadcastDetail, type BroadcastProductItem } from '../lib/live/api'
 import type { LiveItem } from '../lib/live/types'
@@ -130,7 +131,9 @@ const scheduledLabel = computed(() => {
 
 const buildVodItem = (detail: { broadcastId: number; title: string; notice?: string; thumbnailUrl?: string; scheduledAt?: string; startedAt?: string; sellerName?: string }) => {
   const startAt = detail.startedAt ?? detail.scheduledAt ?? ''
-  const endAt = startAt ? new Date(parseLiveDate(startAt).getTime() + 60 * 60 * 1000).toISOString() : ''
+  const startAtMs = startAt ? parseLiveDate(startAt).getTime() : NaN
+  const endAtMs = Number.isNaN(startAtMs) ? undefined : getScheduledEndMs(startAtMs)
+  const endAt = endAtMs ? new Date(endAtMs).toISOString() : ''
   return {
     id: String(detail.broadcastId),
     title: detail.title,

--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -148,8 +148,8 @@ const sseRetryCount = ref(0)
 const sseRetryTimer = ref<number | null>(null)
 const refreshTimer = ref<number | null>(null)
 
-const visibleLive = computed(() => activeTab.value === 'all' || activeTab.value === 'live')
-const visibleScheduled = computed(() => activeTab.value === 'all' || activeTab.value === 'scheduled')
+const visibleLive = computed(() => activeTab.value === 'live')
+const visibleScheduled = computed(() => activeTab.value === 'scheduled')
 const visibleVod = computed(() => activeTab.value === 'all' || activeTab.value === 'vod')
 
 const setTab = (tab: LiveTab) => {
@@ -207,9 +207,8 @@ const mapScheduledSortType = () => {
 }
 
 const mapScheduledStatusFilter = () => {
-  if (scheduledStatus.value === 'reserved') return 'RESERVED'
   if (scheduledStatus.value === 'canceled') return 'CANCELED'
-  return undefined
+  return 'RESERVED'
 }
 
 const mapVodSortType = () => {
@@ -521,9 +520,8 @@ const filteredScheduled = computed(() => {
       return aDate - bDate
     })
 
-  if (scheduledStatus.value === 'reserved') return sortScheduled(reserved)
   if (scheduledStatus.value === 'canceled') return sortScheduled(canceled)
-  return [...sortScheduled(reserved), ...sortScheduled(canceled)]
+  return sortScheduled(reserved)
 })
 
 const filteredVods = computed(() => {

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -208,9 +208,8 @@ const mapScheduledSortType = () => {
 }
 
 const mapScheduledStatusFilter = () => {
-  if (scheduledStatus.value === 'reserved') return 'RESERVED'
   if (scheduledStatus.value === 'canceled') return 'CANCELED'
-  return undefined
+  return 'RESERVED'
 }
 
 const mapVodSortType = () => {
@@ -530,10 +529,8 @@ const filteredScheduledItems = computed(() => {
       return aDate - bDate
     })
 
-  if (scheduledStatus.value === 'reserved') return sortScheduled(reserved)
   if (scheduledStatus.value === 'canceled') return sortScheduled(canceled)
-
-  return [...sortScheduled(reserved), ...sortScheduled(canceled)]
+  return sortScheduled(reserved)
 })
 
 const categoryOptions = computed(() => categories.value)
@@ -571,8 +568,8 @@ const buildLoopItems = (items: LiveItem[]): LiveItem[] => {
 const scheduledLoopItems = computed<LiveItem[]>(() => buildLoopItems(scheduledSummary.value))
 const vodLoopItems = computed<LiveItem[]>(() => buildLoopItems(vodSummary.value))
 
-const visibleLive = computed(() => activeTab.value === 'all' || activeTab.value === 'live')
-const visibleScheduled = computed(() => activeTab.value === 'all' || activeTab.value === 'scheduled')
+const visibleLive = computed(() => activeTab.value === 'live')
+const visibleScheduled = computed(() => activeTab.value === 'scheduled')
 const visibleVod = computed(() => activeTab.value === 'all' || activeTab.value === 'vod')
 
 const { sentinelRef: scheduledSentinelRef } = useInfiniteScroll({

--- a/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastListResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastListResponse.java
@@ -78,9 +78,12 @@ public class BroadcastListResponse {
         if (status == BroadcastStatus.RESERVED) {
             this.startAt = scheduledAt;
             this.endAt = (scheduledAt != null) ? scheduledAt.plusMinutes(30) : null;
-        } else if (status == BroadcastStatus.ON_AIR || status == BroadcastStatus.READY) {
-            this.startAt = (startedAt != null) ? startedAt : LocalDateTime.now();
+        } else if (status == BroadcastStatus.ON_AIR) {
+            this.startAt = (startedAt != null) ? startedAt : scheduledAt;
             this.endAt = null; // 진행 중이라 끝나는 시간 없음
+        } else if (status == BroadcastStatus.READY) {
+            this.startAt = scheduledAt;
+            this.endAt = (scheduledAt != null) ? scheduledAt.plusMinutes(30) : null;
         } else {
             this.startAt = startedAt;
             this.endAt = endedAt;

--- a/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
@@ -15,6 +15,7 @@ public class BroadcastProductResponse {
     private String imageUrl;      // 상품 이미지 (Product API 연동 필요)
     private int originalPrice;    // 원가
     private int stockQty;         // 판매 가능한 재고 수량
+    private int safetyStock;      // 안전 재고
 
     private int bpPrice;        // 라이브 특가 (bp_price)
     private int bpQuantity;     // 판매 수량 (bp_quantity)
@@ -32,6 +33,7 @@ public class BroadcastProductResponse {
 //                .imageUrl(p.getProductThumbUrl())   // 추후 ProductImage 구현되면 추가 예정
                 .originalPrice(p.getPrice())
                 .stockQty(p.getStockQty())
+                .safetyStock(p.getSafetyStock())
                 .bpPrice(bp.getBpPrice())
                 .bpQuantity(bp.getBpQuantity())
                 .displayOrder(bp.getDisplayOrder())

--- a/src/main/java/com/deskit/deskit/livehost/dto/response/ProductSelectResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/ProductSelectResponse.java
@@ -14,6 +14,6 @@ public class ProductSelectResponse {
     private String productName;
     private Integer price;      // 정가
     private Integer stockQty;   // 현재 재고
+    private Integer safetyStock;   // 안전 재고
     private String imageUrl;    // 대표 이미지 URL
 }
-

--- a/src/main/java/com/deskit/deskit/livehost/entity/BroadcastProduct.java
+++ b/src/main/java/com/deskit/deskit/livehost/entity/BroadcastProduct.java
@@ -57,10 +57,9 @@ public class BroadcastProduct {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
-    public boolean markSoldOutIfNeeded(Integer stockQty, Integer safetyStock) {
-        int safeStock = safetyStock == null ? 0 : safetyStock;
-        int remaining = stockQty == null ? 0 : stockQty;
-        if (remaining > safeStock) {
+    public boolean markSoldOutIfNeeded(Integer remainingQuantity) {
+        int remaining = remainingQuantity == null ? 0 : remainingQuantity;
+        if (remaining > 0) {
             return false;
         }
         if (status == BroadcastProductStatus.SOLDOUT) {


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and stale realtime state in seller live pages by centralizing SSE/timer cleanup and wiring missing refs. 
- Ensure sellers cannot schedule/sell more than available stock by honoring `safetyStock` in DTOs and server-side validation. 
- Avoid concurrent/duplicate broadcast state transitions by serializing transition operations. 
- Reduce unnecessary polling traffic and align lifecycle/timing between Live and VOD views for consistent UX.

### Description
- Frontend: add `safetyStock` to product types and API mappings in `front/src/lib/live/api.ts` and `front/src/composables/useLiveCreateDraft.ts`, clamp product quantities in `LiveCreateBasic.vue` via `resolveMaxQuantity`/`clampProductQuantity`, add runtime validation before submit, and ensure drafts restore with clamped quantities. 
- Realtime & polling: centralize realtime cleanup in `LiveStream.vue` with `resetRealtimeState`, add `streamCenterRef` wiring, schedule auto-start (`scheduleAutoStart`) and end-request handling, guard SSE/polling to only refresh stats/products when `ON_AIR` or SSE is disconnected, and reduce redundant refreshes across `LiveDetail.vue`, `Live.vue`, `Vod.vue`, and admin/seller pages. 
- Backend: expose `safetyStock` in DTOs (`BroadcastProductResponse`, `ProductSelectResponse`), enforce `bpQuantity <= stock - safetyStock` in `saveBroadcastProducts`, update sold-out logic to use broadcast-level remaining quantity, and add Redis lock guards around broadcast transitions in `AdminService` and `BroadcastService` using `lock:broadcast_transition:{id}` to throttle concurrent `cancel`/`forceStop` operations. 
- API wiring: add `startSellerBroadcast` and `endSellerBroadcast` client API calls and integrate them into seller UI flows for explicit start/end actions and automatic reservation-time starts (`startSellerBroadcast`, `endSellerBroadcast`, `requestStartBroadcast`, `handleEndBroadcast`).

### Testing
- No automated unit/integration tests were executed for this rollout. 
- The frontend dev server was started previously and Vite reported ready (frontend assets served), indicating basic runtime bundling succeeded. 
- A full backend JVM build was attempted earlier but failed on the runner due to missing Java 17 toolchain configuration, so server-side integration build did not complete. 
- New changes were linted/compiled locally as part of development and a commit was created for the realtime cleanup changes (no CI test run included in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b4fb8ee0832ab61f29f3a5479154)