### PR TITLE
Show live/scheduled on All tab; enforce safetyStock and guard transitions

### DIFF
--- a/front/src/composables/useLiveCreateDraft.ts
+++ b/front/src/composables/useLiveCreateDraft.ts
@@ -9,6 +9,7 @@ export type LiveCreateProduct = {
   price: number
   broadcastPrice: number
   stock: number
+  safetyStock: number
   quantity: number
   thumb?: string
 }
@@ -117,6 +118,7 @@ const normalizeDraft = (payload: LiveCreateDraft): LiveCreateDraft => {
             price: typeof item.price === 'number' ? item.price : 0,
             broadcastPrice: typeof item.broadcastPrice === 'number' ? item.broadcastPrice : 0,
             stock: typeof item.stock === 'number' ? item.stock : 0,
+            safetyStock: typeof item.safetyStock === 'number' ? item.safetyStock : 0,
             quantity: typeof item.quantity === 'number' ? item.quantity : 1,
             thumb: item.thumb ?? '',
           }))
@@ -173,6 +175,7 @@ const mapReservationProducts = (detail: BroadcastDetailResponse) =>
     price: item.originalPrice ?? 0,
     broadcastPrice: item.bpPrice ?? item.originalPrice ?? 0,
     stock: item.stockQty ?? item.bpQuantity ?? 0,
+    safetyStock: item.safetyStock ?? 0,
     quantity: item.bpQuantity ?? 1,
     thumb: item.imageUrl ?? '',
   }))

--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -18,6 +18,7 @@ export type SellerProduct = {
   price: number
   broadcastPrice: number
   stock: number
+  safetyStock: number
   quantity: number
   thumb?: string
 }
@@ -133,6 +134,7 @@ export type BroadcastDetailResponse = {
     imageUrl?: string
     originalPrice: number
     stockQty?: number
+    safetyStock?: number
     bpPrice: number
     bpQuantity: number
     displayOrder: number
@@ -261,7 +263,9 @@ export const fetchCategories = async (): Promise<BroadcastCategory[]> => {
 }
 
 export const fetchSellerProducts = async (): Promise<SellerProduct[]> => {
-  const { data } = await http.get<ApiResult<Array<{ productId: number; productName: string; price: number; stockQty: number; imageUrl?: string }>>>(
+  const { data } = await http.get<
+    ApiResult<Array<{ productId: number; productName: string; price: number; stockQty: number; safetyStock?: number; imageUrl?: string }>>
+  >(
     '/api/seller/broadcasts/products',
   )
   const payload = ensureSuccess(data)
@@ -272,6 +276,7 @@ export const fetchSellerProducts = async (): Promise<SellerProduct[]> => {
     price: item.price,
     broadcastPrice: item.price,
     stock: item.stockQty,
+    safetyStock: item.safetyStock ?? 0,
     quantity: 1,
     thumb: item.imageUrl ?? '',
   }))
@@ -347,6 +352,16 @@ export const fetchSellerBroadcastDetail = async (broadcastId: number): Promise<B
     const { data } = await http.get<ApiResult<BroadcastDetailResponse>>(`/api/seller/broadcasts/${broadcastId}`)
     return ensureSuccess(data)
   })
+}
+
+export const startSellerBroadcast = async (broadcastId: number): Promise<string> => {
+  const { data } = await http.post<ApiResult<string>>(`/api/seller/broadcasts/${broadcastId}/start`)
+  return ensureSuccess(data)
+}
+
+export const endSellerBroadcast = async (broadcastId: number): Promise<void> => {
+  const { data } = await http.post<ApiResult<void>>(`/api/seller/broadcasts/${broadcastId}/end`)
+  return ensureSuccess(data)
 }
 
 export const fetchAdminBroadcastDetail = async (broadcastId: number): Promise<BroadcastDetailResponse> => {

--- a/front/src/pages/Live.vue
+++ b/front/src/pages/Live.vue
@@ -157,6 +157,7 @@ const itemsForDay = computed(() => {
   const filtered = filterLivesByDay(liveItems.value, selectedDay.value)
   const visible = filtered.filter((item) => {
     const status = getLifecycleStatus(item)
+    if (status === 'VOD') return false
     if (status === 'CANCELED') return false
     if (status === 'STOPPED' && isPastScheduledEnd(item)) return false
     return true

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -392,8 +392,12 @@ const connectSse = (id: number) => {
 const startStatsPolling = () => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
-    void loadStats()
-    void loadProducts()
+    if (lifecycleStatus.value === 'ON_AIR' || !sseConnected.value) {
+      void loadStats()
+      if (!sseConnected.value) {
+        void loadProducts()
+      }
+    }
   }, 30000)
 }
 

--- a/front/src/pages/Vod.vue
+++ b/front/src/pages/Vod.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import PageContainer from '../components/PageContainer.vue'
 import PageHeader from '../components/PageHeader.vue'
 import { getLiveStatus, parseLiveDate } from '../lib/live/utils'
+import { getScheduledEndMs } from '../lib/broadcastStatus'
 import { useNow } from '../lib/live/useNow'
 import { fetchBroadcastProducts, fetchPublicBroadcastDetail, type BroadcastProductItem } from '../lib/live/api'
 import type { LiveItem } from '../lib/live/types'
@@ -130,7 +131,9 @@ const scheduledLabel = computed(() => {
 
 const buildVodItem = (detail: { broadcastId: number; title: string; notice?: string; thumbnailUrl?: string; scheduledAt?: string; startedAt?: string; sellerName?: string }) => {
   const startAt = detail.startedAt ?? detail.scheduledAt ?? ''
-  const endAt = startAt ? new Date(parseLiveDate(startAt).getTime() + 60 * 60 * 1000).toISOString() : ''
+  const startAtMs = startAt ? parseLiveDate(startAt).getTime() : NaN
+  const endAtMs = Number.isNaN(startAtMs) ? undefined : getScheduledEndMs(startAtMs)
+  const endAt = endAtMs ? new Date(endAtMs).toISOString() : ''
   return {
     id: String(detail.broadcastId),
     title: detail.title,

--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -207,9 +207,8 @@ const mapScheduledSortType = () => {
 }
 
 const mapScheduledStatusFilter = () => {
-  if (scheduledStatus.value === 'reserved') return 'RESERVED'
   if (scheduledStatus.value === 'canceled') return 'CANCELED'
-  return undefined
+  return 'RESERVED'
 }
 
 const mapVodSortType = () => {
@@ -521,9 +520,8 @@ const filteredScheduled = computed(() => {
       return aDate - bDate
     })
 
-  if (scheduledStatus.value === 'reserved') return sortScheduled(reserved)
   if (scheduledStatus.value === 'canceled') return sortScheduled(canceled)
-  return [...sortScheduled(reserved), ...sortScheduled(canceled)]
+  return sortScheduled(reserved)
 })
 
 const filteredVods = computed(() => {

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -208,9 +208,8 @@ const mapScheduledSortType = () => {
 }
 
 const mapScheduledStatusFilter = () => {
-  if (scheduledStatus.value === 'reserved') return 'RESERVED'
   if (scheduledStatus.value === 'canceled') return 'CANCELED'
-  return undefined
+  return 'RESERVED'
 }
 
 const mapVodSortType = () => {
@@ -530,10 +529,8 @@ const filteredScheduledItems = computed(() => {
       return aDate - bDate
     })
 
-  if (scheduledStatus.value === 'reserved') return sortScheduled(reserved)
   if (scheduledStatus.value === 'canceled') return sortScheduled(canceled)
-
-  return [...sortScheduled(reserved), ...sortScheduled(canceled)]
+  return sortScheduled(reserved)
 })
 
 const categoryOptions = computed(() => categories.value)

--- a/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastListResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastListResponse.java
@@ -78,9 +78,12 @@ public class BroadcastListResponse {
         if (status == BroadcastStatus.RESERVED) {
             this.startAt = scheduledAt;
             this.endAt = (scheduledAt != null) ? scheduledAt.plusMinutes(30) : null;
-        } else if (status == BroadcastStatus.ON_AIR || status == BroadcastStatus.READY) {
-            this.startAt = (startedAt != null) ? startedAt : LocalDateTime.now();
+        } else if (status == BroadcastStatus.ON_AIR) {
+            this.startAt = (startedAt != null) ? startedAt : scheduledAt;
             this.endAt = null; // 진행 중이라 끝나는 시간 없음
+        } else if (status == BroadcastStatus.READY) {
+            this.startAt = scheduledAt;
+            this.endAt = (scheduledAt != null) ? scheduledAt.plusMinutes(30) : null;
         } else {
             this.startAt = startedAt;
             this.endAt = endedAt;

--- a/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
@@ -15,6 +15,7 @@ public class BroadcastProductResponse {
     private String imageUrl;      // 상품 이미지 (Product API 연동 필요)
     private int originalPrice;    // 원가
     private int stockQty;         // 판매 가능한 재고 수량
+    private int safetyStock;      // 안전 재고
 
     private int bpPrice;        // 라이브 특가 (bp_price)
     private int bpQuantity;     // 판매 수량 (bp_quantity)
@@ -32,6 +33,7 @@ public class BroadcastProductResponse {
 //                .imageUrl(p.getProductThumbUrl())   // 추후 ProductImage 구현되면 추가 예정
                 .originalPrice(p.getPrice())
                 .stockQty(p.getStockQty())
+                .safetyStock(p.getSafetyStock())
                 .bpPrice(bp.getBpPrice())
                 .bpQuantity(bp.getBpQuantity())
                 .displayOrder(bp.getDisplayOrder())

--- a/src/main/java/com/deskit/deskit/livehost/dto/response/ProductSelectResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/ProductSelectResponse.java
@@ -14,6 +14,6 @@ public class ProductSelectResponse {
     private String productName;
     private Integer price;      // 정가
     private Integer stockQty;   // 현재 재고
+    private Integer safetyStock;   // 안전 재고
     private String imageUrl;    // 대표 이미지 URL
 }
-

--- a/src/main/java/com/deskit/deskit/livehost/entity/BroadcastProduct.java
+++ b/src/main/java/com/deskit/deskit/livehost/entity/BroadcastProduct.java
@@ -57,10 +57,9 @@ public class BroadcastProduct {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
-    public boolean markSoldOutIfNeeded(Integer stockQty, Integer safetyStock) {
-        int safeStock = safetyStock == null ? 0 : safetyStock;
-        int remaining = stockQty == null ? 0 : stockQty;
-        if (remaining > safeStock) {
+    public boolean markSoldOutIfNeeded(Integer remainingQuantity) {
+        int remaining = remainingQuantity == null ? 0 : remainingQuantity;
+        if (remaining > 0) {
             return false;
         }
         if (status == BroadcastProductStatus.SOLDOUT) {


### PR DESCRIPTION
### Motivation
- Restore the seller/admin UI to show "방송 중" and "예약된 방송" sections when viewing the `all` tab to match develop and avoid hiding sections when lists are empty.
- Prevent sellers from offering more than available inventory by honoring `safetyStock` in DTOs, product selection, and server-side validation.
- Improve realtime reliability by centralizing SSE/timer cleanup and aligning polling behavior with SSE connection state.
- Avoid concurrent broadcast state transitions by throttling transition operations with Redis locks.

### Description
- UI: changed `visibleLive` and `visibleScheduled` to `activeTab === 'all' || ...` in `front/src/pages/seller/Live.vue` and `front/src/pages/admin/AdminLive.vue` to show live/scheduled on the All tab. 
- Product safety & draft: added `safetyStock` to client types and API mappings, added `resolveMaxQuantity`/`clampProductQuantity` and input `min`/`max` enforcement in `LiveCreateBasic.vue`, and ensured drafts/restores clamp quantities. 
- Realtime & lifecycle: added `resetRealtimeState`, scheduled auto-start (`scheduleAutoStart`/`requestStartBroadcast`), explicit end handling (`endSellerBroadcast` integration), and SSE/polling guards to only refresh stats/products when appropriate in `LiveStream.vue` and `LiveDetail.vue`. 
- Backend: exposed `safetyStock` in DTOs and queries, enforced `bpQuantity <= stock - safetyStock` in `saveBroadcastProducts`, updated sold-out logic, and added Redis lock guards (`lock:broadcast_transition:{id}`) around `cancel`/`forceStop`/seller cancel operations in `AdminService` and `BroadcastService`.

### Testing
- No automated unit or integration tests were executed for this rollout.
- No CI build or server integration tests were run (changes were committed locally and a PR body was prepared).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960b4fb8ee0832ab61f29f3a5479154)