### PR TITLE
Add order-based broadcast sales statistics

### DIFF
--- a/src/main/java/com/deskit/deskit/livechat/repository/LiveChatRepository.java
+++ b/src/main/java/com/deskit/deskit/livechat/repository/LiveChatRepository.java
@@ -1,9 +1,13 @@
 package com.deskit.deskit.livechat.repository;
 
+import com.deskit.deskit.livechat.dto.LiveMessageType;
 import com.deskit.deskit.livechat.entity.LiveChat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Collection;
 import java.util.List;
 
 public interface LiveChatRepository extends JpaRepository<LiveChat, Long> {
     List<LiveChat> findByBroadcastIdOrderByMessageIdAsc(Long broadcastId);
+
+    long countByBroadcastIdAndMsgTypeIn(Long broadcastId, Collection<LiveMessageType> msgTypes);
 }


### PR DESCRIPTION
### Motivation

- Broadcast reporting should reflect actual paid orders for broadcast-time product sales rather than inventory counts.
- VOD result persistence must include accurate total sales and chat counts derived from orders and chat records.
- Product ranking for admin statistics should be computed from paid order revenue during broadcast windows.

### Description

- Added `fetchBroadcastSalesSummary` and value records `SalesMetric`/`SalesSummary` to compute per-product sales and total sales from `order`/`order_item` for `OrderStatus.PAID` within a broadcast window.
- Updated `processVod` to populate `BroadcastResult.totalSales` and `totalChats` using the new sales summary and `LiveChatRepository.countByBroadcastIdAndMsgTypeIn` and wired `LiveChatRepository` into `BroadcastService`.
- Reworked `getProductSalesRanking` to aggregate paid-order revenue (using `order` + `order_item`) and joined broadcast/product/broadcast_product to limit to broadcast-time paid orders with `OrderStatus.PAID` filtering.
- Updated broadcast report mapping to fill per-product `salesAmount`, `salesQuantity`, and `price` (using broadcast price fallback) so `BroadcastResultResponse` returns product-level metrics.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610e494a30832484ec49fb4f94aa37)