### PR TITLE
Restore drafts when only `access_token` present and refine seller key resolution

### DIFF
--- a/front/src/lib/live/viewer.ts
+++ b/front/src/lib/live/viewer.ts
@@ -13,7 +13,11 @@ export const resolveViewerId = (user: AuthUser | null): string | null => {
     return String(directId)
   }
 
-  const access = localStorage.getItem('access') || sessionStorage.getItem('access')
+  const access =
+    localStorage.getItem('access') ||
+    sessionStorage.getItem('access') ||
+    localStorage.getItem('access_token') ||
+    sessionStorage.getItem('access_token')
   if (!access) return null
   const tokenParts = access.split('.')
   if (tokenParts.length < 2) return null


### PR DESCRIPTION
### Motivation
- Allow restoring in-progress seller drafts when only an `access_token` is available and session hydration (`getAuthUser()`) is not yet populated.
- Ensure draft restoration remains restricted to the authenticated seller and is invalidated when the session/user changes.
- Fix reported behavior where cancelling and re-entering broadcast creation would not show the confirm prompt and loaded draft data was missing.

### Description
- `resolveViewerId` now also checks `localStorage`/`sessionStorage` for `access_token` in addition to `access`, and extracts the viewer id from the JWT payload when no `user` object is present.
- `resolveSellerKey` signature changed to `({ allowToken }: { allowToken: boolean })` so token-based lookup is performed only when explicitly allowed.
- `loadDraft` and `saveDraft` call `resolveSellerKey({ allowToken: true })` to permit token-based ownership resolution, while the `deskit-user-updated` handler calls `resolveSellerKey({ allowToken: false })` to force session-based clearing of drafts.
- Kept draft storage, parsing/normalization, and ownership-checking logic in `front/src/composables/useLiveCreateDraft.ts` and updated `front/src/lib/live/viewer.ts` to include the `access_token` checks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69611a5c4a188324a579e516d94e0ebb)