### PR TITLE
Limit live create draft to authenticated sellers

### DIFF
--- a/front/src/composables/useLiveCreateDraft.ts
+++ b/front/src/composables/useLiveCreateDraft.ts
@@ -39,15 +39,10 @@ type StoredDraft = {
   data: LiveCreateDraft
 }
 
-const resolveSellerKey = ({ allowToken }: { allowToken: boolean }) => {
+const resolveSellerKey = () => {
   const user = getAuthUser()
-  const tokenOwnerId = allowToken ? resolveViewerId(null) : null
-  if (user) {
-    if (!isSeller()) return ''
-    return tokenOwnerId ?? resolveViewerId(user) ?? ''
-  }
-  if (!allowToken) return ''
-  return tokenOwnerId ?? ''
+  if (!user || !isSeller()) return ''
+  return resolveViewerId(user) ?? ''
 }
 
 const getDraftStorage = () => sessionStorage
@@ -95,7 +90,7 @@ const parseStoredDraft = (raw: string | null): StoredDraft | null => {
 }
 
 window.addEventListener('deskit-user-updated', () => {
-  const ownerId = resolveSellerKey({ allowToken: !!getAuthUser() })
+  const ownerId = resolveSellerKey()
   const stored = parseStoredDraft(getDraftStorage().getItem(DRAFT_KEY))
   if (!ownerId || (stored && stored.ownerId !== ownerId)) {
     clearDraftStorage()
@@ -132,7 +127,7 @@ const normalizeDraft = (payload: LiveCreateDraft): LiveCreateDraft => {
 }
 
 export const loadDraft = (): LiveCreateDraft | null => {
-  const ownerId = resolveSellerKey({ allowToken: true })
+  const ownerId = resolveSellerKey()
   if (!ownerId) return null
   const stored = parseStoredDraft(getDraftStorage().getItem(DRAFT_KEY))
   if (!stored) {
@@ -147,7 +142,7 @@ export const loadDraft = (): LiveCreateDraft | null => {
 }
 
 export const saveDraft = (draft: LiveCreateDraft) => {
-  const ownerId = resolveSellerKey({ allowToken: true })
+  const ownerId = resolveSellerKey()
   if (!ownerId) return
   const payload: StoredDraft = {
     version: DRAFT_SCHEMA_VERSION,


### PR DESCRIPTION
### Motivation
- Ensure broadcast creation drafts are only saved and restored for the currently logged-in seller so drafts don't persist across logout or between different sellers.
- Avoid relying on token-based anonymous owner ids for draft ownership and instead require an authenticated seller session.
- Keep draft behavior consistent with UX request to clear or skip restoring drafts when no seller is logged in or when seller changes.
- Avoid touching authentication core (`auth.ts`) while enforcing owner checks in draft logic.

### Description
- Change draft ownership resolution by implementing `resolveSellerKey` to return an id only for authenticated sellers using `getAuthUser` and `isSeller` and `resolveViewerId(user)`.
- Update the `deskit-user-updated` listener to clear stored drafts when there is no seller owner or the stored `ownerId` differs from the current seller owner.
- Use the new `resolveSellerKey` for `loadDraft`, `saveDraft`, and internal save/clear logic so drafts are skipped/cleared when not logged-in as a seller.
- Modified file: `front/src/composables/useLiveCreateDraft.ts` (replaced token-based fallbacks and tightened ownership checks for `DRAFT_KEY`).

### Testing
- No automated tests were run for this change.
- No CI or unit test results available as part of this rollout.
- Manual verification is recommended to confirm draft restore prompt appears only for logged-in sellers and is cleared on logout.
- Build/type-check was not executed as an automated test in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696125fa318083248458005718c18422)