### PR TITLE
Allow live create drafts before session hydration

### DIFF
--- a/front/src/composables/useLiveCreateDraft.ts
+++ b/front/src/composables/useLiveCreateDraft.ts
@@ -41,13 +41,12 @@ type StoredDraft = {
 
 const resolveSellerKey = ({ allowToken }: { allowToken: boolean }) => {
   const user = getAuthUser()
-  const tokenOwnerId = allowToken ? resolveViewerId(null) : null
   if (user) {
     if (!isSeller()) return ''
-    return tokenOwnerId ?? resolveViewerId(user) ?? ''
+    return resolveViewerId(user) ?? ''
   }
   if (!allowToken) return ''
-  return tokenOwnerId ?? ''
+  return resolveViewerId(null) ?? ''
 }
 
 const getDraftStorage = () => sessionStorage
@@ -95,7 +94,7 @@ const parseStoredDraft = (raw: string | null): StoredDraft | null => {
 }
 
 window.addEventListener('deskit-user-updated', () => {
-  const ownerId = resolveSellerKey({ allowToken: !!getAuthUser() })
+  const ownerId = resolveSellerKey({ allowToken: true })
   const stored = parseStoredDraft(getDraftStorage().getItem(DRAFT_KEY))
   if (!ownerId || (stored && stored.ownerId !== ownerId)) {
     clearDraftStorage()


### PR DESCRIPTION
### Motivation
- Fix a regression where broadcast create drafts could not be saved or restored when the auth session was not yet hydrated.
- Allow drafts to be created/restored using the token-derived viewer id prior to `getAuthUser()` being available.
- Preserve the stricter authenticated-seller ownership check when a user session exists.
- Ensure drafts are cleared when the current owner changes on `deskit-user-updated`.

### Description
- Change `resolveSellerKey` to accept an `{ allowToken }` flag and return a token-backed viewer id when no auth user exists and `allowToken` is `true`.
- Use `resolveSellerKey({ allowToken: true })` from the `deskit-user-updated` listener so stored drafts are cleared only when ownership truly differs.
- Update `loadDraft` and `saveDraft` to call `resolveSellerKey({ allowToken: true })` so drafts can be saved/restored before session hydration.
- Drafts continue to be stored in `sessionStorage` under `deskit_seller_broadcast_draft_v3` with the existing schema validation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696125fa318083248458005718c18422)