### PR TITLE
Fix seller draft key resolution

### DIFF
--- a/front/src/composables/useLiveCreateDraft.ts
+++ b/front/src/composables/useLiveCreateDraft.ts
@@ -39,7 +39,7 @@ type StoredDraft = {
   data: LiveCreateDraft
 }
 
-const resolveSellerKey = () => {
+const resolveSellerKey = ({ allowToken = false }: { allowToken?: boolean } = {}) => {
   const user = getAuthUser()
   if (user) {
     if (!isSeller()) return ''


### PR DESCRIPTION
### Motivation

- Prevent a `ReferenceError` when resolving the seller draft owner because `allowToken` was referenced but not defined.  
- The `deskit-user-updated` listener calls `resolveSellerKey({ allowToken: true })`, so the function must accept that option.  
- Ensure draft ownership resolution can optionally fall back to a token-based viewer id via `allowToken`.  

### Description

- Change the signature of `resolveSellerKey` to accept an optional parameter object `({ allowToken = false }: { allowToken?: boolean } = {})`.  
- Use the `allowToken` parameter where previously an undefined variable could be referenced.  
- No other behavioral changes were made to draft storage, normalization, or reservation mapping.  

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69612acb4d8c83248f5aa53d6facc9ef)