### PR TITLE
Adjust live draft restore flow: prompt at create button and use in-memory working draft

### DIFF
--- a/front/src/composables/useLiveCreateDraft.ts
+++ b/front/src/composables/useLiveCreateDraft.ts
@@ -30,6 +30,7 @@ export type LiveCreateDraft = {
 }
 
 export const DRAFT_KEY = 'deskit_seller_broadcast_draft_v3'
+const DRAFT_RESTORE_KEY = 'deskit_seller_broadcast_draft_restore_v1'
 const DRAFT_SCHEMA_VERSION = 1
 
 type StoredDraft = {
@@ -39,7 +40,7 @@ type StoredDraft = {
   data: LiveCreateDraft
 }
 
-const resolveSellerKey = () => {
+const resolveSellerKey = ({ allowToken = false }: { allowToken?: boolean } = {}) => {
   const user = getAuthUser()
   if (user) {
     if (!isSeller()) return ''
@@ -56,10 +57,31 @@ const resolveSellerKey = () => {
 }
 
 const getDraftStorage = () => sessionStorage
+let workingDraft: LiveCreateDraft | null = null
 
 const clearDraftStorage = () => {
-  getDraftStorage().removeItem(DRAFT_KEY)
+  const storage = getDraftStorage()
+  storage.removeItem(DRAFT_KEY)
+  storage.removeItem(DRAFT_RESTORE_KEY)
+  workingDraft = null
 }
+
+type DraftRestoreDecision = 'accepted' | 'declined'
+
+export const getDraftRestoreDecision = (): DraftRestoreDecision | null => {
+  const stored = getDraftStorage().getItem(DRAFT_RESTORE_KEY)
+  if (stored === 'accepted' || stored === 'declined') return stored
+  return null
+}
+
+export const setDraftRestoreDecision = (decision: DraftRestoreDecision) => {
+  getDraftStorage().setItem(DRAFT_RESTORE_KEY, decision)
+}
+
+export const clearDraftRestoreDecision = () => {
+  getDraftStorage().removeItem(DRAFT_RESTORE_KEY)
+}
+
 
 const createId = () => `q-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
@@ -139,6 +161,19 @@ const normalizeDraft = (payload: LiveCreateDraft): LiveCreateDraft => {
           }))
       : [],
   }
+}
+
+export const loadWorkingDraft = (): LiveCreateDraft | null => {
+  if (!workingDraft) return null
+  return normalizeDraft(workingDraft)
+}
+
+export const saveWorkingDraft = (draft: LiveCreateDraft) => {
+  workingDraft = normalizeDraft(draft)
+}
+
+export const clearWorkingDraft = () => {
+  workingDraft = null
 }
 
 export const loadDraft = (): LiveCreateDraft | null => {

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -22,6 +22,12 @@ import {
 } from '../../lib/live/api'
 import { getAuthUser } from '../../lib/auth'
 import { resolveViewerId } from '../../lib/live/viewer'
+import {
+  clearDraft,
+  clearDraftRestoreDecision,
+  loadDraft,
+  setDraftRestoreDecision,
+} from '../../composables/useLiveCreateDraft'
 
 const router = useRouter()
 const route = useRoute()
@@ -699,6 +705,17 @@ const setTab = (tab: LiveTab) => {
 }
 
 const handleCreate = () => {
+  const savedDraft = loadDraft()
+  if (savedDraft) {
+    const shouldRestore = window.confirm('이전에 작성 중인 내용을 불러올까요?')
+    if (shouldRestore) {
+      setDraftRestoreDecision('accepted')
+    } else {
+      clearDraft()
+    }
+  } else {
+    clearDraftRestoreDecision()
+  }
   router.push('/seller/live/create').catch(() => {})
 }
 

--- a/front/src/pages/seller/LiveCreateBasic.vue
+++ b/front/src/pages/seller/LiveCreateBasic.vue
@@ -7,11 +7,16 @@ import LiveImageCropModal from '../../components/LiveImageCropModal.vue'
 import {
   buildDraftFromReservation,
   clearDraft,
+  clearDraftRestoreDecision,
   createEmptyDraft,
+  getDraftRestoreDecision,
   type LiveCreateDraft,
   type LiveCreateProduct,
   loadDraft,
+  loadWorkingDraft,
   saveDraft,
+  saveWorkingDraft,
+  clearWorkingDraft,
 } from '../../composables/useLiveCreateDraft'
 import {
   type BroadcastCategory,
@@ -127,7 +132,7 @@ const syncDraft = () => {
     draft.value.questions = trimmedQuestions
   }
 
-  saveDraft({
+  saveWorkingDraft({
     ...draft.value,
     title: draft.value.title.trim(),
     subtitle: draft.value.subtitle?.trim() ?? '',
@@ -139,13 +144,16 @@ const syncDraft = () => {
 }
 
 const restoreDraft = async () => {
-  const savedDraft = loadDraft()
+  const workingDraft = loadWorkingDraft()
   let baseDraft = createEmptyDraft()
-  if (!isEditMode.value && savedDraft && (!savedDraft.reservationId || savedDraft.reservationId === reservationId.value)) {
-    const shouldRestore = window.confirm('이전에 작성 중인 내용을 불러올까요?')
-    if (shouldRestore) {
+  if (workingDraft) {
+    baseDraft = { ...createEmptyDraft(), ...workingDraft }
+  } else if (!isEditMode.value) {
+    const savedDraft = loadDraft()
+    const decision = getDraftRestoreDecision()
+    if (savedDraft && decision === 'accepted' && (!savedDraft.reservationId || savedDraft.reservationId === reservationId.value)) {
       baseDraft = { ...createEmptyDraft(), ...savedDraft }
-    } else {
+    } else if (decision === 'declined') {
       clearDraft()
     }
   }
@@ -358,6 +366,9 @@ const goPrev = () => {
 const cancel = () => {
   const ok = window.confirm('작성 중인 내용을 취소하시겠어요?')
   if (!ok) return
+  saveDraft(draft.value)
+  clearDraftRestoreDecision()
+  clearWorkingDraft()
   const redirect = isEditMode.value && reservationId.value
     ? `/seller/broadcasts/reservations/${reservationId.value}`
     : '/seller/live?tab=scheduled'

--- a/front/src/pages/seller/LiveCreateCue.vue
+++ b/front/src/pages/seller/LiveCreateCue.vue
@@ -8,8 +8,13 @@ import {
   clearDraft,
   createDefaultQuestions,
   createEmptyDraft,
+  clearDraftRestoreDecision,
+  getDraftRestoreDecision,
   loadDraft,
+  loadWorkingDraft,
   saveDraft,
+  saveWorkingDraft,
+  clearWorkingDraft,
   type LiveCreateDraft,
 } from '../../composables/useLiveCreateDraft'
 
@@ -29,19 +34,22 @@ const createQuestion = () => ({
 })
 
 const syncDraft = () => {
-  saveDraft({
+  saveWorkingDraft({
     ...draft.value,
     questions: draft.value.questions.map((q) => ({ ...q, text: q.text.trim() })),
   })
 }
 
 const restoreDraft = async () => {
-  const saved = loadDraft()
-  if (!isEditMode.value && saved && (!saved.reservationId || saved.reservationId === reservationId.value)) {
-    const shouldRestore = window.confirm('이전에 작성 중인 내용을 불러올까요?')
-    if (shouldRestore) {
+  const working = loadWorkingDraft()
+  if (working) {
+    draft.value = { ...draft.value, ...working }
+  } else if (!isEditMode.value) {
+    const saved = loadDraft()
+    const decision = getDraftRestoreDecision()
+    if (saved && decision === 'accepted' && (!saved.reservationId || saved.reservationId === reservationId.value)) {
       draft.value = { ...draft.value, ...saved }
-    } else {
+    } else if (decision === 'declined') {
       clearDraft()
     }
   }
@@ -95,6 +103,9 @@ const goNext = () => {
 const cancel = () => {
   const ok = window.confirm('작성 중인 내용을 취소하시겠어요?')
   if (!ok) return
+  saveDraft(draft.value)
+  clearDraftRestoreDecision()
+  clearWorkingDraft()
   const redirect = isEditMode.value && reservationId.value
     ? `/seller/broadcasts/reservations/${reservationId.value}`
     : '/seller/live?tab=scheduled'


### PR DESCRIPTION
### Motivation
- Avoid repeated "restore draft" confirmations when navigating between the cue and basic steps by prompting only once at the list-level create action (`방송 등록`).
- Keep transient edits in memory during the two-step create flow so normal navigation does not persist to storage.
- Persist the user's restore decision for the session so the second step does not re-prompt once a choice was made.
- Persist the draft to storage only on explicit cancel, and clear the restore decision when the draft or session is cleared.

### Description
- Added an in-memory `workingDraft` and helper functions `loadWorkingDraft`, `saveWorkingDraft`, and `clearWorkingDraft` in `front/src/composables/useLiveCreateDraft.ts` and kept storage-backed `loadDraft`/`saveDraft` for explicit persistence.
- Introduced a session-scoped `DRAFT_RESTORE_KEY` and functions `getDraftRestoreDecision`, `setDraftRestoreDecision`, and `clearDraftRestoreDecision` to save the user's restore choice.
- Moved the restore confirmation prompt into the list-level create entry (`handleCreate` in `front/src/pages/seller/Live.vue`) so the prompt runs when clicking `방송 등록` and stores the decision, and updated the cue/basic pages to consult `workingDraft` first and the stored decision thereafter (`LiveCreateCue.vue` and `LiveCreateBasic.vue`).
- Changed step navigation behavior so edits are kept in memory via `saveWorkingDraft` during sync, and the draft is written to storage only on `cancel` (which now calls `saveDraft` and clears the working draft and restore decision).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69612acb4d8c83248f5aa53d6facc9ef)