### PR TITLE
Fix draft restore confirm flow (avoid repeated confirm prompts)

### DIFF
--- a/front/src/pages/seller/LiveCreateBasic.vue
+++ b/front/src/pages/seller/LiveCreateBasic.vue
@@ -9,14 +9,14 @@ import {
   clearDraft,
   clearDraftRestoreDecision,
   createEmptyDraft,
-  DRAFT_KEY,
   type LiveCreateDraft,
   type LiveCreateProduct,
   loadDraft,
-  loadWorkingDraft,
   saveDraft,
   saveWorkingDraft,
-  clearWorkingDraft, getDraftRestoreDecision,
+  clearWorkingDraft,
+  getDraftRestoreDecision,
+  setDraftRestoreDecision,
 } from '../../composables/useLiveCreateDraft'
 import {
   type BroadcastCategory,
@@ -144,15 +144,23 @@ const syncDraft = () => {
 }
 
 const restoreDraft = async () => {
-  const storedDraft = sessionStorage.getItem(DRAFT_KEY)
-  const savedDraft = storedDraft ? loadDraft() : null
+  const savedDraft = loadDraft()
   let baseDraft = createEmptyDraft()
   if (!isEditMode.value && savedDraft && (!savedDraft.reservationId || savedDraft.reservationId === reservationId.value)) {
-    const shouldRestore = window.confirm('이전에 작성 중인 내용을 불러올까요?')
-    if (shouldRestore) {
+    const decision = getDraftRestoreDecision()
+    if (decision === 'accepted') {
       baseDraft = { ...createEmptyDraft(), ...savedDraft }
-    } else {
+    } else if (decision === 'declined') {
       clearDraft()
+    } else {
+      const shouldRestore = window.confirm('이전에 작성 중인 내용을 불러올까요?')
+      if (shouldRestore) {
+        setDraftRestoreDecision('accepted')
+        baseDraft = { ...createEmptyDraft(), ...savedDraft }
+      } else {
+        setDraftRestoreDecision('declined')
+        clearDraft()
+      }
     }
   }
 

--- a/front/src/pages/seller/LiveCreateCue.vue
+++ b/front/src/pages/seller/LiveCreateCue.vue
@@ -8,12 +8,14 @@ import {
   clearDraft,
   createDefaultQuestions,
   createEmptyDraft,
-  DRAFT_KEY,
+  getDraftRestoreDecision,
   loadDraft,
   saveDraft,
   saveWorkingDraft,
   clearWorkingDraft,
-  type LiveCreateDraft, clearDraftRestoreDecision,
+  type LiveCreateDraft,
+  clearDraftRestoreDecision,
+  setDraftRestoreDecision,
 } from '../../composables/useLiveCreateDraft'
 
 const router = useRouter()
@@ -39,14 +41,22 @@ const syncDraft = () => {
 }
 
 const restoreDraft = async () => {
-  const storedDraft = sessionStorage.getItem(DRAFT_KEY)
-  const saved = storedDraft ? loadDraft() : null
+  const saved = loadDraft()
   if (!isEditMode.value && saved && (!saved.reservationId || saved.reservationId === reservationId.value)) {
-    const shouldRestore = window.confirm('이전에 작성 중인 내용을 불러올까요?')
-    if (shouldRestore) {
+    const decision = getDraftRestoreDecision()
+    if (decision === 'accepted') {
       draft.value = { ...draft.value, ...saved }
+    } else if (decision === 'declined') {
+      clearDraft()
     } else {
+      const shouldRestore = window.confirm('이전에 작성 중인 내용을 불러올까요?')
+      if (shouldRestore) {
+        setDraftRestoreDecision('accepted')
+        draft.value = { ...draft.value, ...saved }
+      } else {
+        setDraftRestoreDecision('declined')
         clearDraft()
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- Prevent showing the same `confirm` dialog multiple times when navigating between live create steps by honoring a single user decision.
- Ensure a declined restore clears the saved draft so users are not repeatedly prompted to restore.
- Centralize draft restore decision handling instead of reading `sessionStorage` directly at each step.

### Description
- Updated `front/src/pages/seller/LiveCreateBasic.vue` to use `getDraftRestoreDecision` and `setDraftRestoreDecision` from `useLiveCreateDraft` and to apply the stored decision before prompting the user.
- Updated `front/src/pages/seller/LiveCreateCue.vue` to consult and persist the same restore decision so the confirmation is shown at most once across steps.
- Removed direct `sessionStorage.getItem(DRAFT_KEY)` checks and unified logic to `loadDraft()` + the restore decision, and ensured `clearDraft()` is called when the user declines.
- Adjusted imports from `composables/useLiveCreateDraft` to add `getDraftRestoreDecision`/`setDraftRestoreDecision` and cleaned up unused imports.

### Testing
- No automated tests were run for this change.
- The change is limited to client-side control flow and imports in `LiveCreateBasic.vue` and `LiveCreateCue.vue` and relies on existing `useLiveCreateDraft` behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69613de1a44c8324bb33d3575a267314)