### PR TITLE
Preserve cue card draft data when resuming live creation

### DIFF
--- a/front/src/pages/seller/LiveCreateBasic.vue
+++ b/front/src/pages/seller/LiveCreateBasic.vue
@@ -11,6 +11,7 @@ import {
   createEmptyDraft,
   type LiveCreateDraft,
   type LiveCreateProduct,
+  loadWorkingDraft,
   loadDraft,
   saveDraft,
   saveWorkingDraft,
@@ -144,22 +145,27 @@ const syncDraft = () => {
 }
 
 const restoreDraft = async () => {
-  const savedDraft = loadDraft()
   let baseDraft = createEmptyDraft()
-  if (!isEditMode.value && savedDraft && (!savedDraft.reservationId || savedDraft.reservationId === reservationId.value)) {
-    const decision = getDraftRestoreDecision()
-    if (decision === 'accepted') {
-      baseDraft = { ...createEmptyDraft(), ...savedDraft }
-    } else if (decision === 'declined') {
-      clearDraft()
-    } else {
-      const shouldRestore = window.confirm('이전에 작성 중인 내용을 불러올까요?')
-      if (shouldRestore) {
-        setDraftRestoreDecision('accepted')
+  const workingDraft = loadWorkingDraft()
+  if (workingDraft) {
+    baseDraft = { ...createEmptyDraft(), ...workingDraft }
+  } else {
+    const savedDraft = loadDraft()
+    if (!isEditMode.value && savedDraft && (!savedDraft.reservationId || savedDraft.reservationId === reservationId.value)) {
+      const decision = getDraftRestoreDecision()
+      if (decision === 'accepted') {
         baseDraft = { ...createEmptyDraft(), ...savedDraft }
-      } else {
-        setDraftRestoreDecision('declined')
+      } else if (decision === 'declined') {
         clearDraft()
+      } else {
+        const shouldRestore = window.confirm('이전에 작성 중인 내용을 불러올까요?')
+        if (shouldRestore) {
+          setDraftRestoreDecision('accepted')
+          baseDraft = { ...createEmptyDraft(), ...savedDraft }
+        } else {
+          setDraftRestoreDecision('declined')
+          clearDraft()
+        }
       }
     }
   }


### PR DESCRIPTION
### Motivation
- Cue card questions (drafted on the cue step) could be lost when returning to the basic info step because in-memory working draft was not being loaded first. 
- The intent is to ensure cue card data is preserved across step navigation by preferring the in-memory working draft.

### Description
- Added import of `loadWorkingDraft` from `composables/useLiveCreateDraft`.
- Updated `restoreDraft` in `LiveCreateBasic.vue` to call `loadWorkingDraft()` first and merge it into `baseDraft` when present, falling back to the existing `loadDraft()` + restore-decision flow only if no working draft exists.
- Kept existing reservation-based draft building and fallback behavior unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69621e5e3f148324be28c04c393053aa)