### PR TITLE
Subtract reserved broadcast qty from availability and allow free-form broadcast quantity input

### DIFF
--- a/front/src/composables/useLiveCreateDraft.ts
+++ b/front/src/composables/useLiveCreateDraft.ts
@@ -10,6 +10,7 @@ export type LiveCreateProduct = {
   broadcastPrice: number
   stock: number
   safetyStock: number
+  reservedBroadcastQty?: number
   quantity: number
   thumb?: string
 }

--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -19,6 +19,7 @@ export type SellerProduct = {
   broadcastPrice: number
   stock: number
   safetyStock: number
+  reservedBroadcastQty?: number
   quantity: number
   thumb?: string
 }
@@ -264,7 +265,7 @@ export const fetchCategories = async (): Promise<BroadcastCategory[]> => {
 
 export const fetchSellerProducts = async (): Promise<SellerProduct[]> => {
   const { data } = await http.get<
-    ApiResult<Array<{ productId: number; productName: string; price: number; stockQty: number; safetyStock?: number; imageUrl?: string }>>
+    ApiResult<Array<{ productId: number; productName: string; price: number; stockQty: number; safetyStock?: number; reservedBroadcastQty?: number; imageUrl?: string }>>
   >(
     '/api/seller/broadcasts/products',
   )
@@ -277,6 +278,7 @@ export const fetchSellerProducts = async (): Promise<SellerProduct[]> => {
     broadcastPrice: item.price,
     stock: item.stockQty,
     safetyStock: item.safetyStock ?? 0,
+    reservedBroadcastQty: item.reservedBroadcastQty ?? 0,
     quantity: 1,
     thumb: item.imageUrl ?? '',
   }))

--- a/src/main/java/com/deskit/deskit/livehost/dto/response/ProductSelectResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/ProductSelectResponse.java
@@ -15,5 +15,6 @@ public class ProductSelectResponse {
     private Integer price;      // 정가
     private Integer stockQty;   // 현재 재고
     private Integer safetyStock;   // 안전 재고
+    private Integer reservedBroadcastQty;   // 예약 방송 판매 수량
     private String imageUrl;    // 대표 이미지 URL
 }


### PR DESCRIPTION
### Motivation

- Ensure maximum selectable broadcast quantity excludes units already reserved for other scheduled/ready broadcasts so availability reflects `broadcast_product.bp_quantity` reservations.
- Allow sellers to enter arbitrary desired broadcast sale quantities (not forced to `1`) and normalize them to valid range with user-facing notifications.
- Keep draft/product state in sync between the API response and the live-create UI so calculations are consistent.

### Description

- Backend: updated `getSellerProducts` to aggregate reserved quantities from `broadcast_product` (statuses `RESERVED`/`READY`) and subtract the sum from `stock_qty - safety_stock`, and added `reservedBroadcastQty` to `ProductSelectResponse`.
- Frontend API/types: added `reservedBroadcastQty` to `fetchSellerProducts` mapping and `SellerProduct`/`LiveCreateProduct` types in `front/src/lib/live/api.ts` and `front/src/composables/useLiveCreateDraft.ts`.
- Frontend UI: changed `LiveCreateBasic.vue` to support free-form quantity input via an internal `quantityInputs` map, perform normalization on `blur` and on submit (`normalizeAllProductQuantities`), show alerts when values are adjusted to min/max, and compute `resolveMaxQuantity` using `reservedBroadcastQty`.
- Files touched: `BroadcastService.java`, `ProductSelectResponse.java`, `front/src/lib/live/api.ts`, `front/src/composables/useLiveCreateDraft.ts`, and `front/src/pages/seller/LiveCreateBasic.vue`.

### Testing

- No automated tests were executed as part of this change.
- Manual behaviour added: normalization runs on input `blur` and on form submit to ensure quantities are within allowed ranges (alerts shown when adjusted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623961706c8324ad6636bb3679c90f)