### PR TITLE
Fix duplicate cards in live list carousel summaries

### DIFF
--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -612,10 +612,7 @@ const vodSummary = computed<AdminVodItem[]>(() =>
 
 const buildLoopItems = <T>(items: T[]): T[] => {
   if (!items.length) return []
-  if (items.length === 1) {
-    const single = items[0]!
-    return [single, single, single]
-  }
+  if (items.length === 1) return items
   const first = items[0]!
   const last = items[items.length - 1]!
   return [last, ...items, first]

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -570,10 +570,7 @@ const visibleVodItems = computed(() => filteredVodItems.value.slice(0, VOD_PAGE_
 
 const buildLoopItems = (items: LiveItem[]): LiveItem[] => {
   if (!items.length) return []
-  if (items.length === 1) {
-    const single = items[0]!
-    return [single, single, single]
-  }
+  if (items.length === 1) return items
   const first = items[0]!
   const last = items[items.length - 1]!
   return [last, ...items, first]


### PR DESCRIPTION
### Motivation
- The carousel helper `buildLoopItems` cloned a single summary item into three entries, which caused duplicate cards to appear in the sections shown on the `all` tab.
- The issue affected both seller and admin live pages where single-item summaries were rendered inside looped carousels.

### Description
- Changed `buildLoopItems` in `front/src/pages/seller/Live.vue` to return the original `items` when `items.length === 1` instead of returning the item three times.
- Applied the same fix to `buildLoopItems` in `front/src/pages/admin/AdminLive.vue` so admin carousels behave consistently.
- Preserved existing carousel wrapping behavior for lists with 0 or multiple items so looping still works for normal cases.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623a2c37208324a87817e37851badd)