### PR TITLE
Gate live list carousel auto-slide on overflow

### DIFF
--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -612,10 +612,7 @@ const vodSummary = computed<AdminVodItem[]>(() =>
 
 const buildLoopItems = <T>(items: T[]): T[] => {
   if (!items.length) return []
-  if (items.length === 1) {
-    const single = items[0]!
-    return [single, single, single]
-  }
+  if (items.length === 1) return items
   const first = items[0]!
   const last = items[items.length - 1]!
   return [last, ...items, first]
@@ -669,6 +666,19 @@ const updateSlideWidth = (kind: LoopKind) => {
   if (!root) return
   const card = root.querySelector<HTMLElement>('.live-card')
   slideWidths.value[kind] = card?.offsetWidth ?? 280
+}
+
+const isCarouselOverflowing = (kind: LoopKind) => {
+  const root = carouselRefs.value[kind]
+  if (!root) return false
+  const viewport = root.parentElement
+  if (!viewport) return false
+  const itemCount = baseItemsFor(kind).length
+  if (itemCount <= 1) return false
+  const cardWidth = slideWidths.value[kind] || root.querySelector<HTMLElement>('.live-card')?.offsetWidth || 0
+  if (!cardWidth) return false
+  const totalWidth = (cardWidth * itemCount) + (loopGap * (itemCount - 1))
+  return totalWidth > viewport.clientWidth
 }
 
 const getTrackStyle = (kind: LoopKind) => {
@@ -729,7 +739,7 @@ const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
 
 const startAutoLoop = (kind: LoopKind) => {
   stopAutoLoop(kind)
-  if (baseItemsFor(kind).length <= 1) return
+  if (!isCarouselOverflowing(kind)) return
   autoTimers.value[kind] = window.setInterval(() => {
     stepCarousel(kind, 1)
   }, 3200)
@@ -765,6 +775,9 @@ const handleResize = () => {
   updateSlideWidth('live')
   updateSlideWidth('scheduled')
   updateSlideWidth('vod')
+  restartAutoLoop('live')
+  restartAutoLoop('scheduled')
+  restartAutoLoop('vod')
 }
 
 watch(


### PR DESCRIPTION
### Motivation
- Single-item and small carousels were auto-advancing even when the card list fit within the viewport, causing unexpected slide behavior on `all` list screens.
- The carousel should only auto-slide when the rendered cards exceed the available horizontal space.
- Auto-loop timers should be refreshed on viewport resize so the overflow check and slide behavior stay correct.

### Description
- Stop cloning single summaries into three entries by returning the original list when `items.length === 1` in `buildLoopItems` in `front/src/pages/seller/Live.vue` and `front/src/pages/admin/AdminLive.vue`.
- Add an `isCarouselOverflowing` helper to both `Live.vue` files to compute whether cards + gaps exceed the viewport width.
- Gate `startAutoLoop` with `isCarouselOverflowing` so auto-slide only starts when the carousel actually overflows, and call `restartAutoLoop` inside `handleResize` to refresh timers after resizes.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623a2c37208324a87817e37851badd)