### PR TITLE
Fix carousel auto-loop overflow behavior

### DIFF
--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -737,6 +737,10 @@ const handleLoopTransitionEnd = (kind: LoopKind) => {
 const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
   const items = loopItemsFor(kind)
   if (items.length <= 1) return
+  if (!isCarouselOverflowing(kind)) {
+    loopIndex.value[kind] = getBaseLoopIndex(kind)
+    return
+  }
   const lastIndex = items.length - 1
   loopTransition.value[kind] = true
   const nextIndex = loopIndex.value[kind] + delta
@@ -752,7 +756,10 @@ const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
 
 const startAutoLoop = (kind: LoopKind) => {
   stopAutoLoop(kind)
-  if (!isCarouselOverflowing(kind)) return
+  if (!isCarouselOverflowing(kind)) {
+    loopIndex.value[kind] = getBaseLoopIndex(kind)
+    return
+  }
   autoTimers.value[kind] = window.setInterval(() => {
     if (!isCarouselOverflowing(kind)) {
       stopAutoLoop(kind)

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -669,6 +669,10 @@ const handleLoopTransitionEnd = (kind: LoopKind) => {
 const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
   const items = loopItemsFor(kind)
   if (items.length <= 1) return
+  if (!isCarouselOverflowing(kind)) {
+    loopIndex.value[kind] = getBaseLoopIndex(kind)
+    return
+  }
   const lastIndex = items.length - 1
   loopTransition.value[kind] = true
   const nextIndex = loopIndex.value[kind] + delta
@@ -684,7 +688,10 @@ const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
 
 const startAutoLoop = (kind: LoopKind) => {
   stopAutoLoop(kind)
-  if (!isCarouselOverflowing(kind)) return
+  if (!isCarouselOverflowing(kind)) {
+    loopIndex.value[kind] = getBaseLoopIndex(kind)
+    return
+  }
   autoTimers.value[kind] = window.setInterval(() => {
     if (!isCarouselOverflowing(kind)) {
       stopAutoLoop(kind)


### PR DESCRIPTION
### Motivation
- Carousels were auto-sliding even when there was a single card or when the card list did not overflow the container, causing cards to disappear.
- The intent is to only enable automatic/manual sliding when the total cards width exceeds the viewport width and to reset the loop index when there is no overflow.

### Description
- Added an overflow guard in `stepCarousel` to prevent manual stepping when `isCarouselOverflowing(kind)` is false and reset the index to `getBaseLoopIndex(kind)` via `loopIndex.value[kind]`.
- Added the same overflow guard to `startAutoLoop` so automatic looping does not start when the list does not overflow and resets the loop index instead.
- Applied these changes to both `front/src/pages/seller/Live.vue` and `front/src/pages/admin/AdminLive.vue` for consistent behavior across seller and admin pages.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625ff577c083269f77413eb6f4d547)