### PR TITLE
Skip loop correction for single/non-overflowing carousels

### DIFF
--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -717,7 +717,7 @@ const getBaseLoopIndex = (kind: LoopKind) => (loopItemsFor(kind).length > 1 ? 1 
 
 const handleLoopTransitionEnd = (kind: LoopKind) => {
   const items = loopItemsFor(kind)
-  if (!items.length) return
+  if (items.length <= 1 || !isCarouselOverflowing(kind)) return
   const lastIndex = items.length - 1
   if (loopIndex.value[kind] === lastIndex) {
     loopTransition.value[kind] = false
@@ -737,6 +737,10 @@ const handleLoopTransitionEnd = (kind: LoopKind) => {
 const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
   const items = loopItemsFor(kind)
   if (items.length <= 1) return
+  if (!isCarouselOverflowing(kind)) {
+    loopIndex.value[kind] = getBaseLoopIndex(kind)
+    return
+  }
   const lastIndex = items.length - 1
   loopTransition.value[kind] = true
   const nextIndex = loopIndex.value[kind] + delta
@@ -752,7 +756,10 @@ const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
 
 const startAutoLoop = (kind: LoopKind) => {
   stopAutoLoop(kind)
-  if (!isCarouselOverflowing(kind)) return
+  if (!isCarouselOverflowing(kind)) {
+    loopIndex.value[kind] = getBaseLoopIndex(kind)
+    return
+  }
   autoTimers.value[kind] = window.setInterval(() => {
     if (!isCarouselOverflowing(kind)) {
       stopAutoLoop(kind)

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -649,7 +649,7 @@ const getTrackStyle = (kind: LoopKind) => {
 
 const handleLoopTransitionEnd = (kind: LoopKind) => {
   const items = loopItemsFor(kind)
-  if (!items.length) return
+  if (items.length <= 1 || !isCarouselOverflowing(kind)) return
   const lastIndex = items.length - 1
   if (loopIndex.value[kind] === lastIndex) {
     loopTransition.value[kind] = false
@@ -669,6 +669,10 @@ const handleLoopTransitionEnd = (kind: LoopKind) => {
 const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
   const items = loopItemsFor(kind)
   if (items.length <= 1) return
+  if (!isCarouselOverflowing(kind)) {
+    loopIndex.value[kind] = getBaseLoopIndex(kind)
+    return
+  }
   const lastIndex = items.length - 1
   loopTransition.value[kind] = true
   const nextIndex = loopIndex.value[kind] + delta
@@ -684,7 +688,10 @@ const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
 
 const startAutoLoop = (kind: LoopKind) => {
   stopAutoLoop(kind)
-  if (!isCarouselOverflowing(kind)) return
+  if (!isCarouselOverflowing(kind)) {
+    loopIndex.value[kind] = getBaseLoopIndex(kind)
+    return
+  }
   autoTimers.value[kind] = window.setInterval(() => {
     if (!isCarouselOverflowing(kind)) {
       stopAutoLoop(kind)


### PR DESCRIPTION
### Motivation
- Single-card carousels were briefly disappearing because loop end correction ran even when there was only one item, shifting the track off-screen.
- Automatic/manual sliding should only be active when the total cards width actually overflows the viewport.
- The behavior must be consistent across seller and admin broadcast lists to avoid UI glitches.

### Description
- Added an early-return guard in `handleLoopTransitionEnd` to skip loop correction when `items.length <= 1 || !isCarouselOverflowing(kind)` in both `front/src/pages/seller/Live.vue` and `front/src/pages/admin/AdminLive.vue`.
- Ensured `stepCarousel` and `startAutoLoop` also guard against non-overflowing lists and reset `loopIndex.value[kind]` to `getBaseLoopIndex(kind)` when appropriate.
- Changes were applied to `front/src/pages/seller/Live.vue` and `front/src/pages/admin/AdminLive.vue` to keep behavior consistent.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625ff577c083269f77413eb6f4d547)