### PR TITLE
Center image crop modal and preserve/display uploaded filenames

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -852,7 +852,6 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1524,7 +1523,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1710,7 +1708,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1742,7 +1739,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -1824,7 +1820,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
       "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.26",
         "@vue/compiler-sfc": "3.5.26",

--- a/front/src/components/BasicInfoEditModal.vue
+++ b/front/src/components/BasicInfoEditModal.vue
@@ -46,6 +46,17 @@ const categoryOptions = computed(() => {
 
 const isOpen = computed(() => props.modelValue)
 
+const extractFileName = (source: string) => {
+  if (!source || source.startsWith('data:')) return ''
+  const [path] = source.split('?')
+  const segments = path.split('/')
+  const last = segments[segments.length - 1] ?? ''
+  return decodeURIComponent(last)
+}
+
+const thumbnailDisplayName = computed(() => thumbnailName.value || extractFileName(thumbnailPreview.value))
+const waitingDisplayName = computed(() => waitingName.value || extractFileName(waitingPreview.value))
+
 const hydrateFromBroadcast = () => {
   if (!props.broadcast) return
   title.value = props.broadcast.title
@@ -217,7 +228,7 @@ const handleSave = () => {
                 </div>
               </div>
             </label>
-            <p class="upload-filename">{{ thumbnailName || '선택된 파일 없음' }}</p>
+            <p class="upload-filename">{{ thumbnailDisplayName || '선택된 파일 없음' }}</p>
             <button type="button" class="ds-btn ghost upload-clear" @click="clearThumbnail">이미지 삭제</button>
           </label>
 
@@ -239,7 +250,7 @@ const handleSave = () => {
                 </div>
               </div>
             </label>
-            <p class="upload-filename">{{ waitingName || '선택된 파일 없음' }}</p>
+            <p class="upload-filename">{{ waitingDisplayName || '선택된 파일 없음' }}</p>
             <button type="button" class="ds-btn ghost upload-clear" @click="clearWaiting">이미지 삭제</button>
           </label>
         </div>

--- a/front/src/components/LiveImageCropModal.vue
+++ b/front/src/components/LiveImageCropModal.vue
@@ -209,6 +209,73 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
+.ds-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1400;
+}
+
+.ds-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.ds-modal__card {
+  position: relative;
+  width: min(760px, 94vw);
+  max-height: 92vh;
+  padding: 20px;
+  border-radius: 16px;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.ds-modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.ds-modal__eyebrow {
+  margin: 0 0 4px;
+  color: var(--text-muted);
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+.ds-modal__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 900;
+  color: var(--text-strong);
+}
+
+.ds-modal__close {
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  color: var(--text-strong);
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  font-size: 1.1rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.ds-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
 .cropper {
   position: relative;
   width: min(680px, 94vw);

--- a/front/src/pages/seller/LiveCreateBasic.vue
+++ b/front/src/pages/seller/LiveCreateBasic.vue
@@ -51,6 +51,8 @@ const cropTarget = ref<'thumb' | 'standby' | null>(null)
 const cropperApplied = ref(false)
 const thumbInputRef = ref<HTMLInputElement | null>(null)
 const standbyInputRef = ref<HTMLInputElement | null>(null)
+const thumbName = ref('')
+const standbyName = ref('')
 
 const reservationId = computed(() => {
   const queryValue = route.query.reservationId
@@ -59,6 +61,15 @@ const reservationId = computed(() => {
 })
 const isEditMode = computed(() => route.query.mode === 'edit' && !!reservationId.value)
 const modalCount = computed(() => modalProducts.value.length)
+const extractFileName = (source: string) => {
+  if (!source || source.startsWith('data:')) return ''
+  const [path] = source.split('?')
+  const segments = path.split('/')
+  const last = segments[segments.length - 1] ?? ''
+  return decodeURIComponent(last)
+}
+const thumbDisplayName = computed(() => thumbName.value || extractFileName(draft.value.thumb))
+const standbyDisplayName = computed(() => standbyName.value || extractFileName(draft.value.standbyThumb))
 
 const availableProducts = computed(() => sellerProducts.value)
 
@@ -287,19 +298,23 @@ const applyCroppedImage = (payload: { dataUrl: string; fileName: string }) => {
   cropperApplied.value = true
   if (cropTarget.value === 'thumb') {
     draft.value.thumb = payload.dataUrl
+    thumbName.value = payload.fileName
   }
   if (cropTarget.value === 'standby') {
     draft.value.standbyThumb = payload.dataUrl
+    standbyName.value = payload.fileName
   }
 }
 
 const clearThumb = () => {
   draft.value.thumb = ''
+  thumbName.value = ''
   if (thumbInputRef.value) thumbInputRef.value.value = ''
 }
 
 const clearStandby = () => {
   draft.value.standbyThumb = ''
+  standbyName.value = ''
   if (standbyInputRef.value) standbyInputRef.value.value = ''
 }
 
@@ -725,24 +740,26 @@ watch(
           <h3>썸네일/대기화면</h3>
         </div>
         <div class="field-grid">
-          <label class="field">
-            <span class="field__label">방송 썸네일 업로드</span>
-            <input ref="thumbInputRef" type="file" accept="image/*" @change="handleThumbUpload" />
-            <span v-if="thumbError" class="error">{{ thumbError }}</span>
-            <div v-if="draft.thumb" class="preview">
-              <img :src="draft.thumb" alt="방송 썸네일 미리보기" @error="handleThumbError" />
-            </div>
-            <button type="button" class="btn ghost upload-clear" @click="clearThumb">이미지 삭제</button>
-          </label>
-          <label class="field">
-            <span class="field__label">대기화면 업로드</span>
-            <input ref="standbyInputRef" type="file" accept="image/*" @change="handleStandbyUpload" />
-            <span v-if="standbyError" class="error">{{ standbyError }}</span>
-            <div v-if="draft.standbyThumb" class="preview">
-              <img :src="draft.standbyThumb" alt="대기화면 미리보기" @error="handleStandbyError" />
-            </div>
-            <button type="button" class="btn ghost upload-clear" @click="clearStandby">이미지 삭제</button>
-          </label>
+        <label class="field">
+          <span class="field__label">방송 썸네일 업로드</span>
+          <input ref="thumbInputRef" type="file" accept="image/*" @change="handleThumbUpload" />
+          <span v-if="thumbError" class="error">{{ thumbError }}</span>
+          <span class="upload-filename">{{ thumbDisplayName || '선택된 파일 없음' }}</span>
+          <div v-if="draft.thumb" class="preview">
+            <img :src="draft.thumb" alt="방송 썸네일 미리보기" @error="handleThumbError" />
+          </div>
+          <button type="button" class="btn ghost upload-clear" @click="clearThumb">이미지 삭제</button>
+        </label>
+        <label class="field">
+          <span class="field__label">대기화면 업로드</span>
+          <input ref="standbyInputRef" type="file" accept="image/*" @change="handleStandbyUpload" />
+          <span v-if="standbyError" class="error">{{ standbyError }}</span>
+          <span class="upload-filename">{{ standbyDisplayName || '선택된 파일 없음' }}</span>
+          <div v-if="draft.standbyThumb" class="preview">
+            <img :src="draft.standbyThumb" alt="대기화면 미리보기" @error="handleStandbyError" />
+          </div>
+          <button type="button" class="btn ghost upload-clear" @click="clearStandby">이미지 삭제</button>
+        </label>
         </div>
       </div>
       <div class="section-block">


### PR DESCRIPTION
### Motivation

- The image edit modal opened off-center which required users to move it to the center before editing, so it should open centered and match other modal styling.
- When clicking the file chooser again and then cancelling, the UI showed `선택된 파일 없음` even if an image preview was already uploaded, which is misleading.
- Persist and show the uploaded image file name when a preview exists so users can see the current filename without re-uploading.

### Description

- Centered and styled the crop modal by adding `ds-modal` wrapper styles in `front/src/components/LiveImageCropModal.vue` so it opens in the viewport center with a backdrop.
- Added a filename extraction helper `extractFileName` and computed display names `thumbnailDisplayName` / `waitingDisplayName` in `front/src/components/BasicInfoEditModal.vue` and replaced the empty-state filename rendering to use these computed values.
- Tracked cropped filenames in `front/src/pages/seller/LiveCreateBasic.vue` by adding `thumbName`/`standbyName`, deriving `thumbDisplayName`/`standbyDisplayName`, setting them in `applyCroppedImage`, clearing them on remove, and rendering the display names in the template.
- Updated the front-end assets (minor `package-lock.json` changes) after running `npm install` while exercising the dev server.

### Testing

- Ran `npm install` in the `front` workspace which completed successfully.
- Started the dev server with `npm run dev` and Vite reported readiness, indicating the app built and served in dev mode successfully.
- Executed a Playwright script that navigated to `/seller/live/create/basic` and captured a screenshot which completed without errors.
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626437f788832692280bc0a52eec0c)