### PR TITLE
Fix broadcast carousel loop behavior and reservation cancel redirect

### DIFF
--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -743,16 +743,29 @@ const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
     loopIndex.value[kind] = getBaseLoopIndex(kind)
     return
   }
-  const lastIndex = items.length - 1
-  loopTransition.value[kind] = true
+  const firstRealIndex = 1
+  const lastRealIndex = items.length - 2
   const nextIndex = loopIndex.value[kind] + delta
-  if (nextIndex > lastIndex) {
-    loopIndex.value[kind] = lastIndex
-  } else if (nextIndex < 0) {
-    loopIndex.value[kind] = 0
-  } else {
-    loopIndex.value[kind] = nextIndex
+  if (nextIndex > lastRealIndex) {
+    loopTransition.value[kind] = false
+    loopIndex.value[kind] = firstRealIndex
+    requestAnimationFrame(() => {
+      loopTransition.value[kind] = true
+    })
+    restartAutoLoop(kind)
+    return
   }
+  if (nextIndex < firstRealIndex) {
+    loopTransition.value[kind] = false
+    loopIndex.value[kind] = lastRealIndex
+    requestAnimationFrame(() => {
+      loopTransition.value[kind] = true
+    })
+    restartAutoLoop(kind)
+    return
+  }
+  loopTransition.value[kind] = true
+  loopIndex.value[kind] = nextIndex
   restartAutoLoop(kind)
 }
 

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -675,16 +675,29 @@ const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
     loopIndex.value[kind] = getBaseLoopIndex(kind)
     return
   }
-  const lastIndex = items.length - 1
-  loopTransition.value[kind] = true
+  const firstRealIndex = 1
+  const lastRealIndex = items.length - 2
   const nextIndex = loopIndex.value[kind] + delta
-  if (nextIndex > lastIndex) {
-    loopIndex.value[kind] = lastIndex
-  } else if (nextIndex < 0) {
-    loopIndex.value[kind] = 0
-  } else {
-    loopIndex.value[kind] = nextIndex
+  if (nextIndex > lastRealIndex) {
+    loopTransition.value[kind] = false
+    loopIndex.value[kind] = firstRealIndex
+    requestAnimationFrame(() => {
+      loopTransition.value[kind] = true
+    })
+    restartAutoLoop(kind)
+    return
   }
+  if (nextIndex < firstRealIndex) {
+    loopTransition.value[kind] = false
+    loopIndex.value[kind] = lastRealIndex
+    requestAnimationFrame(() => {
+      loopTransition.value[kind] = true
+    })
+    restartAutoLoop(kind)
+    return
+  }
+  loopTransition.value[kind] = true
+  loopIndex.value[kind] = nextIndex
   restartAutoLoop(kind)
 }
 

--- a/front/src/pages/seller/broadcasts/ReservationDetail.vue
+++ b/front/src/pages/seller/broadcasts/ReservationDetail.vue
@@ -58,6 +58,7 @@ const handleCancel = () => {
         detail.value.status = 'CANCELED'
       }
       window.alert('예약이 취소되었습니다.')
+      router.push('/seller/live?tab=scheduled').catch(() => {})
     })
     .catch(() => {})
 }


### PR DESCRIPTION
### Motivation
- Prevent summary carousels from showing the first card again at the end of an automatic slide cycle which creates a visual duplicate.
- Make carousel wrapping seamless by jumping to the real first/last indices without exposing cloned items during transition.
- Improve seller UX by navigating back to the reservation list (`tab=scheduled`) immediately after a successful reservation cancel.
- Keep the existing behavior that lists `RESERVED`/`VOD` items before `CANCELED`/`STOPPED` items in scheduled/VOD sections.

### Description
- Modify `stepCarousel` in `front/src/pages/admin/AdminLive.vue` to use `firstRealIndex`/`lastRealIndex` and perform a non-visual jump when wrapping instead of briefly showing cloned cards.
- Apply the same `stepCarousel` wrapping fix to `front/src/pages/seller/Live.vue` so seller-side carousels behave identically.
- Add a redirect in `front/src/pages/seller/broadcasts/ReservationDetail.vue` to `router.push('/seller/live?tab=scheduled')` after `cancelSellerBroadcast` completes successfully.
- Ensure the auto-loop is restarted consistently via `restartAutoLoop` after wrap adjustments to preserve timing and behavior.

### Testing
- No automated tests were run for these changes.
- All changes were implemented in the indicated files: `front/src/pages/admin/AdminLive.vue`, `front/src/pages/seller/Live.vue`, and `front/src/pages/seller/broadcasts/ReservationDetail.vue`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696284c502c48326a4aa09687ffdd4c3)