### PR TITLE
Fix broadcast ordering/visibility and admin carousel looping

### DIFF
--- a/front/src/pages/Live.vue
+++ b/front/src/pages/Live.vue
@@ -156,10 +156,16 @@ const getCountdownLabel = (item: LiveItem) => {
 const itemsForDay = computed(() => {
   const filtered = filterLivesByDay(liveItems.value, selectedDay.value)
   const visible = filtered.filter((item) => {
+    const rawStatus = (item.status ?? '').toUpperCase()
+    if (rawStatus === 'DELETED') return false
     const status = getLifecycleStatus(item)
-    if (status === 'VOD') return false
     if (status === 'CANCELED') return false
+    if (!['RESERVED', 'READY', 'ON_AIR', 'STOPPED', 'ENDED', 'VOD'].includes(status)) return false
     if (status === 'STOPPED' && isPastScheduledEnd(item)) return false
+    if (status === 'VOD') {
+      const visibility = (item as { isPublic?: boolean; public?: boolean }).isPublic ?? (item as { public?: boolean }).public
+      if (typeof visibility === 'boolean' && !visibility) return false
+    }
     return true
   })
   return sortLivesByStartAt(visible)

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -553,7 +553,7 @@ const filteredScheduledItems = computed(() => {
 
   if (scheduledStatus.value === 'canceled') return sortScheduled(canceled)
   if (scheduledStatus.value === 'reserved') return sortScheduled(reserved)
-  return sortScheduled([...reserved, ...canceled])
+  return [...sortScheduled(reserved), ...sortScheduled(canceled)]
 })
 
 const categoryOptions = computed(() => categories.value)

--- a/front/src/pages/seller/broadcasts/ReservationDetail.vue
+++ b/front/src/pages/seller/broadcasts/ReservationDetail.vue
@@ -58,7 +58,7 @@ const handleCancel = () => {
         detail.value.status = 'CANCELED'
       }
       window.alert('예약이 취소되었습니다.')
-      router.push('/seller/live?tab=scheduled').catch(() => {})
+      router.replace({ path: '/seller/live', query: { tab: 'scheduled' } }).catch(() => {})
     })
     .catch(() => {})
 }


### PR DESCRIPTION
### Motivation

- Prevent the admin "전체" carousel from showing duplicate edge cards caused by unconditional loop cloning and to avoid unexpected carousel behavior. 
- Ensure scheduled lists show `RESERVED` items before `CANCELED` items regardless of other sort settings in both admin and seller views. 
- After a seller cancels a reservation, the UI should return the seller to the reservations list instead of leaving them on the detail page. 
- Restrict public viewer lists to only the intended statuses (`RESERVED`, `READY`, `ON_AIR`, `STOPPED` within window, `ENDED`, and public `VOD`) and exclude `DELETED`/`CANCELED` entries.

### Description

- Adjusted scheduled list merging to keep reserved items ahead of canceled ones by returning `[...]sortScheduled(reserved), ...sortScheduled(canceled)` in both `AdminLive.vue` and `seller/Live.vue`. 
- Introduced a `loopEnabled` flag and changed `buildLoopItems` to accept an `enableLoop` parameter, initialized `loopIndex` to `0`, and guarded loop logic in `AdminLive.vue` to stop creating cloned edge cards and to disable auto-looping when not enabled. 
- Tightened viewer filtering in `Live.vue` to exclude `DELETED` and `CANCELED` statuses, only include the allowed lifecycle statuses, allow `VOD` only if public, and keep `STOPPED` visible only within its scheduled window. 
- Changed reservation cancel flow in `ReservationDetail.vue` to navigate back using `router.replace({ path: '/seller/live', query: { tab: 'scheduled' } })` after successful cancellation.

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962899beac48326aca21d0639b06288)