### PR TITLE
Fix carousel duplication, scheduled ordering, and public visibility

### DIFF
--- a/front/src/pages/Live.vue
+++ b/front/src/pages/Live.vue
@@ -156,10 +156,16 @@ const getCountdownLabel = (item: LiveItem) => {
 const itemsForDay = computed(() => {
   const filtered = filterLivesByDay(liveItems.value, selectedDay.value)
   const visible = filtered.filter((item) => {
+    const rawStatus = (item.status ?? '').toUpperCase()
+    if (rawStatus === 'DELETED') return false
     const status = getLifecycleStatus(item)
-    if (status === 'VOD') return false
     if (status === 'CANCELED') return false
+    if (!['RESERVED', 'READY', 'ON_AIR', 'STOPPED', 'ENDED', 'VOD'].includes(status)) return false
     if (status === 'STOPPED' && isPastScheduledEnd(item)) return false
+    if (status === 'VOD') {
+      const visibility = (item as { isPublic?: boolean; public?: boolean }).isPublic ?? (item as { public?: boolean }).public
+      if (typeof visibility === 'boolean' && !visibility) return false
+    }
     return true
   })
   return sortLivesByStartAt(visible)

--- a/front/src/pages/seller/broadcasts/ReservationDetail.vue
+++ b/front/src/pages/seller/broadcasts/ReservationDetail.vue
@@ -58,7 +58,7 @@ const handleCancel = () => {
         detail.value.status = 'CANCELED'
       }
       window.alert('예약이 취소되었습니다.')
-      router.push('/seller/live?tab=scheduled').catch(() => {})
+      router.replace({ path: '/seller/live', query: { tab: 'scheduled' } }).catch(() => {})
     })
     .catch(() => {})
 }


### PR DESCRIPTION
### Motivation
- Prevent duplicate edge cards and unexpected looping behavior in seller/admin carousels by making loop cloning conditional.
- Ensure scheduled lists present `RESERVED` items before `CANCELED` ones regardless of sort settings.
- Restrict public viewer lists to intended lifecycle statuses and only show `VOD` when it is public.
- After a seller cancels a reservation, return the user to the reservations list instead of staying on the detail page.

### Description
- Added a `loopEnabled` flag and updated `loopIndex` initialization to `0`, modified `buildLoopItems` to accept `enableLoop` and only clone edges when enabled, and guarded loop logic in `seller/Live.vue` and `admin/AdminLive.vue` (affects `getBaseLoopIndex`, `handleLoopTransitionEnd`, `stepCarousel`, `startAutoLoop`, and `resetLoop`).
- Changed scheduled merging to keep reserved items ahead of canceled ones by returning `[..., sortScheduled(reserved), ...sortScheduled(canceled)]` in both `AdminLive.vue` and `seller/Live.vue`.
- Tightened public viewer filtering in `front/src/pages/Live.vue` to exclude `DELETED`/`CANCELED`, allow only `RESERVED`, `READY`, `ON_AIR`, `STOPPED`, `ENDED`, and `VOD` (with `VOD` visible only if public).
- Updated seller cancel flow in `front/src/pages/seller/broadcasts/ReservationDetail.vue` to navigate back using `router.replace({ path: '/seller/live', query: { tab: 'scheduled' } })` after successful cancellation.

### Testing
- Launched the dev server with `npm run dev` and the server started successfully.
- Ran a Playwright script that opened `http://127.0.0.1:4173/seller/live?tab=all` and captured a screenshot to verify the seller carousel no longer shows duplicate edge cards (screenshot produced successfully).
- No unit or integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962899beac48326aca21d0639b06288)