### PR TITLE
Align live lifecycle status handling, polling, and product ordering

### DIFF
--- a/front/src/pages/Live.vue
+++ b/front/src/pages/Live.vue
@@ -4,13 +4,7 @@ import { useRouter } from 'vue-router'
 import ConfirmModal from '../components/ConfirmModal.vue'
 import PageContainer from '../components/PageContainer.vue'
 import PageHeader from '../components/PageHeader.vue'
-import {
-  filterLivesByDay,
-  getDayWindow,
-  getLiveStatus,
-  parseLiveDate,
-  sortLivesByStartAt,
-} from '../lib/live/utils'
+import { filterLivesByDay, getDayWindow, parseLiveDate, sortLivesByStartAt } from '../lib/live/utils'
 import { computeLifecycleStatus, getScheduledEndMs, normalizeBroadcastStatus, type BroadcastStatus } from '../lib/broadcastStatus'
 import type { LiveItem } from '../lib/live/types'
 import { useNow } from '../lib/live/useNow'
@@ -102,7 +96,12 @@ const getLifecycleStatus = (item: LiveItem): BroadcastStatus => {
   })
 }
 
-const getStatus = (item: LiveItem) => getLiveStatus(item, now.value)
+const getStatus = (item: LiveItem) => {
+  const status = getLifecycleStatus(item)
+  if (status === 'RESERVED') return 'UPCOMING'
+  if (status === 'VOD') return 'ENDED'
+  return 'LIVE'
+}
 const getSectionStatus = (item: LiveItem) => {
   const status = getLifecycleStatus(item)
   if (status === 'RESERVED') return 'UPCOMING'

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -357,6 +357,17 @@ const liveItemsSorted = computed(() => {
 const currentLive = computed(() => liveItemsSorted.value[0] ?? null)
 const showLiveStats = computed(() => Boolean(currentLive.value && liveStats.value?.hasData))
 const showLiveProducts = computed(() => Boolean(currentLive.value && liveProducts.value.length))
+const sortedLiveProducts = computed(() => {
+  const items = [...liveProducts.value]
+  items.sort((a, b) => {
+    const aSoldOut = a.status === '품절'
+    const bSoldOut = b.status === '품절'
+    if (aSoldOut !== bSoldOut) return aSoldOut ? 1 : -1
+    if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+    return 0
+  })
+  return items
+})
 const formatStatusLabel = (status?: BroadcastStatus | string | null) => getBroadcastStatusLabel(status)
 
 const loadSellerData = async () => {
@@ -1092,7 +1103,7 @@ onBeforeUnmount(() => {
             <span class="live-products__count">{{ liveProducts.length }}개</span>
           </div>
           <div class="live-products__list">
-            <div v-for="item in liveProducts" :key="item.id" class="product-row">
+            <div v-for="item in sortedLiveProducts" :key="item.id" class="product-row">
               <div class="product-thumb">
                 <img :src="item.thumb" :alt="item.title" loading="lazy" />
                 <span v-if="item.pinned" class="product-pin">PIN</span>

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -220,6 +220,20 @@ const lifecycleStatus = computed(() =>
   }),
 )
 const isInteractive = computed(() => lifecycleStatus.value === 'ON_AIR')
+const streamPlaceholderTitle = computed(() => {
+  if (lifecycleStatus.value === 'STOPPED') return '송출 중지됨'
+  if (lifecycleStatus.value === 'ENDED') return '방송 종료'
+  if (lifecycleStatus.value === 'READY' || lifecycleStatus.value === 'RESERVED') return '방송 시작 대기 중'
+  return '송출 화면 (WebRTC Stream)'
+})
+const streamPlaceholderSubtitle = computed(() => {
+  if (lifecycleStatus.value === 'STOPPED') return '운영 정책 위반으로 송출이 중지되었습니다.'
+  if (lifecycleStatus.value === 'ENDED') return '송출이 종료되어 대기 화면으로 전환되었습니다.'
+  if (lifecycleStatus.value === 'READY' || lifecycleStatus.value === 'RESERVED') {
+    return '예약 시간이 되면 자동으로 방송 송출이 시작됩니다.'
+  }
+  return '현재 송출 중인 화면이 표시됩니다.'
+})
 
 const clearStartTimer = () => {
   if (startTimer.value) {
@@ -606,7 +620,7 @@ const connectSse = (broadcastId: number) => {
 const startStatsPolling = (broadcastId: number) => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
-    if (lifecycleStatus.value === 'ON_AIR' || !sseConnected.value) {
+    if (['READY', 'ON_AIR', 'ENDED'].includes(lifecycleStatus.value) || !sseConnected.value) {
       void refreshStats(broadcastId)
       if (!sseConnected.value) {
         void refreshProducts(broadcastId)
@@ -978,8 +992,8 @@ const toggleFullscreen = async () => {
               </div>
             </div>
             <div v-else class="stream-placeholder">
-              <p class="stream-title">송출 화면 (WebRTC Stream)</p>
-              <p class="stream-sub">현재 송출 중인 화면이 표시됩니다.</p>
+              <p class="stream-title">{{ streamPlaceholderTitle }}</p>
+              <p class="stream-sub">{{ streamPlaceholderSubtitle }}</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Ensure UI and polling behavior follow the broadcast lifecycle (RESERVED → READY → ON_AIR → ENDED → VOD / STOPPED) so viewers, sellers and admins see correct state and messages.
- Keep realtime viewer/product stats updated during `READY` and `ENDED` windows to support pre-start and post-end panels.
- Surface clear placeholder messages for `READY`, `ENDED`, and `STOPPED` states in the player and seller stream views.
- Order products in live product panels so sold-out items appear after available items while preserving pinned items' priority.

### Description
- Compute and expose lifecycle-based display status in `front/src/pages/Live.vue` and `front/src/pages/LiveDetail.vue`, replacing the previous time-only `getLiveStatus` usage with `computeLifecycleStatus`/`normalizeBroadcastStatus` logic and mapping lifecycle values to `UPCOMING`/`LIVE`/`ENDED` UI labels.
- Extend stats/products polling conditions in `front/src/pages/LiveDetail.vue` and `front/src/pages/seller/LiveStream.vue` to run when lifecycle is `READY`, `ON_AIR`, or `ENDED`, and when SSE is disconnected, by checking `['READY','ON_AIR','ENDED']` before fetching.
- Update product sorting in `front/src/pages/LiveDetail.vue` and `front/src/pages/seller/Live.vue` so sold-out items are pushed to the end and pinned items are prioritized; replace direct iteration with new `sortedProducts`/`sortedLiveProducts` computed lists.
- Add lifecycle-aware placeholder labels and subtitles in the player areas: explicit messages for `STOPPED` (policy stop), `ENDED` (ended), and `READY`/`RESERVED` (waiting) in `LiveDetail.vue` and `LiveStream.vue`; remove unused `useNow` from `LiveDetail.vue` import.

### Testing
- No automated tests were run as part of this change.
- Changes were committed and code diffs were generated; no CI/lint/build results are included here.
- Manual inspection of modified files was performed during the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962956d341883268daff66623238ef9)