### PR TITLE
Gate viewer join tokens to READY/ON_AIR and request tokens from client

### DIFF
--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -54,6 +54,8 @@ export type BroadcastDetail = {
   scheduledAt?: string
   startedAt?: string
   thumbnailUrl?: string
+  waitScreenUrl?: string
+  stoppedReason?: string
   vodUrl?: string
   totalViews?: number
   totalLikes?: number
@@ -346,6 +348,12 @@ export const fetchBroadcastStats = async (broadcastId: number): Promise<Broadcas
     const { data } = await http.get<ApiResult<BroadcastStats>>(`/api/broadcasts/${broadcastId}/stats`)
     return ensureSuccess(data)
   })
+}
+
+export const joinBroadcast = async (broadcastId: number, viewerId?: string | null): Promise<string> => {
+  const headers = viewerId ? { 'X-Viewer-Id': viewerId } : undefined
+  const { data } = await http.post<ApiResult<string>>(`/api/broadcasts/${broadcastId}/join`, null, { headers })
+  return ensureSuccess(data)
 }
 
 export const fetchSellerBroadcastReport = async (broadcastId: number): Promise<BroadcastResult> => {

--- a/front/src/lib/live/types.ts
+++ b/front/src/lib/live/types.ts
@@ -10,4 +10,6 @@ export type LiveItem = {
   vodUrl?: string
   streamUrl?: string
   sellerName?: string
+  waitScreenUrl?: string
+  stoppedReason?: string
 }

--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -488,7 +488,7 @@ public class BroadcastService {
         if (broadcast.getStatus() == BroadcastStatus.STOPPED) {
             throw new BusinessException(ErrorCode.BROADCAST_STOPPED_BY_ADMIN);
         }
-        if (!isLiveGroup(broadcast.getStatus())) {
+        if (!isJoinableGroup(broadcast.getStatus())) {
             throw new BusinessException(ErrorCode.BROADCAST_NOT_ON_AIR);
         }
 
@@ -1260,6 +1260,10 @@ public class BroadcastService {
 
     private boolean isLiveGroup(BroadcastStatus status) {
         return status == BroadcastStatus.ON_AIR || status == BroadcastStatus.READY || status == BroadcastStatus.ENDED;
+    }
+
+    private boolean isJoinableGroup(BroadcastStatus status) {
+        return status == BroadcastStatus.ON_AIR || status == BroadcastStatus.READY;
     }
 
     private Long parseMemberId(String viewerId) {


### PR DESCRIPTION
### Motivation
- Prevent issuing WebRTC join tokens for broadcasts that are not joinable (e.g. ENDED) and ensure viewers receive a token only when appropriate.
- Ensure the frontend requests join tokens automatically when entering a live detail page or when lifecycle transitions to `READY`/`ON_AIR`.
- Surface lifecycle-aware UI states (waiting screen, countdowns, stopped reason) and make product/chat interactions respect broadcast lifecycle and login state.
- Improve realtime resilience by keeping polling for stats/products when SSE is unavailable or during READY/ON_AIR/ENDED windows.

### Description
- Backend: factor `isJoinableGroup` (`ON_AIR`/`READY`) and replace the previous join check in `joinBroadcast` to block token issuance when broadcasts are not joinable (`src/main/java/.../BroadcastService.java`).
- Frontend API: expose a `joinBroadcast` helper that posts to `/api/broadcasts/{id}/join` with an optional `X-Viewer-Id` header (`front/src/lib/live/api.ts`).
- Frontend pages: automatically request a join token on entering viewer/admin live detail pages and on lifecycle transitions by adding `requestJoinToken`, `streamToken` and `joinInFlight` state and watching `lifecycleStatus` (`front/src/pages/LiveDetail.vue`, `front/src/pages/admin/live/LiveDetail.vue`).
- UI/UX and resilience: add waiting/stopped placeholders, countdown/elapsed labels, login gating for product/chat, product sort adjustments, SSE fallback polling windows, and local media device helpers wired into seller stream settings (`front/...` changes across `Live.vue`, `seller/*`, and `LiveStream.vue`).

### Testing
- No automated tests were executed for these changes.
- (No CI/test run output was produced as part of this PR.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69629eafb1088326a40d6a0d9a3600ad)