### PR TITLE
feat: 챗봇 문의 기능을 헤더 탭에 연결한다

### DIFF
--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -11,11 +11,19 @@ const panelRef = ref<HTMLElement | null>(null)
 const isLoggedIn = ref(false)
 const memberCategory = ref<string | null>(null)
 
-const navLinks = [
+const navLinksBase = [
   {label: '상품', to: '/products'},
   {label: '셋업', to: '/setup'},
   {label: '라이브', to: '/live'},
 ]
+const showInquiryTab = computed(
+  () => isLoggedIn.value && !isSeller() && !isAdmin() && memberCategory.value !== 'ROLE_GUEST',
+)
+const navLinks = computed(() =>
+  showInquiryTab.value
+    ? [...navLinksBase, {label: '문의', to: '/chat'}]
+    : navLinksBase,
+)
 
 const sellerTabs = [
   {


### PR DESCRIPTION
## 📌 관련 이슈

- closes #198 

## 📝 작업 내용

- 챗봇 문의 기능(/chat)을 헤더 탭에 연결했습니다(문의).

## 🧐 리뷰 포인트

- 일반회원 로그인 후 상단 헤더 확인
