### PR TITLE
Include ON_AIR broadcasts in reserved quantity calculation

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -262,7 +262,11 @@ public class BroadcastService {
         var bpBroadcastId = field(name("bp", "broadcast_id"), Long.class);
 
         List<String> statuses = List.of(Status.ON_SALE.name(), Status.READY.name(), Status.LIMITED_SALE.name());
-        List<String> reservedStatuses = List.of(BroadcastStatus.RESERVED.name(), BroadcastStatus.READY.name());
+        List<String> reservedStatuses = List.of(
+                BroadcastStatus.RESERVED.name(),
+                BroadcastStatus.READY.name(),
+                BroadcastStatus.ON_AIR.name()
+        );
 
         var reservedQuantityField = org.jooq.impl.DSL.coalesce(org.jooq.impl.DSL.sum(bpQuantity), 0).as("reserved_qty");
         var reservedSubquery = dsl.select(bpProductId, reservedQuantityField)


### PR DESCRIPTION
### Motivation
- Ensure product availability calculation accounts for items already assigned to ongoing broadcasts as well as reserved/ready ones.
- Previously only `RESERVED` and `READY` broadcast statuses were considered when aggregating reserved quantities.
- Ended or VOD broadcasts should remain excluded from the reservation calculation so their quantities become available again.

### Description
- Updated `reservedStatuses` in `BroadcastService#getSellerProducts` to include `BroadcastStatus.ON_AIR`.
- The jOOQ subquery that computes `reserved_qty` now aggregates quantities from broadcasts in `RESERVED`, `READY`, and `ON_AIR` states.
- This value is used to compute `availableQty` and returned as `reservedBroadcastQty` in `ProductSelectResponse`.
- Change was made in `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java`.

### Testing
- No automated tests were executed as part of this change.
- The change is limited to the SQL aggregation condition and should be covered by existing product availability/unit tests when run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963455c99008326b20e2f4368266940)