### PR TITLE
VOD: retention, admin-lock enforcement, S3 cleanup and admin download

### DIFF
--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -108,6 +108,7 @@ export type BroadcastResult = {
   sanctionCount: number
   vodUrl?: string
   vodStatus?: string
+  vodAdminLock?: boolean
   encoding?: boolean
   productStats?: Array<{
     productId: number

--- a/src/main/java/com/deskit/deskit/livehost/common/exception/ErrorCode.java
+++ b/src/main/java/com/deskit/deskit/livehost/common/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     // 9. VOD 에러
     VOD_NOT_FOUND(HttpStatus.NOT_FOUND, "V001", "VOD를 찾을 수 없습니다."),
     CANNOT_OPEN_STOPPED_BROADCAST(HttpStatus.BAD_REQUEST, "V002", "제재된 방송은 공개로 전환할 수 없습니다."),
+    VOD_ADMIN_LOCKED(HttpStatus.FORBIDDEN, "V003", "관리자에 의해 비공개 처리된 VOD는 공개로 전환할 수 없습니다."),
 
     // 10. 파일 업로드 / S3 에러
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드에 실패했습니다."),

--- a/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastResultResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastResultResponse.java
@@ -40,6 +40,7 @@ public class BroadcastResultResponse {
     // vod
     private String vodUrl;
     private VodStatus vodStatus;
+    private boolean vodAdminLock;
     private boolean isEncoding;
 
     private List<ProductSalesStat> productStats;

--- a/src/main/java/com/deskit/deskit/livehost/entity/Vod.java
+++ b/src/main/java/com/deskit/deskit/livehost/entity/Vod.java
@@ -64,4 +64,10 @@ public class Vod {
     public void setAdminLock(boolean lock) {
         this.vodAdminLock = lock;
     }
+
+    public void markDeleted() {
+        this.status = VodStatus.DELETED;
+        this.vodUrl = null;
+        this.vodSize = 0L;
+    }
 }

--- a/src/main/java/com/deskit/deskit/livehost/repository/VodRepository.java
+++ b/src/main/java/com/deskit/deskit/livehost/repository/VodRepository.java
@@ -2,10 +2,15 @@ package com.deskit.deskit.livehost.repository;
 
 import com.deskit.deskit.livehost.entity.Broadcast;
 import com.deskit.deskit.livehost.entity.Vod;
+import com.deskit.deskit.livehost.common.enums.VodStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface VodRepository extends JpaRepository<Vod, Long> {
     Optional<Vod> findByBroadcast(Broadcast broadcast);
+
+    List<Vod> findByStatusNotAndCreatedAtBefore(VodStatus status, LocalDateTime threshold);
 }

--- a/src/main/java/com/deskit/deskit/livehost/service/AwsS3Service.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/AwsS3Service.java
@@ -143,6 +143,21 @@ public class AwsS3Service {
         }
     }
 
+    public void deleteObjectByUrl(String fileUrl) {
+        String key = extractKeyFromUrl(fileUrl);
+        if (key == null) {
+            return;
+        }
+        try {
+            if (amazonS3.doesObjectExist(bucket, key)) {
+                amazonS3.deleteObject(bucket, key);
+            }
+        } catch (Exception e) {
+            log.error("Failed to delete S3 object: {}", fileUrl, e);
+            throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
+        }
+    }
+
     private String extractKeyFromUrl(String fileUrl) {
         if (fileUrl == null || fileUrl.isBlank()) {
             return null;

--- a/src/main/java/com/deskit/deskit/livehost/service/VodMaintenanceService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/VodMaintenanceService.java
@@ -1,0 +1,42 @@
+package com.deskit.deskit.livehost.service;
+
+import com.deskit.deskit.livehost.common.enums.VodStatus;
+import com.deskit.deskit.livehost.entity.Vod;
+import com.deskit.deskit.livehost.repository.VodRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VodMaintenanceService {
+
+    private final VodRepository vodRepository;
+    private final AwsS3Service s3Service;
+
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void purgeExpiredVods() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(3);
+        List<Vod> expired = vodRepository.findByStatusNotAndCreatedAtBefore(VodStatus.DELETED, threshold);
+        if (expired.isEmpty()) {
+            return;
+        }
+        for (Vod vod : expired) {
+            try {
+                if (vod.getVodUrl() != null && !vod.getVodUrl().isBlank()) {
+                    s3Service.deleteObjectByUrl(vod.getVodUrl());
+                }
+                vod.markDeleted();
+            } catch (Exception e) {
+                log.error("VOD 자동 삭제 실패: vodId={}", vod.getVodId(), e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure VOD objects are retained only for the configured window (3 days) and then removed from object storage.
- Enforce that VODs marked private by an administrator cannot be republished by sellers and that STOPPED broadcasts published by admin transition to `VOD` correctly.
- Remove VOD files from S3 when deleted and persist a clear deleted state in the `Vod` entity.
- Provide administrators with a local copy of STOPPED recordings and expose admin-lock metadata to the seller UI so sellers cannot override admin decisions.

### Description
- Added `VodMaintenanceService` with a scheduled job (`@Scheduled(cron = "0 0 3 * * *")`) that finds VODs older than 3 days and deletes their S3 objects then marks them deleted using `Vod.markDeleted()`.
- Added `AwsS3Service.deleteObjectByUrl(String)` to remove objects by URL and `Vod.markDeleted()` to clear URL/size and set `VodStatus.DELETED`.
- Updated `BroadcastService` to: download STOPPED VODs to an admin-local directory (`vod.admin-download-dir`), set `Vod` status to `PRIVATE` when recording is stopped or missing a URL, enforce admin-lock in seller `updateVodVisibility` to throw `VOD_ADMIN_LOCKED` when a seller tries to make an admin-locked VOD public, and perform S3 deletions + `markDeleted()` on seller/admin delete endpoints.
- Exposed `vodAdminLock` in `BroadcastResultResponse` and updated frontend types and `front/src/pages/seller/broadcasts/VodDetail.vue` to disable the visibility toggle and show a notice when the VOD is admin-locked, while leaving download and delete actions intact.

### Testing
- No automated tests (unit or integration) were executed as part of this change.
- A code-level review was performed to ensure API and UI changes are wired (no runtime verification performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963531377d08326a7510b565f13ebf7)