### PR TITLE
Improve live cards and viewer layout

### DIFF
--- a/front/src/pages/Home.vue
+++ b/front/src/pages/Home.vue
@@ -61,7 +61,7 @@ const loadPopulars = async () => {
   popularSetupsLoading.value = false
 }
 
-const mapToLiveItems = (items: Array<{ broadcastId: number; title: string; notice?: string; thumbnailUrl?: string; startAt?: string; endAt?: string; liveViewerCount?: number; viewerCount?: number; sellerName?: string }>) =>
+const mapToLiveItems = (items: Array<{ broadcastId: number; title: string; notice?: string; thumbnailUrl?: string; startAt?: string; endAt?: string; liveViewerCount?: number; viewerCount?: number; sellerName?: string; status?: string }>) =>
   items
     .filter((item) => item.startAt)
     .map((item) => ({
@@ -71,6 +71,7 @@ const mapToLiveItems = (items: Array<{ broadcastId: number; title: string; notic
       thumbnailUrl: item.thumbnailUrl ?? '',
       startAt: item.startAt ?? '',
       endAt: item.endAt ?? item.startAt ?? '',
+      status: item.status,
       viewerCount: item.liveViewerCount ?? item.viewerCount ?? 0,
       sellerName: item.sellerName ?? '',
     }))

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -311,6 +311,14 @@ const syncChatHeight = () => {
   playerHeight.value = playerPanelRef.value.getBoundingClientRect().height
 }
 
+watch(showChat, async (value) => {
+  if (!value) {
+    return
+  }
+  await nextTick()
+  syncChatHeight()
+})
+
 const toggleSettings = () => {
   isSettingsOpen.value = !isSettingsOpen.value
 }
@@ -913,7 +921,7 @@ onBeforeUnmount(() => {
               <span class="status-badge" :class="statusBadgeClass">
                 {{ statusLabel }}
               </span>
-              <span v-if="lifecycleStatus === 'ON_AIR' && liveItem.viewerCount" class="status-viewers">
+              <span v-if="liveItem.viewerCount != null" class="status-viewers">
                 {{ liveItem.viewerCount.toLocaleString() }}명 시청 중
               </span>
               <span v-else-if="lifecycleStatus === 'RESERVED'" class="status-schedule">
@@ -1057,7 +1065,12 @@ onBeforeUnmount(() => {
           :style="{ height: playerHeight ? `${playerHeight}px` : undefined }"
         >
           <header class="chat-head">
-            <h4>실시간 채팅</h4>
+            <div class="chat-head__title">
+              <h4>실시간 채팅</h4>
+              <span v-if="liveItem.viewerCount != null" class="chat-viewers">
+                시청자 {{ liveItem.viewerCount.toLocaleString() }}명
+              </span>
+            </div>
             <button type="button" class="chat-close" aria-label="채팅 닫기" @click="toggleChat">×</button>
           </header>
           <div ref="chatListRef" class="chat-messages">
@@ -1464,11 +1477,26 @@ onBeforeUnmount(() => {
   gap: 10px;
 }
 
+.chat-head__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .chat-head h4 {
   margin: 0;
   font-size: 1rem;
   font-weight: 900;
   color: var(--text-strong);
+}
+
+.chat-viewers {
+  font-size: 0.85rem;
+  font-weight: 800;
+  color: var(--text-soft);
+  background: var(--surface-weak);
+  padding: 3px 8px;
+  border-radius: 999px;
 }
 
 .chat-close {


### PR DESCRIPTION
### Motivation
- Normalize live card visuals and ensure all broadcast cards share the same media aspect ratio and layout. 
- Allow viewers to enter broadcasts that are in `READY` state and surface READY/LIVE badges on cards. 
- Surface real-time data (viewer counts and broadcast time/countdown) on home and list cards. 
- Keep the live detail chat panel height in sync with the player and show viewer counts in chat header for better UX.

### Description
- Reworked `LiveCard.vue` to compute lifecycle status using `computeLifecycleStatus`, `normalizeBroadcastStatus`, and `getScheduledEndMs`, added `READY` badge, and enabled entry CTA for `READY` status. 
- Added viewer/time chips, truncated two-line descriptions, and enforced `16:9` media aspect ratio and stretched card rows for consistent sizing in `LiveCard.vue`. 
- Updated `Home.vue` mapping to pass through `status` from the public broadcast overview so cards can reflect lifecycle state. 
- Updated `LiveDetail.vue` to sync chat panel height when the chat panel is toggled and surface `viewerCount` both in the player status row and in the chat header with supporting styles.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready on the configured port (success). 
- Captured a UI screenshot using a Playwright script against the running dev server which completed and produced a screenshot artifact (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963648a1cd0832688514d3d43ad6389)