### PR TITLE
Fallback to `scheduledAt` for live lists and adjust stop navigation/confirmations

### DIFF
--- a/front/src/pages/Live.vue
+++ b/front/src/pages/Live.vue
@@ -349,20 +349,24 @@ onMounted(() => {
   }
 })
 
-const mapToLiveItems = (items: Array<{ broadcastId: number; title: string; notice?: string; thumbnailUrl?: string; startAt?: string; endAt?: string; liveViewerCount?: number; viewerCount?: number; sellerName?: string; status?: string }>) =>
+const mapToLiveItems = (items: Array<{ broadcastId: number; title: string; notice?: string; thumbnailUrl?: string; startAt?: string; scheduledAt?: string; endAt?: string; liveViewerCount?: number; viewerCount?: number; sellerName?: string; status?: string }>) =>
   items
-    .filter((item) => item.startAt)
-    .map((item) => ({
-      id: String(item.broadcastId),
-      title: item.title,
-      description: item.notice ?? '',
-      thumbnailUrl: item.thumbnailUrl ?? '',
-      startAt: item.startAt ?? '',
-      endAt: item.endAt ?? item.startAt ?? '',
-      viewerCount: item.liveViewerCount ?? item.viewerCount ?? 0,
-      status: item.status,
-      sellerName: item.sellerName ?? '',
-    }))
+    .map((item) => {
+      const startAt = item.startAt ?? item.scheduledAt ?? ''
+      if (!startAt) return null
+      return {
+        id: String(item.broadcastId),
+        title: item.title,
+        description: item.notice ?? '',
+        thumbnailUrl: item.thumbnailUrl ?? '',
+        startAt,
+        endAt: item.endAt ?? startAt,
+        viewerCount: item.liveViewerCount ?? item.viewerCount ?? 0,
+        status: item.status,
+        sellerName: item.sellerName ?? '',
+      }
+    })
+    .filter((item): item is LiveItem => Boolean(item))
 
 const loadBroadcasts = async () => {
   try {

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -385,6 +385,11 @@ const parseSseData = (event: MessageEvent) => {
   }
 }
 
+const buildStopConfirmMessage = (data: unknown) => {
+  const reason = typeof data === 'string' && data.trim() ? data.trim() : '관리자에 의해 방송이 중지되었습니다.'
+  return `${reason}\n방송에서 나가겠습니까?`
+}
+
 const scheduleRefresh = () => {
   if (refreshTimer.value) window.clearTimeout(refreshTimer.value)
   refreshTimer.value = window.setTimeout(() => {
@@ -431,7 +436,7 @@ const handleSseEvent = (event: MessageEvent) => {
         }
       }
       scheduleRefresh()
-      if (window.confirm(typeof data === 'string' ? data : '관리자에 의해 방송이 중지되었습니다.')) {
+      if (window.confirm(buildStopConfirmMessage(data))) {
         router.push({ name: 'live' }).catch(() => {})
       }
       break

--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -24,6 +24,7 @@ type LiveItem = {
   subtitle?: string
   thumb: string
   datetime?: string
+  scheduledAt?: string
   statusBadge?: string
   viewerBadge?: string
   ctaLabel?: string
@@ -246,12 +247,13 @@ const mapVodVisibility = () => {
 }
 
 const mapLiveItem = (item: any, kind: 'live' | 'scheduled' | 'vod'): LiveItem => {
-  const startAtMs = item.startAt ? toDateMs(item.startAt) : undefined
+  const startAtValue = item.startAt ?? item.scheduledAt
+  const startAtMs = startAtValue ? toDateMs(startAtValue) : undefined
   const endAtMs = item.endAt ? toDateMs(item.endAt) : getScheduledEndMs(startAtMs)
   const status = normalizeBroadcastStatus(item.status)
   const rawPublic = item.isPublic ?? item.public
   const visibility = typeof rawPublic === 'boolean' ? (rawPublic ? 'public' : 'private') : 'public'
-  const dateLabel = formatDateTime(item.startAt)
+  const dateLabel = formatDateTime(startAtValue)
   const datetime = kind === 'vod' ? (dateLabel ? `업로드: ${dateLabel}` : '') : dateLabel
   const liveViewerCount = typeof item.liveViewerCount === 'number' ? item.liveViewerCount : undefined
   const viewerBadge = liveViewerCount ? `${liveViewerCount}명 시청 중` : undefined
@@ -266,6 +268,7 @@ const mapLiveItem = (item: any, kind: 'live' | 'scheduled' | 'vod'): LiveItem =>
     sellerName: item.sellerName ?? '',
     status,
     startedAt: item.startAt,
+    scheduledAt: item.scheduledAt ?? item.startAt,
     viewers: toNumber(liveViewerCount ?? item.viewerCount),
     likes: toNumber(item.totalLikes),
     reports: toNumber(item.reportCount),
@@ -308,7 +311,7 @@ const mapVodItem = (item: any): AdminVodItem => {
 }
 
 const withLifecycleStatus = <T extends LiveItem>(item: T): T & { startAtMs?: number; endAtMs?: number; lifecycleStatus?: BroadcastStatus } => {
-  const startAtMs = item.startAtMs ?? item.startedAtMs ?? toDateMs(item.startedAt ?? item.datetime)
+  const startAtMs = item.startAtMs ?? item.startedAtMs ?? toDateMs(item.scheduledAt ?? item.startedAt ?? item.datetime)
   const endAtMs = getScheduledEndMs(startAtMs, item.endAtMs)
   const lifecycleStatus = computeLifecycleStatus({
     status: item.lifecycleStatus ?? item.status,

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -351,6 +351,11 @@ const parseSseData = (event: MessageEvent) => {
   }
 }
 
+const buildStopConfirmMessage = (data: unknown) => {
+  const reason = typeof data === 'string' && data.trim() ? data.trim() : '관리자에 의해 방송이 중지되었습니다.'
+  return `${reason}\n방송에서 나가겠습니까?`
+}
+
 const scheduleRefresh = (broadcastId: number) => {
   if (refreshTimer.value) window.clearTimeout(refreshTimer.value)
   refreshTimer.value = window.setTimeout(() => {
@@ -395,7 +400,7 @@ const handleSseEvent = (event: MessageEvent) => {
         detail.value.status = 'STOPPED'
       }
       scheduleRefresh(idValue)
-      if (window.confirm(typeof data === 'string' ? data : '관리자에 의해 방송이 중지되었습니다.')) {
+      if (window.confirm(buildStopConfirmMessage(data))) {
         goToList()
       }
       break
@@ -492,6 +497,7 @@ const handleStopSave = () => {
         detail.value.status = 'STOPPED'
         detail.value.stoppedReason = reason
       }
+      goToList()
     })
     .catch(() => {})
     .finally(() => {

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -327,15 +327,18 @@ const resolveRouteId = (item: LiveItem) => {
 }
 
 const mapBroadcastItem = (item: any, kind: 'live' | 'scheduled' | 'vod'): LiveItem => {
-  const startAtMs = item.startAt ? parseLiveDate(item.startAt).getTime() : undefined
+  const startAtValue = item.startAt ?? item.scheduledAt
+  const startAtMs = startAtValue ? parseLiveDate(startAtValue).getTime() : undefined
   const endAtMs = item.endAt ? parseLiveDate(item.endAt).getTime() : getScheduledEndMs(startAtMs)
   const status = normalizeBroadcastStatus(item.status)
   const rawPublic = item.isPublic ?? item.public
   const visibility = typeof rawPublic === 'boolean' ? (rawPublic ? 'public' : 'private') : 'public'
-  const dateLabel = formatDateTime(item.startAt)
+  const dateLabel = formatDateTime(startAtValue)
   const datetime = kind === 'vod' ? (dateLabel ? `업로드: ${dateLabel}` : '') : dateLabel
-  const liveViewerCount = typeof item.liveViewerCount === 'number' ? item.liveViewerCount : undefined
-  const viewerBadge = liveViewerCount ? `${liveViewerCount}명 시청 중` : undefined
+  const viewers = typeof item.liveViewerCount === 'number'
+    ? item.liveViewerCount
+    : (typeof item.viewerCount === 'number' ? item.viewerCount : 0)
+  const viewerBadge = typeof viewers === 'number' ? `${viewers}명 시청 중` : undefined
 
   return {
     id: String(item.broadcastId),
@@ -349,7 +352,7 @@ const mapBroadcastItem = (item: any, kind: 'live' | 'scheduled' | 'vod'): LiveIt
     lifecycleStatus: status,
     startAtMs: Number.isNaN(startAtMs) ? undefined : startAtMs,
     endAtMs: Number.isNaN(endAtMs ?? NaN) ? undefined : endAtMs,
-    viewers: liveViewerCount ?? item.viewerCount ?? 0,
+    viewers,
     likes: item.totalLikes ?? 0,
     revenue: parseAmount(item.totalSales),
     visibility,

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -556,6 +556,11 @@ const parseSseData = (event: MessageEvent) => {
   }
 }
 
+const buildStopConfirmMessage = (data: unknown) => {
+  const reason = typeof data === 'string' && data.trim() ? data.trim() : '관리자에 의해 방송이 중지되었습니다.'
+  return `${reason}\n방송에서 나가겠습니까?`
+}
+
 const scheduleRefresh = (broadcastId: number) => {
   if (refreshTimer.value) window.clearTimeout(refreshTimer.value)
   refreshTimer.value = window.setTimeout(() => {
@@ -610,7 +615,7 @@ const handleSseEvent = (event: MessageEvent) => {
     case 'BROADCAST_STOPPED':
       streamStatus.value = 'STOPPED'
       scheduleRefresh(id)
-      if (window.confirm(typeof data === 'string' ? data : '관리자에 의해 방송이 중지되었습니다.')) {
+      if (window.confirm(buildStopConfirmMessage(data))) {
         handleGoToList()
       }
       break


### PR DESCRIPTION
### Motivation

- Ensure list cards and badges use the intended scheduled start time when `startAt` is missing so time-based UI (badges, countdowns, lifecycle) remains correct during polling/SSE updates.
- Normalize viewer count selection so viewer badges display consistently across list and detail views.
- When an admin forces a broadcast `STOPPED`, return admins to the live list rather than VOD detail and treat STOPPED broadcasts appropriately in list sections.
- Make stop confirmations include the admin-provided reason and explicitly ask the user whether to leave the broadcast.

### Description

- Use `scheduledAt` as a fallback when building public live list items in `front/src/pages/Live.vue` by updating `mapToLiveItems` to derive `startAt` from `startAt ?? scheduledAt` and filter out entries without a start time.
- Normalize start time usage in seller/admin mappings by adding `startAtValue` / `scheduledAt` fallbacks in `front/src/pages/seller/Live.vue` and `front/src/pages/admin/AdminLive.vue`, and update lifecycle computations (`withLifecycleStatus`) to consider `scheduledAt` when deriving `startAtMs`/`endAtMs`.
- Prefer `liveViewerCount` then `viewerCount` for viewer badges in `front/src/pages/seller/Live.vue` and propagate a consistent `viewers` value into item objects.
- Add `buildStopConfirmMessage` and update SSE/stop handlers in `front/src/pages/LiveDetail.vue`, `front/src/pages/admin/live/LiveDetail.vue`, and `front/src/pages/seller/LiveStream.vue` to show a confirmation containing the stop reason and the prompt `방송에서 나가겠습니까?`, and route admin stop flows back to the live list (use `goToList`/`handleGoToList`).

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696364a6cc5c8326a9e82e65ab118ec0)