### PR TITLE
Enable viewer quality selection, standardize stop message, and keep STOPPED broadcasts in live window

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastListResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastListResponse.java
@@ -84,6 +84,13 @@ public class BroadcastListResponse {
         } else if (status == BroadcastStatus.READY) {
             this.startAt = scheduledAt;
             this.endAt = (scheduledAt != null) ? scheduledAt.plusMinutes(30) : null;
+        } else if (status == BroadcastStatus.STOPPED) {
+            this.startAt = (startedAt != null) ? startedAt : scheduledAt;
+            if (scheduledAt != null) {
+                this.endAt = scheduledAt.plusMinutes(30);
+            } else {
+                this.endAt = endedAt;
+            }
         } else {
             this.startAt = startedAt;
             this.endAt = endedAt;


### PR DESCRIPTION
### Motivation
- Make the viewer-side quality selector actually affect the playback/resolution instead of being a static UI control. 
- Simplify and standardize the UX when an admin forces a broadcast stop so viewers see a consistent policy-violation message. 
- Ensure broadcasts that were force-stopped remain visible in the ongoing/live section (and viewer lists) for the 30-minute scheduled window after their scheduled time. 

### Description
- Frontend: updated `front/src/pages/LiveDetail.vue` to add `selectedQuality`, `qualityOptions`, `applyVideoQuality` and a `MutationObserver`, bound the settings dropdown to `selectedQuality`, applied video track `applyConstraints` calls where possible, added CSS visual cues for lower quality, and cleaned up observer lifecycle handling. 
- Frontend: unified stop messaging and the confirm dialog text to the policy-violation phrasing shown to viewers. 
- Backend: updated `src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastListResponse.java` to map `STOPPED` broadcasts to a `startAt`/`endAt` window (use scheduled time + 30 minutes when available) so stopped items remain in the live/ongoing list for the expected window. 
- Misc: small defensive guards/try-catch added around quality application to avoid runtime errors when media tracks are unavailable. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637b818a3c83268e7542dcc68b27cf)