### PR TITLE
Enable auto-looping carousels on all broadcast tabs

### DIFF
--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -849,6 +849,15 @@ const resetAllLoops = () => {
   resetLoop('vod')
 }
 
+const updateLoopEnabled = () => {
+  const enable = activeTab.value === 'all'
+  loopEnabled.value = {
+    live: enable,
+    scheduled: enable,
+    vod: enable,
+  }
+}
+
 const handleResize = () => {
   updateSlideWidth('live')
   updateSlideWidth('scheduled')
@@ -861,6 +870,15 @@ const handleResize = () => {
 watch(
   () => route.query.tab,
   () => refreshTabFromQuery(),
+)
+
+watch(
+  () => activeTab.value,
+  () => {
+    updateLoopEnabled()
+    resetAllLoops()
+  },
+  { immediate: true },
 )
 
 watch([liveCategory, liveSort], () => {

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -815,6 +815,14 @@ const resetAllLoops = () => {
   resetLoop('vod')
 }
 
+const updateLoopEnabled = () => {
+  const enable = activeTab.value === 'all'
+  loopEnabled.value = {
+    scheduled: enable,
+    vod: enable,
+  }
+}
+
 const handleResize = () => {
   updateSlideWidth('scheduled')
   updateSlideWidth('vod')
@@ -864,6 +872,15 @@ watch(
   () => {
     syncTabFromRoute()
   },
+)
+
+watch(
+  () => activeTab.value,
+  () => {
+    updateLoopEnabled()
+    resetAllLoops()
+  },
+  { immediate: true },
 )
 
 watch(


### PR DESCRIPTION
### Motivation

- Ensure broadcast card lists auto-scroll when the card row width exceeds the viewport on the seller and admin broadcast pages. 
- Previously the carousel auto-looping was not enabled/updated when viewing the `all` tab, so overflowed lists did not auto-scroll. 

### Description

- Added `updateLoopEnabled` helper and a `watch` on `activeTab` to `front/src/pages/seller/Live.vue` to enable/disable loop behavior and reset loops when the tab changes. 
- Added the same `updateLoopEnabled` helper and `watch` to `front/src/pages/admin/AdminLive.vue` to keep admin carousels in sync. 
- The change enables looping for `scheduled` and `vod` in the seller view and `live`, `scheduled`, and `vod` in the admin view when `activeTab === 'all'`. 
- Existing resize and overflow checks remain in place so auto-loop only runs when the carousel actually overflows the viewport. 

### Testing

- No automated tests were run for this change. 
- Changes were limited to two files: `front/src/pages/seller/Live.vue` and `front/src/pages/admin/AdminLive.vue`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69638518eda48326b76c3b52099291ea)