### PR TITLE
Avoid duplicate cards in broadcast auto-looping

### DIFF
--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -633,9 +633,7 @@ const visibleVodItems = computed(() => filteredVodItems.value.slice(0, VOD_PAGE_
 const buildLoopItems = (items: LiveItem[], enableLoop: boolean): LiveItem[] => {
   if (!items.length) return []
   if (!enableLoop || items.length === 1) return items
-  const first = items[0]!
-  const last = items[items.length - 1]!
-  return [last, ...items, first]
+  return items
 }
 
 const scheduledLoopItems = computed<LiveItem[]>(() => buildLoopItems(scheduledSummary.value, loopEnabled.value.scheduled))
@@ -667,7 +665,7 @@ const baseItemsFor = (kind: LoopKind) => (kind === 'scheduled' ? scheduledSummar
 const getBaseLoopIndex = (kind: LoopKind) => {
   const items = loopItemsFor(kind)
   if (!items.length) return 0
-  return loopEnabled.value[kind] && items.length > 1 ? 1 : 0
+  return 0
 }
 
 const setCarouselRef = (kind: LoopKind) => (el: Element | ComponentPublicInstance | null) => {
@@ -708,22 +706,7 @@ const getTrackStyle = (kind: LoopKind) => {
 
 const handleLoopTransitionEnd = (kind: LoopKind) => {
   if (!loopEnabled.value[kind]) return
-  const items = loopItemsFor(kind)
-  if (items.length <= 1 || !isCarouselOverflowing(kind)) return
-  const lastIndex = items.length - 1
-  if (loopIndex.value[kind] === lastIndex) {
-    loopTransition.value[kind] = false
-    loopIndex.value[kind] = 1
-    requestAnimationFrame(() => {
-      loopTransition.value[kind] = true
-    })
-  } else if (loopIndex.value[kind] === 0) {
-    loopTransition.value[kind] = false
-    loopIndex.value[kind] = lastIndex - 1
-    requestAnimationFrame(() => {
-      loopTransition.value[kind] = true
-    })
-  }
+  if (!isCarouselOverflowing(kind)) return
 }
 
 const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
@@ -739,21 +722,20 @@ const stepCarousel = (kind: LoopKind, delta: -1 | 1) => {
     loopIndex.value[kind] = getBaseLoopIndex(kind)
     return
   }
-  const firstRealIndex = 1
-  const lastRealIndex = items.length - 2
   const nextIndex = loopIndex.value[kind] + delta
-  if (nextIndex > lastRealIndex) {
+  const lastIndex = items.length - 1
+  if (nextIndex > lastIndex) {
     loopTransition.value[kind] = false
-    loopIndex.value[kind] = firstRealIndex
+    loopIndex.value[kind] = 0
     requestAnimationFrame(() => {
       loopTransition.value[kind] = true
     })
     restartAutoLoop(kind)
     return
   }
-  if (nextIndex < firstRealIndex) {
+  if (nextIndex < 0) {
     loopTransition.value[kind] = false
-    loopIndex.value[kind] = lastRealIndex
+    loopIndex.value[kind] = lastIndex
     requestAnimationFrame(() => {
       loopTransition.value[kind] = true
     })
@@ -815,6 +797,14 @@ const resetAllLoops = () => {
   resetLoop('vod')
 }
 
+const updateLoopEnabled = () => {
+  const enable = activeTab.value === 'all'
+  loopEnabled.value = {
+    scheduled: enable,
+    vod: enable,
+  }
+}
+
 const handleResize = () => {
   updateSlideWidth('scheduled')
   updateSlideWidth('vod')
@@ -864,6 +854,15 @@ watch(
   () => {
     syncTabFromRoute()
   },
+)
+
+watch(
+  () => activeTab.value,
+  () => {
+    updateLoopEnabled()
+    resetAllLoops()
+  },
+  { immediate: true },
 )
 
 watch(


### PR DESCRIPTION
### Motivation
- Prevent the first/last broadcast card from appearing duplicated when carousels auto-advance.
- Remove the reliance on cloned edge items to implement looping so the UI shows only real items.
- Ensure loop behavior is enabled/disabled and loops reset when switching the `activeTab` (for the `all` view).

### Description
- In `front/src/pages/seller/Live.vue` and `front/src/pages/admin/AdminLive.vue` `buildLoopItems` no longer clones first/last items and instead returns the original item list when looping is enabled.
- `getBaseLoopIndex` now returns `0` and the clone-based index adjustments in `handleLoopTransitionEnd` were removed so we no longer depend on sentinel cloned slides.
- `stepCarousel` was refactored to wrap indices by setting the index to `0` or `lastIndex` when advancing past bounds, preserving smooth transitions without duplicated cards.
- Added `updateLoopEnabled` and a `watch` on `activeTab` that updates `loopEnabled` and calls `resetAllLoops` (immediate) to keep loop state in sync when tabs change.

### Testing
- No automated tests were run for this change.
- Changes were limited to `front/src/pages/seller/Live.vue` and `front/src/pages/admin/AdminLive.vue`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69638518eda48326b76c3b52099291ea)