### PR TITLE
Import missing `nextTick` in LiveDetail to fix runtime error

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -1,5 +1,5 @@
 ﻿<script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Client, type StompSubscription } from '@stomp/stompjs'
 import SockJS from 'sockjs-client/dist/sockjs'


### PR DESCRIPTION
### Motivation

- Users hit an uncaught `ReferenceError: nextTick is not defined` when entering a broadcast because `scrollToBottom` calls Vue's `nextTick` but it was not imported in `LiveDetail.vue`.
- Adding the missing import prevents the runtime error and stabilizes scroll behavior when joining a live.

### Description

- Added `nextTick` to the Vue import list in `front/src/pages/LiveDetail.vue`.
- No other logic or behavior changes were made to the component.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696387b8f3f08326bf1da0b1c7f6dc29)