### PR TITLE
Inject realtime live stats into admin broadcast list responses

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -458,7 +458,9 @@ public class BroadcastService {
 
     @Transactional(readOnly = true)
     public Object getAdminBroadcasts(BroadcastSearch condition, Pageable pageable) {
-        return broadcastRepository.searchBroadcasts(null, condition, pageable, true);
+        Slice<BroadcastListResponse> list = broadcastRepository.searchBroadcasts(null, condition, pageable, true);
+        injectLiveStats(list.getContent());
+        return list;
     }
 
     @Transactional


### PR DESCRIPTION
### Motivation
- Admin-side broadcast cards showed stale "0명" counts because the admin broadcasts API did not include realtime viewer/like/report metrics for on-air items.
- The front-end polls the list frequently (every 5s) but received no realtime stats from the admin endpoint, so polling had no effect.

### Description
- Update `BroadcastService#getAdminBroadcasts` to load a `Slice<BroadcastListResponse>`, call `injectLiveStats(list.getContent())`, and return the modified `Slice`.
- This makes the admin endpoint consistent with `getPublicBroadcasts` and `getSellerBroadcasts` which already inject realtime stats for on-air broadcasts.
- Changed file: `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java`.

### Testing
- No automated tests were run for this change.
- The change is a small server-side data enrichment and does not alter API signatures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696388bd2e608326a0c84a73dd64efa7)