### PR TITLE
[FEAT] 판매자 상품 등록 API 구현 (Product/Image/Tag)

### DIFF
--- a/src/main/java/com/deskit/deskit/product/controller/SellerProductController.java
+++ b/src/main/java/com/deskit/deskit/product/controller/SellerProductController.java
@@ -1,0 +1,103 @@
+package com.deskit.deskit.product.controller;
+
+import com.deskit.deskit.account.entity.Seller;
+import com.deskit.deskit.account.oauth.CustomOAuth2User;
+import com.deskit.deskit.account.repository.SellerRepository;
+import com.deskit.deskit.product.dto.ProductCreateRequest;
+import com.deskit.deskit.product.dto.ProductCreateResponse;
+import com.deskit.deskit.product.dto.ProductImageResponse;
+import com.deskit.deskit.product.dto.ProductTagUpdateRequest;
+import com.deskit.deskit.product.entity.ProductImage.ImageType;
+import com.deskit.deskit.product.service.ProductImageService;
+import com.deskit.deskit.product.service.ProductService;
+import com.deskit.deskit.product.service.ProductTagService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/seller/products")
+public class SellerProductController {
+
+  private final ProductService productService;
+  private final ProductImageService productImageService;
+  private final ProductTagService productTagService;
+  private final SellerRepository sellerRepository;
+
+  public SellerProductController(ProductService productService,
+                                 ProductImageService productImageService,
+                                 ProductTagService productTagService,
+                                 SellerRepository sellerRepository) {
+    this.productService = productService;
+    this.productImageService = productImageService;
+    this.productTagService = productTagService;
+    this.sellerRepository = sellerRepository;
+  }
+
+  @PostMapping
+  public ResponseEntity<ProductCreateResponse> createProduct(
+          @AuthenticationPrincipal CustomOAuth2User user,
+          @Valid @RequestBody ProductCreateRequest request
+  ) {
+    Long sellerId = resolveSellerId(user);
+    return ResponseEntity.ok(productService.createProduct(sellerId, request));
+  }
+
+  @PostMapping("/{productId}/images")
+  public ResponseEntity<ProductImageResponse> uploadProductImage(
+          @AuthenticationPrincipal CustomOAuth2User user,
+          @PathVariable("productId") Long productId,
+          @RequestParam("file") MultipartFile file,
+          @RequestParam("imageType") ImageType imageType,
+          @RequestParam("slotIndex") Integer slotIndex
+  ) {
+    Long sellerId = resolveSellerId(user);
+    return ResponseEntity.ok(
+      productImageService.uploadImage(sellerId, productId, file, imageType, slotIndex)
+    );
+  }
+
+  @PutMapping("/{productId}/tags")
+  public ResponseEntity<Void> updateProductTags(
+          @AuthenticationPrincipal CustomOAuth2User user,
+          @PathVariable("productId") Long productId,
+          @Valid @RequestBody ProductTagUpdateRequest request
+  ) {
+    Long sellerId = resolveSellerId(user);
+    productTagService.updateProductTags(sellerId, productId, request);
+    return ResponseEntity.ok().build();
+  }
+
+  private Long resolveSellerId(CustomOAuth2User user) {
+    if (user == null) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+    }
+
+    String role = user.getAuthorities().iterator().next().getAuthority();
+    if (role == null || !role.startsWith("ROLE_SELLER")) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "seller role required");
+    }
+
+    String loginId = user.getUsername();
+    if (loginId == null || loginId.isBlank()) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "seller not found");
+    }
+
+    Seller seller = sellerRepository.findByLoginId(loginId);
+    if (seller == null || seller.getSellerId() == null) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "seller not found");
+    }
+
+    return seller.getSellerId();
+  }
+}

--- a/src/main/java/com/deskit/deskit/product/dto/ProductCreateRequest.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductCreateRequest.java
@@ -1,0 +1,34 @@
+package com.deskit.deskit.product.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ProductCreateRequest(
+  @JsonProperty("product_name")
+  @NotBlank
+  String productName,
+
+  @JsonProperty("short_desc")
+  @NotBlank
+  String shortDesc,
+
+  @JsonProperty("detail_html")
+  @NotBlank
+  String detailHtml,
+
+  @JsonProperty("price")
+  @NotNull
+  @Min(0)
+  Integer price,
+
+  @JsonProperty("stock_qty")
+  @NotNull
+  @Min(0)
+  Integer stockQty,
+
+  @JsonProperty("cost_price")
+  @Min(0)
+  Integer costPrice
+) {}

--- a/src/main/java/com/deskit/deskit/product/dto/ProductCreateResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductCreateResponse.java
@@ -1,0 +1,27 @@
+package com.deskit.deskit.product.dto;
+
+import com.deskit.deskit.product.entity.Product;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+
+public record ProductCreateResponse(
+  @JsonProperty("product_id")
+  Long productId,
+
+  @JsonProperty("status")
+  Product.Status status,
+
+  @JsonProperty("created_at")
+  LocalDateTime createdAt
+) {
+  public static ProductCreateResponse from(Product product) {
+    if (product == null) {
+      return new ProductCreateResponse(null, null, null);
+    }
+    return new ProductCreateResponse(
+      product.getId(),
+      product.getStatus(),
+      product.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/deskit/deskit/product/dto/ProductImageResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductImageResponse.java
@@ -1,0 +1,31 @@
+package com.deskit.deskit.product.dto;
+
+import com.deskit.deskit.product.entity.ProductImage;
+import com.deskit.deskit.product.entity.ProductImage.ImageType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ProductImageResponse(
+  @JsonProperty("product_image_id")
+  Long productImageId,
+
+  @JsonProperty("product_image_url")
+  String productImageUrl,
+
+  @JsonProperty("image_type")
+  ImageType imageType,
+
+  @JsonProperty("slot_index")
+  Integer slotIndex
+) {
+  public static ProductImageResponse from(ProductImage image) {
+    if (image == null) {
+      return new ProductImageResponse(null, null, null, null);
+    }
+    return new ProductImageResponse(
+      image.getId(),
+      image.getProductImageUrl(),
+      image.getImageType(),
+      image.getSlotIndex()
+    );
+  }
+}

--- a/src/main/java/com/deskit/deskit/product/dto/ProductTagUpdateRequest.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductTagUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.deskit.deskit.product.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record ProductTagUpdateRequest(
+  @JsonProperty("tag_ids")
+  @NotNull
+  List<Long> tagIds
+) {}

--- a/src/main/java/com/deskit/deskit/product/entity/ProductImage.java
+++ b/src/main/java/com/deskit/deskit/product/entity/ProductImage.java
@@ -1,0 +1,53 @@
+package com.deskit.deskit.product.entity;
+
+import com.deskit.deskit.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "product_image")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductImage extends BaseEntity {
+
+  public enum ImageType {
+    THUMBNAIL,
+    GALLERY
+  }
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "product_image_id", nullable = false)
+  private Long id;
+
+  @Column(name = "product_id", nullable = false)
+  private Long productId;
+
+  @Column(name = "product_image_url", nullable = false, length = 500)
+  private String productImageUrl;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "image_type", nullable = false)
+  private ImageType imageType;
+
+  @Column(name = "slot_index", nullable = false)
+  private Integer slotIndex;
+
+  public static ProductImage create(Long productId, String productImageUrl, ImageType imageType, Integer slotIndex) {
+    ProductImage image = new ProductImage();
+    image.productId = productId;
+    image.productImageUrl = productImageUrl;
+    image.imageType = imageType;
+    image.slotIndex = slotIndex;
+    return image;
+  }
+}

--- a/src/main/java/com/deskit/deskit/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductImageRepository.java
@@ -1,0 +1,16 @@
+package com.deskit.deskit.product.repository;
+
+import com.deskit.deskit.product.entity.ProductImage;
+import com.deskit.deskit.product.entity.ProductImage.ImageType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+
+  long countByProductIdAndDeletedAtIsNull(Long productId);
+
+  boolean existsByProductIdAndImageTypeAndSlotIndexAndDeletedAtIsNull(
+    Long productId,
+    ImageType imageType,
+    Integer slotIndex
+  );
+}

--- a/src/main/java/com/deskit/deskit/product/repository/ProductTagRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductTagRepository.java
@@ -46,7 +46,9 @@ public interface ProductTagRepository extends JpaRepository<ProductTag, ProductT
          and t.deletedAt is null
          and tc.deletedAt is null
          and pt.product.id in :productIds
-       order by pt.product.id, tc.tagCode, t.tagName
+      order by pt.product.id, tc.tagCode, t.tagName
       """)
   List<ProductTagRow> findActiveTagsByProductIds(@Param("productIds") List<Long> productIds);
+
+  void deleteByProduct_Id(Long productId);
 }

--- a/src/main/java/com/deskit/deskit/product/service/ProductImageService.java
+++ b/src/main/java/com/deskit/deskit/product/service/ProductImageService.java
@@ -1,0 +1,76 @@
+package com.deskit.deskit.product.service;
+
+import com.deskit.deskit.product.dto.ProductImageResponse;
+import com.deskit.deskit.product.entity.Product;
+import com.deskit.deskit.product.entity.ProductImage;
+import com.deskit.deskit.product.entity.ProductImage.ImageType;
+import com.deskit.deskit.product.repository.ProductImageRepository;
+import com.deskit.deskit.product.repository.ProductRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class ProductImageService {
+
+  private final ProductRepository productRepository;
+  private final ProductImageRepository productImageRepository;
+  private final S3Uploader s3Uploader;
+
+  public ProductImageService(ProductRepository productRepository,
+                             ProductImageRepository productImageRepository,
+                             S3Uploader s3Uploader) {
+    this.productRepository = productRepository;
+    this.productImageRepository = productImageRepository;
+    this.s3Uploader = s3Uploader;
+  }
+
+  public ProductImageResponse uploadImage(Long sellerId,
+                                          Long productId,
+                                          MultipartFile file,
+                                          ImageType imageType,
+                                          Integer slotIndex) {
+    if (sellerId == null) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "seller_id required");
+    }
+    if (productId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "product_id required");
+    }
+    if (file == null || file.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "file required");
+    }
+    if (imageType == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "imageType required");
+    }
+    if (slotIndex == null || slotIndex < 0) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "slotIndex required");
+    }
+
+    Product product = productRepository.findByIdAndDeletedAtIsNull(productId)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "product not found"));
+    if (!product.getSellerId().equals(sellerId)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+    }
+
+    long currentCount = productImageRepository.countByProductIdAndDeletedAtIsNull(productId);
+    if (currentCount >= 5) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "max 5 images per product");
+    }
+
+    if (productImageRepository.existsByProductIdAndImageTypeAndSlotIndexAndDeletedAtIsNull(
+      productId, imageType, slotIndex)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "image slot already used");
+    }
+
+    String keyPrefix = "seller/" + sellerId
+      + "/products/" + productId
+      + "/" + imageType.name().toLowerCase()
+      + "_" + slotIndex;
+    String imageUrl = s3Uploader.upload(keyPrefix, file);
+
+    ProductImage image = ProductImage.create(productId, imageUrl, imageType, slotIndex);
+    ProductImage saved = productImageRepository.save(image);
+    return ProductImageResponse.from(saved);
+  }
+}

--- a/src/main/java/com/deskit/deskit/product/service/ProductTagService.java
+++ b/src/main/java/com/deskit/deskit/product/service/ProductTagService.java
@@ -1,0 +1,78 @@
+package com.deskit.deskit.product.service;
+
+import com.deskit.deskit.product.dto.ProductTagUpdateRequest;
+import com.deskit.deskit.product.entity.Product;
+import com.deskit.deskit.product.entity.ProductTag;
+import com.deskit.deskit.product.repository.ProductRepository;
+import com.deskit.deskit.product.repository.ProductTagRepository;
+import com.deskit.deskit.tag.entity.Tag;
+import com.deskit.deskit.tag.repository.TagRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class ProductTagService {
+
+  private final ProductRepository productRepository;
+  private final ProductTagRepository productTagRepository;
+  private final TagRepository tagRepository;
+
+  public ProductTagService(ProductRepository productRepository,
+                           ProductTagRepository productTagRepository,
+                           TagRepository tagRepository) {
+    this.productRepository = productRepository;
+    this.productTagRepository = productTagRepository;
+    this.tagRepository = tagRepository;
+  }
+
+  @Transactional
+  public void updateProductTags(Long sellerId, Long productId, ProductTagUpdateRequest request) {
+    if (sellerId == null) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "seller_id required");
+    }
+    if (productId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "product_id required");
+    }
+    if (request == null || request.tagIds() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "tag_ids required");
+    }
+
+    Product product = productRepository.findByIdAndDeletedAtIsNull(productId)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "product not found"));
+    if (!product.getSellerId().equals(sellerId)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+    }
+
+    List<Long> tagIds = request.tagIds();
+    Set<Long> uniqueIds = new LinkedHashSet<>(tagIds);
+
+    if (uniqueIds.isEmpty()) {
+      productTagRepository.deleteByProduct_Id(productId);
+      return;
+    }
+
+    List<Tag> tags = tagRepository.findAllById(uniqueIds);
+    if (tags.size() != uniqueIds.size()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid tag_id");
+    }
+    for (Tag tag : tags) {
+      if (tag.getDeletedAt() != null) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid tag_id");
+      }
+    }
+
+    productTagRepository.deleteByProduct_Id(productId);
+
+    List<ProductTag> mappings = new ArrayList<>();
+    for (Tag tag : tags) {
+      mappings.add(new ProductTag(product, tag));
+    }
+    productTagRepository.saveAll(mappings);
+  }
+}

--- a/src/main/java/com/deskit/deskit/product/service/S3Uploader.java
+++ b/src/main/java/com/deskit/deskit/product/service/S3Uploader.java
@@ -1,0 +1,64 @@
+package com.deskit.deskit.product.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import jakarta.annotation.PostConstruct;
+import java.io.InputStream;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class S3Uploader {
+
+  private final AmazonS3 amazonS3;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  @Value("${cloud.aws.s3.endpoint}")
+  private String endpoint;
+
+  public S3Uploader(AmazonS3 amazonS3) {
+    this.amazonS3 = amazonS3;
+  }
+
+  @PostConstruct
+  void validateConfig() {
+    if (bucket == null || bucket.isBlank()) {
+      throw new IllegalStateException("cloud.aws.s3.bucket is required");
+    }
+    if (endpoint == null || endpoint.isBlank()) {
+      throw new IllegalStateException("cloud.aws.s3.endpoint is required");
+    }
+  }
+
+  public String upload(String keyPrefix, MultipartFile file) {
+    String originalFileName = file.getOriginalFilename();
+    String extension = resolveExtension(originalFileName);
+    String objectKey = keyPrefix + "/" + UUID.randomUUID() + extension;
+
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentType(file.getContentType());
+    metadata.setContentLength(file.getSize());
+
+    try (InputStream inputStream = file.getInputStream()) {
+      amazonS3.putObject(bucket, objectKey, inputStream, metadata);
+      return amazonS3.getUrl(bucket, objectKey).toString();
+    } catch (Exception ex) {
+      throw new IllegalStateException("file upload failed");
+    }
+  }
+
+  private String resolveExtension(String originalFileName) {
+    if (originalFileName == null || originalFileName.isBlank()) {
+      return "";
+    }
+    int dotIndex = originalFileName.lastIndexOf('.');
+    if (dotIndex < 0 || dotIndex == originalFileName.length() - 1) {
+      return "";
+    }
+    return originalFileName.substring(dotIndex);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- closes #149 

## 📝 작업 내용
- 판매자 상품 생성 API 구현 (POST /api/seller/products)
- 상품 기본 상태를 DRAFT로 생성하도록 처리
- ProductImage 업로드 전용 ProductImageService 분리 및 S3Uploader 연동
- 상품 이미지 업로드 API 추가 (POST /api/seller/products/{productId}/images)
- 상품 태그 매핑 API 구현 (PUT /api/seller/products/{productId}/tags)
- seller_id 기준 권한 및 소유권 검증 로직 추가
- 가격/재고/필수값 validation 처리