### PR TITLE
Poll live viewer counts for live cards and inject live stats into admin broadcasts

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -458,7 +458,9 @@ public class BroadcastService {
 
     @Transactional(readOnly = true)
     public Object getAdminBroadcasts(BroadcastSearch condition, Pageable pageable) {
-        return broadcastRepository.searchBroadcasts(null, condition, pageable, true);
+        Slice<BroadcastListResponse> list = broadcastRepository.searchBroadcasts(null, condition, pageable, true);
+        injectLiveStats(list.getContent());
+        return list;
     }
 
     @Transactional


### PR DESCRIPTION
### Motivation
- Admin-side broadcast lists were returning stale "0명" counts because the admin endpoint did not include realtime viewer/like/report metrics for on-air items.
- Buyer and seller live cards should refresh only realtime metrics (viewer counts) on a short interval so the UI updates frequently without reloading full list data.
- Polling should run every 5 seconds only for on-air broadcasts and only when the page is visible to avoid unnecessary load. 

### Description
- Server: `BroadcastService#getAdminBroadcasts` now loads a `Slice<BroadcastListResponse>`, calls `injectLiveStats(list.getContent())`, and returns the enriched `Slice` so admin list responses include realtime stats (`src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java`).
- Frontend: added `updateLiveViewerCounts` helpers that call `fetchBroadcastStats` and update viewer counts for on-air items without reloading lists in `front/src/pages/Live.vue`, `front/src/pages/Home.vue`, and `front/src/pages/seller/Live.vue`.
- Polling: replaced full-list refreshes with 5s polling that only fetches per-broadcast stats for targets where lifecycle/status is `ON_AIR`, and guarded polling by `document.visibilityState`.
- Implementation uses `Promise.allSettled` to fetch stats in parallel and safely merges `viewerCount`/`viewers`/`viewerBadge` into existing list items.

### Testing
- No automated tests were run for these changes.
- Manual verification was implied by local edits and commit, but no CI or unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696388bd2e608326a0c84a73dd64efa7)