### PR TITLE
Poll live viewer counts every 5s and refresh detail stats while visible

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -519,11 +519,12 @@ const connectSse = (id: number) => {
 const startStatsPolling = () => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
-    if (['READY', 'ON_AIR', 'ENDED'].includes(lifecycleStatus.value) || !sseConnected.value) {
-      void loadStats()
-      if (!sseConnected.value) {
-        void loadProducts()
-      }
+    if (document.visibilityState !== 'visible') {
+      return
+    }
+    void loadStats()
+    if (!sseConnected.value) {
+      void loadProducts()
     }
   }, 5000)
 }

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -474,11 +474,12 @@ const connectSse = (broadcastId: number) => {
 const startStatsPolling = (broadcastId: number) => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
-    if (['READY', 'ON_AIR', 'ENDED'].includes(lifecycleStatus.value) || !sseConnected.value) {
-      void refreshStats(broadcastId)
-      if (!sseConnected.value) {
-        void refreshProducts(broadcastId)
-      }
+    if (document.visibilityState !== 'visible') {
+      return
+    }
+    void refreshStats(broadcastId)
+    if (!sseConnected.value) {
+      void refreshProducts(broadcastId)
     }
   }, 5000)
 }

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -838,11 +838,12 @@ const connectSse = (broadcastId: number) => {
 const startStatsPolling = (broadcastId: number) => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
-    if (['READY', 'ON_AIR', 'ENDED'].includes(lifecycleStatus.value) || !sseConnected.value) {
-      void refreshStats(broadcastId)
-      if (!sseConnected.value) {
-        void refreshProducts(broadcastId)
-      }
+    if (document.visibilityState !== 'visible') {
+      return
+    }
+    void refreshStats(broadcastId)
+    if (!sseConnected.value) {
+      void refreshProducts(broadcastId)
     }
   }, 5000)
 }

--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -458,7 +458,9 @@ public class BroadcastService {
 
     @Transactional(readOnly = true)
     public Object getAdminBroadcasts(BroadcastSearch condition, Pageable pageable) {
-        return broadcastRepository.searchBroadcasts(null, condition, pageable, true);
+        Slice<BroadcastListResponse> list = broadcastRepository.searchBroadcasts(null, condition, pageable, true);
+        injectLiveStats(list.getContent());
+        return list;
     }
 
     @Transactional


### PR DESCRIPTION
### Motivation
- Keep viewer counts and realtime metrics accurate across list and detail screens (home, public list, seller, admin, and viewer detail) without requiring full list reloads. 
- Ensure polling is scoped to the visible page to reduce unnecessary network load. 
- Allow detail pages to update stats even when SSE is unavailable by falling back to periodic fetches. 
- Make admin lists include live stats server-side so management views do not show stale zeros.

### Description
- Added `updateLiveViewerCounts` to list screens (`front/src/pages/Home.vue`, `front/src/pages/Live.vue`, `front/src/pages/seller/Live.vue`, `front/src/pages/admin/AdminLive.vue`) to `fetchBroadcastStats` for on-air items in parallel and merge `viewerCount`/`viewers`/`viewerBadge` into existing items. 
- Changed polling behavior in detail and stream pages (`front/src/pages/LiveDetail.vue`, `front/src/pages/seller/LiveStream.vue`, `front/src/pages/admin/live/LiveDetail.vue`) to always call `loadStats`/`refreshStats` every 5 seconds while `document.visibilityState === 'visible'`, and still fetch products when SSE is disconnected. 
- Replaced lifecycle/SSE-only guards so visible pages keep updating even if SSE is down. 
- Server-side: updated `BroadcastService#getAdminBroadcasts` to load a `Slice<BroadcastListResponse>`, call `injectLiveStats(list.getContent())`, and return the enriched `Slice` so admin lists include realtime stats.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696388bd2e608326a0c84a73dd64efa7)