### PR TITLE
Add OpenVidu viewer playback for admin and public live pages and publisher support for sellers

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@stomp/stompjs": "^7.2.1",
     "axios": "^1.4.0",
+    "openvidu-browser": "^2.30.0",
     "sockjs-client": "^1.6.1",
     "swiper": "^12.0.3",
     "vue": "^3.5.24",

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -1,4 +1,5 @@
 ﻿<script setup lang="ts">
+import { OpenVidu, type Session, type Subscriber } from 'openvidu-browser'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Client, type StompSubscription } from '@stomp/stompjs'
@@ -38,6 +39,11 @@ const streamToken = ref<string | null>(null)
 const viewerId = ref<string | null>(resolveViewerId(getAuthUser()))
 const joinedBroadcastId = ref<number | null>(null)
 const leaveRequested = ref(false)
+const viewerContainerRef = ref<HTMLDivElement | null>(null)
+const openviduInstance = ref<OpenVidu | null>(null)
+const openviduSession = ref<Session | null>(null)
+const openviduSubscriber = ref<Subscriber | null>(null)
+const openviduConnected = ref(false)
 
 const FALLBACK_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
 
@@ -115,6 +121,7 @@ const playerMessage = computed(() => {
   }
   return ''
 })
+const hasSubscriberStream = computed(() => openviduConnected.value && !!openviduSubscriber.value)
 
 const handleImageError = (event: Event) => {
   const target = event.target as HTMLImageElement | null
@@ -316,6 +323,68 @@ const applyVideoQuality = async (value: typeof selectedQuality.value) => {
   } catch {
     return
   }
+}
+
+const clearViewerContainer = () => {
+  if (viewerContainerRef.value) {
+    viewerContainerRef.value.innerHTML = ''
+  }
+}
+
+const resetOpenViduState = () => {
+  openviduConnected.value = false
+  openviduSubscriber.value = null
+  openviduSession.value = null
+  openviduInstance.value = null
+  clearViewerContainer()
+}
+
+const disconnectOpenVidu = () => {
+  if (openviduSession.value) {
+    try {
+      if (openviduSubscriber.value) {
+        openviduSession.value.unsubscribe(openviduSubscriber.value)
+      }
+      openviduSession.value.disconnect()
+    } catch {
+      // noop
+    }
+  }
+  resetOpenViduState()
+}
+
+const connectSubscriber = async (token: string) => {
+  if (!viewerContainerRef.value) return
+  try {
+    disconnectOpenVidu()
+    openviduInstance.value = new OpenVidu()
+    openviduSession.value = openviduInstance.value.initSession()
+    openviduSession.value.on('streamCreated', (event) => {
+      if (!viewerContainerRef.value || !openviduSession.value) return
+      if (openviduSubscriber.value) {
+        openviduSession.value.unsubscribe(openviduSubscriber.value)
+        openviduSubscriber.value = null
+        clearViewerContainer()
+      }
+      openviduSubscriber.value = openviduSession.value.subscribe(event.stream, viewerContainerRef.value, {
+        insertMode: 'append',
+      })
+    })
+    openviduSession.value.on('streamDestroyed', () => {
+      openviduSubscriber.value = null
+      clearViewerContainer()
+    })
+    await openviduSession.value.connect(token)
+    openviduConnected.value = true
+  } catch {
+    disconnectOpenVidu()
+  }
+}
+
+const ensureSubscriberConnected = async () => {
+  if (!streamToken.value || lifecycleStatus.value !== 'ON_AIR') return
+  if (openviduConnected.value) return
+  await connectSubscriber(streamToken.value)
 }
 
 const toggleChat = () => {
@@ -867,11 +936,13 @@ watch(
     isLiked.value = false
     likeCount.value = 0
     hasReported.value = false
+    streamToken.value = null
     void loadDetail()
     void loadProducts()
     void loadStats()
     messages.value = []
     disconnectChat()
+    disconnectOpenVidu()
     sseSource.value?.close()
     sseSource.value = null
     sseConnected.value = false
@@ -911,8 +982,19 @@ watch(
   lifecycleStatus,
   () => {
     void requestJoinToken()
+    if (lifecycleStatus.value === 'ON_AIR') {
+      void ensureSubscriberConnected()
+      return
+    }
+    disconnectOpenVidu()
   },
 )
+
+watch(streamToken, () => {
+  if (lifecycleStatus.value === 'ON_AIR') {
+    void ensureSubscriberConnected()
+  }
+})
 
 watch(
   selectedQuality,
@@ -928,6 +1010,7 @@ onBeforeUnmount(() => {
   document.removeEventListener('fullscreenchange', handleFullscreenChange)
   window.removeEventListener('deskit-user-updated', handleAuthUpdate)
   window.removeEventListener('pagehide', handlePageHide)
+  disconnectOpenVidu()
   qualityObserver.value?.disconnect()
   qualityObserver.value = null
   void sendLeaveSignal()
@@ -995,6 +1078,7 @@ onBeforeUnmount(() => {
           </div>
 
           <div ref="stageRef" class="player-frame" :class="{ 'player-frame--fullscreen': isFullscreen }">
+            <div v-show="hasSubscriberStream" ref="viewerContainerRef" class="player-frame__viewer"></div>
             <div v-if="['READY', 'ENDED', 'STOPPED'].includes(lifecycleStatus)" class="player-frame__placeholder">
               <img
                 v-if="waitingScreenUrl"
@@ -1005,7 +1089,7 @@ onBeforeUnmount(() => {
               />
               <p v-if="playerMessage" class="player-frame__message">{{ playerMessage }}</p>
             </div>
-            <span v-else class="player-frame__label">LIVE 플레이어</span>
+            <span v-else-if="!hasSubscriberStream" class="player-frame__label">LIVE 플레이어</span>
             <div class="player-actions">
               <div class="icon-action">
                 <button
@@ -1385,6 +1469,20 @@ onBeforeUnmount(() => {
   min-height: clamp(160px, auto, 560px);
   max-width: min(100%, calc((100vh - 180px) * (16 / 9)));
   overflow: hidden;
+}
+
+.player-frame__viewer {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: #000;
+}
+
+.player-frame__viewer :deep(video) {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .player-frame[data-quality='720p'] video,

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { OpenVidu, type Session, type Subscriber } from 'openvidu-browser'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import {
@@ -79,6 +80,11 @@ const streamToken = ref<string | null>(null)
 const viewerId = ref<string | null>(resolveViewerId(getAuthUser()))
 const joinedBroadcastId = ref<number | null>(null)
 const leaveRequested = ref(false)
+const viewerContainerRef = ref<HTMLDivElement | null>(null)
+const openviduInstance = ref<OpenVidu | null>(null)
+const openviduSession = ref<Session | null>(null)
+const openviduSubscriber = ref<Subscriber | null>(null)
+const openviduConnected = ref(false)
 const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
 const FALLBACK_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
 
@@ -329,6 +335,69 @@ const playerMessage = computed(() => {
   }
   return ''
 })
+const hasSubscriberStream = computed(() => openviduConnected.value && !!openviduSubscriber.value)
+
+const clearViewerContainer = () => {
+  if (viewerContainerRef.value) {
+    viewerContainerRef.value.innerHTML = ''
+  }
+}
+
+const resetOpenViduState = () => {
+  openviduConnected.value = false
+  openviduSubscriber.value = null
+  openviduSession.value = null
+  openviduInstance.value = null
+  clearViewerContainer()
+}
+
+const disconnectOpenVidu = () => {
+  if (openviduSession.value) {
+    try {
+      if (openviduSubscriber.value) {
+        openviduSession.value.unsubscribe(openviduSubscriber.value)
+      }
+      openviduSession.value.disconnect()
+    } catch {
+      // noop
+    }
+  }
+  resetOpenViduState()
+}
+
+const connectSubscriber = async (token: string) => {
+  if (!viewerContainerRef.value) return
+  try {
+    disconnectOpenVidu()
+    openviduInstance.value = new OpenVidu()
+    openviduSession.value = openviduInstance.value.initSession()
+    openviduSession.value.on('streamCreated', (event) => {
+      if (!viewerContainerRef.value || !openviduSession.value) return
+      if (openviduSubscriber.value) {
+        openviduSession.value.unsubscribe(openviduSubscriber.value)
+        openviduSubscriber.value = null
+        clearViewerContainer()
+      }
+      openviduSubscriber.value = openviduSession.value.subscribe(event.stream, viewerContainerRef.value, {
+        insertMode: 'append',
+      })
+    })
+    openviduSession.value.on('streamDestroyed', () => {
+      openviduSubscriber.value = null
+      clearViewerContainer()
+    })
+    await openviduSession.value.connect(token)
+    openviduConnected.value = true
+  } catch {
+    disconnectOpenVidu()
+  }
+}
+
+const ensureSubscriberConnected = async () => {
+  if (!streamToken.value || lifecycleStatus.value !== 'ON_AIR') return
+  if (openviduConnected.value) return
+  await connectSubscriber(streamToken.value)
+}
 
 const requestJoinToken = async () => {
   if (!detail.value) return
@@ -640,6 +709,7 @@ onBeforeUnmount(() => {
   statsTimer.value = null
   if (refreshTimer.value) window.clearTimeout(refreshTimer.value)
   refreshTimer.value = null
+  disconnectOpenVidu()
 })
 
 onMounted(() => {
@@ -655,6 +725,8 @@ watch(
     }
     leaveRequested.value = false
     joinedBroadcastId.value = null
+    streamToken.value = null
+    disconnectOpenVidu()
     loadDetail()
     const idValue = Number(value)
     if (!Number.isNaN(idValue)) {
@@ -680,8 +752,19 @@ watch(
   lifecycleStatus,
   () => {
     void requestJoinToken()
+    if (lifecycleStatus.value === 'ON_AIR') {
+      void ensureSubscriberConnected()
+      return
+    }
+    disconnectOpenVidu()
   },
 )
+
+watch(streamToken, () => {
+  if (lifecycleStatus.value === 'ON_AIR') {
+    void ensureSubscriberConnected()
+  }
+})
 </script>
 
 <template>
@@ -743,6 +826,7 @@ watch(
           <div ref="stageRef" class="monitor-stage" :class="{ 'monitor-stage--chat': showChat }">
             <div class="player-wrap">
               <div class="player-frame" :class="{ 'player-frame--fullscreen': isFullscreen }">
+                <div v-show="hasSubscriberStream" ref="viewerContainerRef" class="player-frame__viewer"></div>
                 <div class="player-overlay">
                   <div class="overlay-item">⏱ {{ detail.elapsed }}</div>
                   <div class="overlay-item">👥 {{ detail.viewers }}명</div>
@@ -781,7 +865,7 @@ watch(
                   />
                   <p v-if="playerMessage" class="player-placeholder__message">{{ playerMessage }}</p>
                 </div>
-                <div v-else class="player-label">송출 화면</div>
+                <div v-else-if="!hasSubscriberStream" class="player-label">송출 화면</div>
               </div>
             </div>
 
@@ -1009,6 +1093,20 @@ watch(
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.player-frame__viewer {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: #000;
+}
+
+.player-frame__viewer :deep(video) {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .player-frame--fullscreen {

--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -477,8 +477,19 @@ public class BroadcastService {
                 throw new BusinessException(ErrorCode.FORBIDDEN_ACCESS);
             }
 
-            if (broadcast.getScheduledAt() != null && LocalDateTime.now().isBefore(broadcast.getScheduledAt())) {
+            if (broadcast.getStatus() != BroadcastStatus.ON_AIR
+                    && broadcast.getScheduledAt() != null
+                    && LocalDateTime.now().isBefore(broadcast.getScheduledAt())) {
                 throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+
+            if (broadcast.getStatus() == BroadcastStatus.ON_AIR) {
+                try {
+                    Map<String, Object> params = Map.of("role", "HOST", "sellerId", sellerId);
+                    return openViduService.createToken(broadcastId, params);
+                } catch (Exception e) {
+                    throw new BusinessException(ErrorCode.OPENVIDU_ERROR);
+                }
             }
 
             validateTransition(broadcast.getStatus(), BroadcastStatus.ON_AIR);


### PR DESCRIPTION
### Motivation
- Allow viewers and admins to see the live OpenVidu stream in the public `LiveDetail` and admin monitor pages so realtime video is visible in the UI.  
- Let hosts/sellers obtain an OpenVidu host token while a broadcast is already `ON_AIR` so they can (re)connect without restarting the broadcast.  
- Integrate OpenVidu publisher flow into the seller live UI to enable in-browser publishing and handle device/volume changes.  

### Description
- Update `BroadcastService.startBroadcast` to return a host token immediately when the broadcast status is `ON_AIR` by calling `openViduService.createToken` and relax the scheduled-at check when already `ON_AIR`.  
- Add `openvidu-browser` to `front/package.json` and wire subscriber playback in `front/src/pages/LiveDetail.vue` by importing `OpenVidu`, rendering a viewer container, and adding connect/disconnect, event handlers, and lifecycle watchers.  
- Apply the same subscriber container, styles and lifecycle handling to the admin monitor at `front/src/pages/admin/live/LiveDetail.vue`.  
- Extend seller publisher logic in `front/src/pages/seller/LiveStream.vue` to request a publisher token, connect an OpenVidu publisher, handle restart on device changes, toggle audio/video, and apply volume to the publisher video.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69638e43f3048326a5a407ebd9811cc5)