### PR TITLE
Use realtime viewer counts for READY/ENDED broadcasts

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -1440,7 +1440,7 @@ public class BroadcastService {
 
     private void injectLiveStats(List<BroadcastListResponse> list) {
         list.forEach(item -> {
-            if (item.getStatus() == BroadcastStatus.ON_AIR) {
+            if (isLiveGroup(item.getStatus())) {
                 item.setLiveViewerCount(redisService.getRealtimeViewerCount(item.getBroadcastId()));
                 item.setTotalLikes(redisService.getLikeCount(item.getBroadcastId()));
                 item.setReportCount(redisService.getReportCount(item.getBroadcastId()));
@@ -1450,7 +1450,7 @@ public class BroadcastService {
 
     private void injectLiveDetails(List<BroadcastListResponse> list) {
         List<Long> liveIds = list.stream()
-                .filter(item -> item.getStatus() == BroadcastStatus.ON_AIR)
+                .filter(item -> isLiveGroup(item.getStatus()))
                 .map(BroadcastListResponse::getBroadcastId)
                 .toList();
         if (liveIds.isEmpty()) {
@@ -1461,7 +1461,7 @@ public class BroadcastService {
                 .collect(Collectors.groupingBy(bp -> bp.getBroadcast().getBroadcastId()));
 
         list.forEach(item -> {
-            if (item.getStatus() == BroadcastStatus.ON_AIR) {
+            if (isLiveGroup(item.getStatus())) {
                 item.setLiveViewerCount(redisService.getRealtimeViewerCount(item.getBroadcastId()));
                 item.setTotalLikes(redisService.getLikeCount(item.getBroadcastId()));
                 item.setReportCount(redisService.getReportCount(item.getBroadcastId()));


### PR DESCRIPTION
### Motivation
- Ensure broadcasts with status `READY` and `ENDED` receive realtime viewer, like, and report counts like `ON_AIR` to keep listing/detail counts consistent.
- Prevent stale counts in lists and details by treating ready/ended items as part of the live group for stats injection.

### Description
- Replaced direct `item.getStatus() == BroadcastStatus.ON_AIR` checks with `isLiveGroup(item.getStatus())` in `injectLiveStats` and `injectLiveDetails`.
- Updated the `liveIds` filter to use `isLiveGroup` so product/details loading and realtime counts include the live group.
- Changes made in `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963938015c48326bf5b9fff0dea4f95)