### PR TITLE
Allow stopping READY broadcasts; add VOD stats buffering, scheduler, and UI updates

### DIFF
--- a/front/src/components/LiveCard.vue
+++ b/front/src/components/LiveCard.vue
@@ -43,7 +43,7 @@ const status = computed(() => {
   if (lifecycleStatus.value === 'READY') return 'READY'
   if (lifecycleStatus.value === 'RESERVED') return 'UPCOMING'
   if (lifecycleStatus.value === 'STOPPED') return 'STOPPED'
-  if (lifecycleStatus.value === 'VOD') return 'ENDED'
+  if (lifecycleStatus.value === 'VOD') return 'VOD'
   return 'ENDED'
 })
 const buttonLabel = computed(() => {
@@ -51,6 +51,9 @@ const buttonLabel = computed(() => {
     return '입장하기'
   }
   if (status.value === 'ENDED') {
+    return '방송 입장'
+  }
+  if (status.value === 'VOD') {
     return 'VOD 다시보기'
   }
   return '예정'
@@ -79,9 +82,6 @@ const countdownLabel = computed(() => {
     const seconds = totalSeconds % 60
     return `${minutes}분 ${String(seconds).padStart(2, '0')}초 뒤 방송 시작`
   }
-  if (status.value === 'ENDED') {
-    return '방송 종료'
-  }
   return ''
 })
 
@@ -92,8 +92,14 @@ const timeLabel = computed(() => {
   if (status.value === 'READY') {
     return countdownLabel.value
   }
+  if (status.value === 'UPCOMING') {
+    return scheduledLabel.value
+  }
   if (status.value === 'STOPPED') {
     return '송출 중지'
+  }
+  if (status.value === 'VOD') {
+    return 'VOD'
   }
   return '방송 종료'
 })
@@ -101,6 +107,12 @@ const timeLabel = computed(() => {
 const viewerLabel = computed(() => {
   if (props.item.viewerCount == null) return ''
   if (status.value === 'LIVE' || status.value === 'READY') {
+    return `시청자 ${props.item.viewerCount.toLocaleString()}명`
+  }
+  if (status.value === 'VOD') {
+    return `누적 시청자 ${props.item.viewerCount.toLocaleString()}명`
+  }
+  if (status.value === 'ENDED') {
     return `시청자 ${props.item.viewerCount.toLocaleString()}명`
   }
   return ''
@@ -116,6 +128,10 @@ const handleWatchNow = () => {
     return
   }
   if (status.value === 'ENDED') {
+    router.push({ name: 'live-detail', params: { id: props.item.id } })
+    return
+  }
+  if (status.value === 'VOD') {
     router.push({ name: 'vod', params: { id: props.item.id } })
   }
 }
@@ -128,6 +144,7 @@ const handleWatchNow = () => {
       <div class="top-badges">
         <span v-if="status === 'LIVE'" class="badge badge-live">LIVE</span>
         <span v-else-if="status === 'READY'" class="badge badge-ready">READY</span>
+        <span v-else-if="status === 'UPCOMING'" class="badge badge-upcoming">예약</span>
         <span
           v-if="status === 'LIVE' && props.item.viewerCount != null"
           class="badge badge-viewers"
@@ -222,6 +239,10 @@ const handleWatchNow = () => {
 
 .badge-ready {
   background: rgba(56, 189, 248, 0.9);
+}
+
+.badge-upcoming {
+  background: rgba(139, 122, 94, 0.9);
 }
 
 .top-badges {

--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -376,6 +376,15 @@ export const leaveBroadcast = async (broadcastId: number, viewerId?: string | nu
   ensureSuccess(data)
 }
 
+export const recordVodView = async (broadcastId: number, viewerId?: string | null): Promise<void> => {
+  const headers = viewerId ? { 'X-Viewer-Id': viewerId } : undefined
+  const { data } = await http.post<ApiResult<void>>(`/api/broadcasts/${broadcastId}/vod/view`, null, {
+    headers,
+    params: viewerId ? { viewerId } : undefined,
+  })
+  ensureSuccess(data)
+}
+
 export const toggleBroadcastLike = async (broadcastId: number): Promise<BroadcastLikeResponse> => {
   const { data } = await http.post<ApiResult<BroadcastLikeResponse>>(`/api/member/broadcasts/${broadcastId}/like`)
   return ensureSuccess(data)

--- a/front/src/pages/Live.vue
+++ b/front/src/pages/Live.vue
@@ -108,6 +108,7 @@ const getStatus = (item: LiveItem) => {
   if (status === 'READY') return 'READY'
   if (status === 'RESERVED') return 'UPCOMING'
   if (status === 'STOPPED') return 'STOPPED'
+  if (status === 'VOD') return 'VOD'
   return 'ENDED'
 }
 const getSectionStatus = (item: LiveItem) => {
@@ -119,10 +120,9 @@ const getSectionStatus = (item: LiveItem) => {
 const isPastScheduledEnd = (item: LiveItem): boolean => {
   const startAtMs = parseLiveDate(item.startAt).getTime()
   const normalizedStart = Number.isNaN(startAtMs) ? undefined : startAtMs
-  const endAtMs = parseLiveDate(item.endAt).getTime()
-  const normalizedEnd = Number.isNaN(endAtMs) ? getScheduledEndMs(normalizedStart) : endAtMs
-  if (!normalizedEnd) return false
-  return Date.now() > normalizedEnd
+  const scheduledEndMs = getScheduledEndMs(normalizedStart)
+  if (!scheduledEndMs) return false
+  return Date.now() > scheduledEndMs
 }
 const isRowDisabled = (item: LiveItem) => getLifecycleStatus(item) === 'RESERVED'
 const getElapsedLabel = (item: LiveItem) => {
@@ -580,7 +580,18 @@ onMounted(() => {
                 <span v-else-if="getStatus(item) === 'READY'" class="status-pill">대기</span>
                 <span v-else-if="getStatus(item) === 'UPCOMING'" class="status-pill">예정</span>
                 <span v-else-if="getStatus(item) === 'STOPPED'" class="status-pill status-pill--ended">중지됨</span>
-                <span v-else class="status-pill status-pill--ended">종료</span>
+                <span v-else-if="getStatus(item) === 'VOD'" class="status-pill status-pill--ended">
+                  VOD
+                  <span v-if="item.viewerCount" class="status-viewers">
+                    누적 {{ item.viewerCount.toLocaleString() }}명
+                  </span>
+                </span>
+                <span v-else class="status-pill status-pill--ended">
+                  종료
+                  <span v-if="item.viewerCount" class="status-viewers">
+                    시청자 {{ item.viewerCount.toLocaleString() }}명
+                  </span>
+                </span>
                 <span
                   v-if="getStatus(item) === 'LIVE'"
                   class="status-pill status-pill--sub"

--- a/front/src/pages/Vod.vue
+++ b/front/src/pages/Vod.vue
@@ -6,8 +6,17 @@ import PageHeader from '../components/PageHeader.vue'
 import { getLiveStatus, parseLiveDate } from '../lib/live/utils'
 import { getScheduledEndMs } from '../lib/broadcastStatus'
 import { useNow } from '../lib/live/useNow'
-import { fetchBroadcastProducts, fetchPublicBroadcastDetail, type BroadcastProductItem } from '../lib/live/api'
+import {
+  fetchBroadcastProducts,
+  fetchPublicBroadcastDetail,
+  recordVodView,
+  reportBroadcast,
+  toggleBroadcastLike,
+  type BroadcastProductItem,
+} from '../lib/live/api'
 import type { LiveItem } from '../lib/live/types'
+import { getAuthUser } from '../lib/auth'
+import { resolveViewerId } from '../lib/live/viewer'
 
 const route = useRoute()
 const router = useRouter()
@@ -61,12 +70,54 @@ const showChat = ref(true)
 const isFullscreen = ref(false)
 const stageRef = ref<HTMLElement | null>(null)
 const isLiked = ref(false)
+const likeCount = ref(0)
+const likeInFlight = ref(false)
+const reportInFlight = ref(false)
+const hasReported = ref(false)
 const isSettingsOpen = ref(false)
 const settingsButtonRef = ref<HTMLElement | null>(null)
 const settingsPanelRef = ref<HTMLElement | null>(null)
 
-const toggleLike = () => {
-  isLiked.value = !isLiked.value
+const isLoggedIn = computed(() => Boolean(getAuthUser()))
+
+const requireMemberAction = () => {
+  if (!isLoggedIn.value) {
+    alert('회원만 이용할 수 있습니다.')
+    return false
+  }
+  return true
+}
+
+const toggleLike = async () => {
+  if (!vodItem.value || likeInFlight.value || !requireMemberAction()) return
+  likeInFlight.value = true
+  try {
+    const result = await toggleBroadcastLike(Number(vodItem.value.id))
+    isLiked.value = result.liked
+    likeCount.value = result.likeCount
+  } catch {
+    return
+  } finally {
+    likeInFlight.value = false
+  }
+}
+
+const submitReport = async () => {
+  if (!vodItem.value || reportInFlight.value || !requireMemberAction()) return
+  reportInFlight.value = true
+  try {
+    const result = await reportBroadcast(Number(vodItem.value.id))
+    hasReported.value = hasReported.value || result.reported
+    if (result.reported) {
+      alert('신고가 접수되었습니다.')
+    } else {
+      alert('이미 신고한 VOD입니다.')
+    }
+  } catch {
+    return
+  } finally {
+    reportInFlight.value = false
+  }
 }
 
 const toggleChat = () => {
@@ -145,7 +196,12 @@ const loadVodDetail = async () => {
   try {
     const detail = await fetchPublicBroadcastDetail(numeric)
     vodItem.value = buildVodItem(detail)
+    likeCount.value = detail.totalLikes ?? 0
+    isLiked.value = false
+    hasReported.value = false
     await loadProducts(numeric)
+    const viewerId = resolveViewerId(getAuthUser())
+    void recordVodView(numeric, viewerId)
   } catch {
     vodItem.value = null
   }
@@ -315,28 +371,47 @@ watch(showChat, (visible) => {
             <video v-else class="player-video" :src="vodItem.vodUrl" controls />
 
             <div class="player-actions">
-              <button
-                type="button"
-                class="icon-circle"
-                :class="{ active: isLiked }"
-                aria-label="좋아요"
-                @click="toggleLike"
-              >
-                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path
-                    v-if="isLiked"
-                    d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
-                    fill="currentColor"
-                  />
-                  <path
-                    v-else
-                    d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.8"
-                  />
-                </svg>
-              </button>
+              <div class="icon-action">
+                <button
+                  type="button"
+                  class="icon-circle"
+                  :class="{ active: isLiked }"
+                  aria-label="좋아요"
+                  :disabled="likeInFlight"
+                  @click="toggleLike"
+                >
+                  <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path
+                      v-if="isLiked"
+                      d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
+                      fill="currentColor"
+                    />
+                    <path
+                      v-else
+                      d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.8"
+                    />
+                  </svg>
+                </button>
+                <span class="icon-count">{{ likeCount.toLocaleString('ko-KR') }}</span>
+              </div>
+              <div class="icon-action">
+                <button
+                  type="button"
+                  class="icon-circle"
+                  aria-label="신고하기"
+                  :disabled="reportInFlight || hasReported"
+                  @click="submitReport"
+                >
+                  <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 3v18" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+                    <path d="M6 4h11l-2 4 2 4H6z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" />
+                  </svg>
+                </button>
+                <span class="icon-label">신고</span>
+              </div>
               <button
                 type="button"
                 class="icon-circle"
@@ -743,6 +818,19 @@ watch(showChat, (visible) => {
   align-items: flex-end;
   gap: 12px;
   z-index: 3;
+}
+
+.icon-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #fff;
+  font-weight: 700;
+}
+
+.icon-count,
+.icon-label {
+  font-size: 0.85rem;
 }
 
 .player-settings {

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -291,6 +291,7 @@ const lifecycleStatus = computed(() => {
 
 const statusLabel = computed(() => getBroadcastStatusLabel(lifecycleStatus.value))
 const isInteractive = computed(() => lifecycleStatus.value === 'ON_AIR')
+const canForceStop = computed(() => ['READY', 'ON_AIR', 'ENDED'].includes(lifecycleStatus.value))
 const isReadOnly = computed(() => lifecycleStatus.value !== 'ON_AIR')
 const waitingScreenUrl = computed(() => detail.value?.waitScreenUrl ?? '')
 const readyCountdownLabel = computed(() => {
@@ -554,7 +555,7 @@ const startStatsPolling = (broadcastId: number) => {
 }
 
 const openStopConfirm = () => {
-  if (!detail.value || detail.value.status === 'STOPPED' || !isInteractive.value) return
+  if (!detail.value || detail.value.status === 'STOPPED' || !canForceStop.value) return
   showStopModal.value = true
   error.value = ''
 }
@@ -774,7 +775,12 @@ watch(streamToken, () => {
       <button type="button" class="back-link" @click="goBack">← 뒤로 가기</button>
       <div class="header-actions">
         <button type="button" class="btn" @click="goToList">목록으로</button>
-        <button type="button" class="btn danger" :disabled="detail.status === 'STOPPED'" @click="openStopConfirm">
+        <button
+          type="button"
+          class="btn danger"
+          :disabled="detail.status === 'STOPPED' || !canForceStop"
+          @click="openStopConfirm"
+        >
           {{ detail.status === 'STOPPED' ? '송출 중지됨' : '방송 송출 중지' }}
         </button>
       </div>

--- a/front/src/pages/admin/live/VodDetail.vue
+++ b/front/src/pages/admin/live/VodDetail.vue
@@ -31,7 +31,9 @@ type AdminVodDetail = {
   sellerName: string
   thumb: string
   metrics: {
+    totalViews: number
     maxViewers: number
+    maxViewerTime?: string
     reports: number
     sanctions: number
     likes: number
@@ -180,7 +182,9 @@ const buildDetail = (broadcast: BroadcastDetailResponse, report: BroadcastResult
   sellerName: broadcast.sellerName ?? '',
   thumb: broadcast.thumbnailUrl ?? '',
   metrics: {
+    totalViews: report.totalViews ?? 0,
     maxViewers: report.maxViewers ?? 0,
+    maxViewerTime: formatDateTime(report.maxViewerTime),
     reports: report.reportCount ?? 0,
     sanctions: report.sanctionCount ?? 0,
     likes: report.totalLikes ?? 0,
@@ -259,8 +263,13 @@ watch(vodId, () => {
 
     <section class="kpi-grid">
       <article class="kpi-card ds-surface">
-        <p class="kpi-label">최대 시청자 수</p>
+        <p class="kpi-label">누적 조회수</p>
+        <p class="kpi-value">{{ detail.metrics.totalViews.toLocaleString('ko-KR') }}회</p>
+      </article>
+      <article class="kpi-card ds-surface">
+        <p class="kpi-label">방송 중 최대 시청자 수</p>
         <p class="kpi-value">{{ detail.metrics.maxViewers.toLocaleString('ko-KR') }}명</p>
+        <p v-if="detail.metrics.maxViewerTime" class="kpi-sub">{{ detail.metrics.maxViewerTime }} 기준</p>
       </article>
       <article class="kpi-card ds-surface">
         <p class="kpi-label">신고 건수</p>
@@ -562,7 +571,7 @@ watch(vodId, () => {
 
 .kpi-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 16px;
   margin-bottom: 16px;
 }
@@ -584,6 +593,12 @@ watch(vodId, () => {
   font-size: 1.2rem;
   font-weight: 900;
   color: var(--text-strong);
+}
+
+.kpi-sub {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 600;
 }
 
 .card-head {

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -214,9 +214,9 @@ const withLifecycleStatus = (item: LiveItem): LiveItem => {
 }
 
 const isPastScheduledEnd = (item: LiveItem): boolean => {
-  const endAtMs = getScheduledEndMs(item.startAtMs, item.endAtMs)
-  if (!endAtMs) return false
-  return Date.now() > endAtMs
+  const scheduledEndMs = getScheduledEndMs(item.startAtMs)
+  if (!scheduledEndMs) return false
+  return Date.now() > scheduledEndMs
 }
 
 const formatDateLabel = (ms?: number, prefix: string = '업로드'): string => {

--- a/front/src/pages/seller/broadcasts/VodDetail.vue
+++ b/front/src/pages/seller/broadcasts/VodDetail.vue
@@ -30,7 +30,9 @@ type SellerVodDetail = {
   stopReason?: string
   thumb: string
   metrics: {
+    totalViews: number
     maxViewers: number
+    maxViewerTime?: string
     reports: number
     sanctions: number
     likes: number
@@ -183,7 +185,9 @@ const buildDetail = (broadcast: BroadcastDetailResponse, report: BroadcastResult
   stopReason: report.stoppedReason ?? broadcast.stoppedReason ?? undefined,
   thumb: broadcast.thumbnailUrl ?? '',
   metrics: {
+    totalViews: report.totalViews ?? 0,
     maxViewers: report.maxViewers ?? 0,
+    maxViewerTime: formatDateTime(report.maxViewerTime),
     reports: report.reportCount ?? 0,
     sanctions: report.sanctionCount ?? 0,
     likes: report.totalLikes ?? 0,
@@ -262,8 +266,13 @@ watch(vodId, () => {
 
     <section class="kpi-grid">
       <article class="kpi-card ds-surface">
-        <p class="kpi-label">최대 시청자 수</p>
+        <p class="kpi-label">누적 조회수</p>
+        <p class="kpi-value">{{ detail.metrics.totalViews.toLocaleString('ko-KR') }}회</p>
+      </article>
+      <article class="kpi-card ds-surface">
+        <p class="kpi-label">방송 중 최대 시청자 수</p>
         <p class="kpi-value">{{ detail.metrics.maxViewers.toLocaleString('ko-KR') }}</p>
+        <p v-if="detail.metrics.maxViewerTime" class="kpi-sub">{{ detail.metrics.maxViewerTime }} 기준</p>
       </article>
       <article class="kpi-card ds-surface">
         <p class="kpi-label">신고 건수</p>
@@ -560,7 +569,7 @@ watch(vodId, () => {
 
 .kpi-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 16px;
   margin-bottom: 16px;
 }
@@ -585,6 +594,13 @@ watch(vodId, () => {
   color: var(--text-strong);
   font-weight: 900;
   font-size: 1.2rem;
+}
+
+.kpi-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 600;
 }
 
 .card-head {

--- a/src/main/java/com/deskit/deskit/livehost/common/utils/VodStatsScheduler.java
+++ b/src/main/java/com/deskit/deskit/livehost/common/utils/VodStatsScheduler.java
@@ -1,0 +1,32 @@
+package com.deskit.deskit.livehost.common.utils;
+
+import com.deskit.deskit.livehost.service.RedisService;
+import com.deskit.deskit.livehost.service.VodStatsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VodStatsScheduler {
+    private final RedisService redisService;
+    private final VodStatsService vodStatsService;
+
+    @Scheduled(fixedDelay = 10000)
+    public void flushVodStats() {
+        var broadcastIds = redisService.getDirtyVodIds();
+        if (broadcastIds.isEmpty()) {
+            return;
+        }
+
+        for (Long broadcastId : broadcastIds) {
+            try {
+                vodStatsService.flushVodStats(broadcastId);
+            } catch (Exception e) {
+                log.error("VOD 통계 반영 실패: broadcastId={}, msg={}", broadcastId, e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/deskit/deskit/livehost/controller/BroadcastPublicController.java
+++ b/src/main/java/com/deskit/deskit/livehost/controller/BroadcastPublicController.java
@@ -73,6 +73,17 @@ public class BroadcastPublicController {
         return ResponseEntity.ok(ApiResult.success(null));
     }
 
+    @PostMapping("/broadcasts/{broadcastId}/vod/view")
+    public ResponseEntity<ApiResult<Void>> recordVodView(
+            @PathVariable Long broadcastId,
+            @RequestHeader(value = "X-Viewer-Id", required = false) String viewerId,
+            @RequestParam(value = "viewerId", required = false) String viewerIdParam
+    ) {
+        String userId = (viewerId != null) ? viewerId : viewerIdParam;
+        broadcastService.recordVodView(broadcastId, userId);
+        return ResponseEntity.ok(ApiResult.success(null));
+    }
+
     @GetMapping("/broadcasts/{broadcastId}/stats")
     public ResponseEntity<ApiResult<BroadcastStatsResponse>> getBroadcastStats(
             @PathVariable Long broadcastId

--- a/src/main/java/com/deskit/deskit/livehost/entity/BroadcastResult.java
+++ b/src/main/java/com/deskit/deskit/livehost/entity/BroadcastResult.java
@@ -60,5 +60,22 @@ public class BroadcastResult {
     // 관리자용
     @Column(name = "total_result", nullable = false)
     private int totalReports;
-}
 
+    public void updateFinalStats(int views, int likes, int reports, int avgWatchTime, int maxViews,
+                                 LocalDateTime pickViewsAt, int totalChats, BigDecimal totalSales) {
+        this.totalViews = views;
+        this.totalLikes = likes;
+        this.totalReports = reports;
+        this.avgWatchTime = avgWatchTime;
+        this.maxViews = maxViews;
+        this.pickViewsAt = pickViewsAt;
+        this.totalChats = totalChats;
+        this.totalSales = totalSales;
+    }
+
+    public void applyVodStatsDelta(int viewDelta, int likeDelta, int reportDelta) {
+        this.totalViews = Math.max(0, this.totalViews + viewDelta);
+        this.totalLikes = Math.max(0, this.totalLikes + likeDelta);
+        this.totalReports = Math.max(0, this.totalReports + reportDelta);
+    }
+}

--- a/src/main/java/com/deskit/deskit/livehost/entity/Vod.java
+++ b/src/main/java/com/deskit/deskit/livehost/entity/Vod.java
@@ -70,4 +70,8 @@ public class Vod {
         this.vodUrl = null;
         this.vodSize = 0L;
     }
+
+    public void applyReportDelta(int delta) {
+        this.vodReportCount = Math.max(0, this.vodReportCount + delta);
+    }
 }

--- a/src/main/java/com/deskit/deskit/livehost/service/VodStatsDelta.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/VodStatsDelta.java
@@ -1,0 +1,7 @@
+package com.deskit.deskit.livehost.service;
+
+public record VodStatsDelta(int viewDelta, int likeDelta, int reportDelta) {
+    public boolean isEmpty() {
+        return viewDelta == 0 && likeDelta == 0 && reportDelta == 0;
+    }
+}

--- a/src/main/java/com/deskit/deskit/livehost/service/VodStatsService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/VodStatsService.java
@@ -1,0 +1,60 @@
+package com.deskit.deskit.livehost.service;
+
+import com.deskit.deskit.livehost.common.enums.BroadcastStatus;
+import com.deskit.deskit.livehost.entity.Broadcast;
+import com.deskit.deskit.livehost.entity.BroadcastResult;
+import com.deskit.deskit.livehost.entity.Vod;
+import com.deskit.deskit.livehost.repository.BroadcastRepository;
+import com.deskit.deskit.livehost.repository.BroadcastResultRepository;
+import com.deskit.deskit.livehost.repository.VodRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class VodStatsService {
+    private final RedisService redisService;
+    private final BroadcastRepository broadcastRepository;
+    private final BroadcastResultRepository broadcastResultRepository;
+    private final VodRepository vodRepository;
+
+    @Transactional
+    public void flushVodStats(Long broadcastId) {
+        VodStatsDelta delta = redisService.consumeVodStats(broadcastId);
+        if (delta.isEmpty()) {
+            return;
+        }
+
+        Broadcast broadcast = broadcastRepository.findById(broadcastId).orElse(null);
+        if (broadcast == null || broadcast.getStatus() != BroadcastStatus.VOD) {
+            return;
+        }
+
+        BroadcastResult result = broadcastResultRepository.findById(broadcastId).orElse(null);
+        if (result == null) {
+            result = BroadcastResult.builder()
+                    .broadcast(broadcast)
+                    .totalViews(0)
+                    .totalLikes(0)
+                    .totalReports(0)
+                    .avgWatchTime(0)
+                    .maxViews(0)
+                    .totalChats(0)
+                    .totalSales(BigDecimal.ZERO)
+                    .build();
+        }
+
+        result.applyVodStatsDelta(delta.viewDelta(), delta.likeDelta(), delta.reportDelta());
+        broadcastResultRepository.save(result);
+
+        if (delta.reportDelta() != 0) {
+            Vod vod = vodRepository.findByBroadcast(broadcast).orElse(null);
+            if (vod != null) {
+                vod.applyReportDelta(delta.reportDelta());
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow admins to force-stop broadcasts that are in `READY` state while keeping `STOPPED` items visible in live lists until their scheduled end time. 
- Surface cumulative VOD consumption metrics (total views and peak viewer timestamp) in admin/seller VOD reports for better reporting context. 
- Reduce synchronous DB writes for VOD interactions (views/likes/reports) by buffering deltas in Redis and applying them periodically.

### Description
- Frontend: added `recordVodView` to `front/src/lib/live/api.ts` and updated `Vod.vue`, `LiveCard.vue`, `Live.vue`, and seller/admin VOD detail pages to show `totalViews`/`maxViewerTime`, improve lifecycle labels, and add in-page like/report UI and buffering-aware behavior. 
- Redis/Backend: extended `RedisService` with VOD keys and helpers (`recordVodView`, `toggleVodLike`, `reportVod`, `consumeVodStats`, `getDirtyVodIds`, and delta keys) and added a `consumeDelta` helper. 
- Services/Scheduler: introduced `VodStatsDelta`, `VodStatsService` and `VodStatsScheduler` (runs every 10s) to flush buffered deltas into `BroadcastResult`/`Vod`, and wired `BroadcastService.recordVodView` plus VOD-aware `likeBroadcast`/`reportBroadcast` flows. 
- Entities & API: added `updateFinalStats`/`applyVodStatsDelta` on `BroadcastResult`, `applyReportDelta` on `Vod`, and exposed `POST /api/broadcasts/{broadcastId}/vod/view` in `BroadcastPublicController`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696395adab98832691518abf9cb86fb0)