### PR TITLE
Handle stopped-broadcast UX, skip device modal when media config exists, and filter reserved slots

### DIFF
--- a/front/src/components/DeviceSetupModal.vue
+++ b/front/src/components/DeviceSetupModal.vue
@@ -325,6 +325,9 @@ const modalTitle = computed(() => (props.broadcastTitle ? `${props.broadcastTitl
   display: flex;
   flex-direction: column;
   gap: 14px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .preview-box {

--- a/front/src/components/LiveCard.vue
+++ b/front/src/components/LiveCard.vue
@@ -50,6 +50,9 @@ const buttonLabel = computed(() => {
   if (status.value === 'LIVE' || status.value === 'READY') {
     return '입장하기'
   }
+  if (status.value === 'STOPPED') {
+    return '방송 입장'
+  }
   if (status.value === 'ENDED') {
     return '방송 입장'
   }
@@ -118,7 +121,7 @@ const viewerLabel = computed(() => {
   return ''
 })
 
-const isCtaDisabled = computed(() => status.value === 'UPCOMING' || status.value === 'STOPPED')
+const isCtaDisabled = computed(() => status.value === 'UPCOMING')
 
 const router = useRouter()
 
@@ -127,7 +130,7 @@ const handleWatchNow = () => {
     router.push({ name: 'live-detail', params: { id: props.item.id } })
     return
   }
-  if (status.value === 'ENDED') {
+  if (status.value === 'ENDED' || status.value === 'STOPPED') {
     router.push({ name: 'live-detail', params: { id: props.item.id } })
     return
   }

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -17,6 +17,7 @@ import { useNow } from '../../lib/live/useNow'
 import {
   fetchBroadcastStats,
   fetchCategories,
+  fetchMediaConfig,
   fetchSellerBroadcastDetail,
   fetchSellerBroadcastReport,
   fetchSellerBroadcasts,
@@ -937,10 +938,22 @@ watch(
   { immediate: true },
 )
 
-const handleCta = (kind: CarouselKind, item: LiveItem) => {
+const handleCta = async (kind: CarouselKind, item: LiveItem) => {
   if (kind === 'live') {
     const lifecycleStatus = getLifecycleStatus(item)
     if (lifecycleStatus === 'READY' && hasReachedStartTime(item.startAtMs)) {
+      const id = parseBroadcastId(item.id)
+      if (id) {
+        try {
+          const config = await fetchMediaConfig(id)
+          if (config) {
+            router.push({ path: `/seller/live/stream/${resolveRouteId(item)}`, query: { tab: activeTab.value } }).catch(() => {})
+            return
+          }
+        } catch {
+          // ignore
+        }
+      }
       selectedScheduled.value = item
       showDeviceModal.value = true
       return


### PR DESCRIPTION
### Motivation

- Prevent sellers from booking the same time slot twice by hiding already-booked slots for the selected day in the reservation UI.  
- Make the device-setup modal behave better on entry by only prompting once for READY and skipping it if the seller already has saved media configuration.  
- Standardize messaging and UX when a broadcast is forcibly stopped so viewers/sellers/admins see a clear prompt and restricted controls.  
- Ensure modals fit viewport and long modal content can scroll.

### Description

- Filter reservation slots in the seller create flow by fetching existing reserved broadcasts and excluding those start times from `timeOptions` while preserving the edit case (`front/src/pages/seller/LiveCreateBasic.vue`).  
- Skip the device setup modal when a saved media config exists and only open it once when entering from `READY`, by introducing `hasSavedMediaConfig` and changing the watch logic for `stream`/`lifecycleStatus` (`front/src/pages/seller/LiveStream.vue`), and adjust the CTA path in the seller listing to fetch media config first (`front/src/pages/seller/Live.vue`).  
- Make the device setup modal body scrollable and responsive to viewport by changing the `.ds-modal__body` layout (`front/src/components/DeviceSetupModal.vue`).  
- Standardize stopped-broadcast copy and the confirm flow to: `방송 운영 정책 위반으로 방송이 중지되었습니다.
방송에서 나가시겠습니까?`, show that once and, if the user cancels, restrict UI (hide chat/products/settings and disable seller controls such as basic info/qcards/end) across viewer, seller and admin pages (`front/src/pages/LiveDetail.vue`, `front/src/pages/seller/LiveStream.vue`, `front/src/pages/admin/live/LiveDetail.vue`).  
- Allow entering a stopped broadcast from cards (home/seller list) while disabling CTA blocking for STOPPED and change `LiveCard` to allow navigation to the live detail for `STOPPED` items (`front/src/components/LiveCard.vue`).  
- Misc: minor UI and state guards to avoid repeated prompts (`stopEntryPrompted`, `isStopRestricted`) and adjusted layout values when UI is restricted (stream pane sizing).  

### Testing

- No automated tests were executed as part of this change.  
- Manual runtime verification was not performed in this PR (no test runs were requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a98c2d4c8326b59dbb0bd6ca3c49)