### PR TITLE
Restrict peak viewer tracking to ON_AIR status

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/RedisService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/RedisService.java
@@ -115,7 +115,6 @@ public class RedisService {
 
         if (count != null && count == 1) {
             redisTemplate.opsForSet().add(activeKey, uuid);
-            updatePeakViewers(broadcastId);
         }
 
         redisTemplate.opsForSet().add(totalKey, uuid);
@@ -338,7 +337,7 @@ public class RedisService {
         redisTemplate.expire(key, Duration.ofDays(1));
     }
 
-    private void updatePeakViewers(Long broadcastId) {
+    public void updatePeakViewers(Long broadcastId) {
         int current = getRealtimeViewerCount(broadcastId);
         String maxKey = getMaxViewersKey(broadcastId);
 


### PR DESCRIPTION
### Motivation

- Prevent peak viewer calculations from running for broadcasts that are not actively on air.
- Remove side-effects from the generic Redis join path so entering a room does not always update peak metrics.
- Ensure peak updates are only triggered from flows that have broadcast context and are `ON_AIR`.

### Description

- Stop calling `updatePeakViewers` inside `RedisService.enterLiveRoom` so the Redis enter path has no peak-tracking side-effect.
- Change `updatePeakViewers` visibility from `private` to `public` to allow explicit calls where appropriate.
- Call `redisService.updatePeakViewers(broadcastId)` in `BroadcastService.joinBroadcast` only when `broadcast.getStatus() == BroadcastStatus.ON_AIR`.
- In `BroadcastService.handleConnectListener` parse `broadcastId` and conditionally call `updatePeakViewers` only if the loaded broadcast is `ON_AIR`.

### Testing

- No automated tests were executed for this change.
- Code changes were committed successfully and files modified include `RedisService.java` and `BroadcastService.java`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963af2540748326b103b367a151fd5c)