### PR TITLE
Fix device setup modal visibility in READY state

### DIFF
--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -20,6 +20,7 @@ import {
   pinSellerBroadcastProduct,
   saveMediaConfig,
   updateBroadcast,
+  type MediaConfig,
   type BroadcastDetailResponse,
 } from '../../lib/live/api'
 import { parseLiveDate } from '../../lib/live/utils'
@@ -288,6 +289,13 @@ const resolveMediaSelection = (value: string, fallback: string) => {
   const trimmed = value?.trim()
   if (!trimmed || trimmed === 'default') return fallback
   return trimmed
+}
+
+const hasPersistedMediaConfig = (mediaConfig?: MediaConfig | null) => {
+  if (!mediaConfig) return false
+  const cameraId = mediaConfig.cameraId?.trim()
+  const microphoneId = mediaConfig.microphoneId?.trim()
+  return (cameraId && cameraId !== 'default') || (microphoneId && microphoneId !== 'default')
 }
 
 const toMediaId = (value: string, fallback: string) => {
@@ -743,7 +751,7 @@ const hydrateStream = async () => {
       micEnabled.value = mediaConfig.microphoneOn
       videoEnabled.value = mediaConfig.cameraOn
       volume.value = mediaConfig.volume
-      hasSavedMediaConfig.value = true
+      hasSavedMediaConfig.value = hasPersistedMediaConfig(mediaConfig)
     } else {
       selectedMic.value = '기본 마이크'
       selectedCamera.value = '기본 카메라'


### PR DESCRIPTION
### Motivation
- The device setup modal should open when entering `READY` only if the seller has no saved device information, but the UI was incorrectly treating empty/default API media config as a saved config. 
- As a result the modal sometimes did not appear even when the user had not provided device IDs. 

### Description
- Import the `MediaConfig` type and add a helper `hasPersistedMediaConfig` to detect whether the API media config contains non-empty, non-`default` device IDs. 
- Use `hasPersistedMediaConfig(mediaConfig)` to set `hasSavedMediaConfig.value` instead of unconditionally marking a returned `mediaConfig` as saved. 
- Change is contained in `front/src/pages/seller/LiveStream.vue` and only affects the logic that controls whether the `DeviceSetupModal` is considered already fulfilled. 

### Testing
- No automated tests were executed for this change. 
- Manual verification expected: entering a `READY` broadcast without saved device IDs should now show the `DeviceSetupModal`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963bacdfa488326b99d64e64cf0a66b)