### PR TITLE
Show stop message and hide waiting screen for STOPPED broadcasts

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -111,7 +111,7 @@ const endedCountdownLabel = computed(() => {
 })
 const playerMessage = computed(() => {
   if (lifecycleStatus.value === 'STOPPED') {
-    return '방송이 운영정책 위반으로 송출 중지되었습니다.'
+    return '방송 운영 정책 위반으로 송출 중지되었습니다.'
   }
   if (lifecycleStatus.value === 'ENDED') {
     return '방송이 종료되었습니다.'
@@ -1106,7 +1106,7 @@ onBeforeUnmount(() => {
             <div v-show="hasSubscriberStream" ref="viewerContainerRef" class="player-frame__viewer"></div>
             <div v-if="['READY', 'ENDED', 'STOPPED'].includes(lifecycleStatus)" class="player-frame__placeholder">
               <img
-                v-if="waitingScreenUrl"
+                v-if="waitingScreenUrl && lifecycleStatus !== 'STOPPED'"
                 class="player-frame__image"
                 :src="waitingScreenUrl"
                 alt="대기 화면"

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -326,7 +326,7 @@ const endedCountdownLabel = computed(() => {
 })
 const playerMessage = computed(() => {
   if (lifecycleStatus.value === 'STOPPED') {
-    return '방송이 운영정책 위반으로 송출 중지되었습니다.'
+    return '방송 운영 정책 위반으로 송출 중지되었습니다.'
   }
   if (lifecycleStatus.value === 'ENDED') {
     return '방송이 종료되었습니다.'
@@ -887,7 +887,7 @@ watch(streamToken, () => {
                 </div>
                 <div v-if="isReadOnly" class="player-placeholder">
                   <img
-                    v-if="waitingScreenUrl"
+                    v-if="waitingScreenUrl && lifecycleStatus !== 'STOPPED'"
                     class="player-placeholder__image"
                     :src="waitingScreenUrl"
                     alt="대기 화면"

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -274,7 +274,7 @@ const readyCountdownLabel = computed(() => {
 })
 const streamPlaceholderMessage = computed(() => {
   if (lifecycleStatus.value === 'STOPPED') {
-    return '방송이 운영정책 위반으로 송출 중지되었습니다.'
+    return '방송 운영 정책 위반으로 송출 중지되었습니다.'
   }
   if (lifecycleStatus.value === 'ENDED') {
     return '방송이 종료되었습니다.'
@@ -1556,14 +1556,14 @@ const toggleFullscreen = async () => {
               :class="{ 'stream-placeholder--waiting': lifecycleStatus !== 'ON_AIR' }"
             >
               <img
-                v-if="waitingScreenUrl && lifecycleStatus !== 'ON_AIR'"
+                v-if="waitingScreenUrl && lifecycleStatus !== 'ON_AIR' && lifecycleStatus !== 'STOPPED'"
                 class="stream-placeholder__image"
                 :src="waitingScreenUrl"
                 alt="대기 화면"
               />
               <p class="stream-title">{{ streamPlaceholderMessage }}</p>
               <p v-if="lifecycleStatus === 'ON_AIR'" class="stream-sub">현재 송출 중인 화면이 표시됩니다.</p>
-              <p v-else-if="!waitingScreenUrl" class="stream-sub">대기 화면 이미지가 없습니다.</p>
+              <p v-else-if="!waitingScreenUrl && lifecycleStatus !== 'STOPPED'" class="stream-sub">대기 화면 이미지가 없습니다.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- When a broadcast is forcibly stopped for policy violation, the stop message should be visible instead of the waiting-screen image for viewer, seller, and admin views.
- The waiting-image and the “대기 화면 이미지가 없습니다.” hint are misleading when the stop message is the primary information for a stopped broadcast.
- Ensure the stop wording is consistent and visible: `방송 운영 정책 위반으로 송출 중지되었습니다.`.

### Description
- Standardized the stop message to `방송 운영 정책 위반으로 송출 중지되었습니다.` in `front/src/pages/LiveDetail.vue`, `front/src/pages/admin/live/LiveDetail.vue`, and `front/src/pages/seller/LiveStream.vue`.
- Prevented rendering the waiting-screen image when `lifecycleStatus === 'STOPPED'` by changing image `v-if` checks to include `lifecycleStatus !== 'STOPPED'` in viewer and admin pages.
- Hid the “대기 화면 이미지가 없습니다.” hint in the seller view when `lifecycleStatus === 'STOPPED'` so the stop message is the primary visible text.

### Testing
- Attempted a Playwright screenshot run using `mcp__browser_tools__run_playwright_script`, but it failed with `net::ERR_EMPTY_RESPONSE` from `http://127.0.0.1:5173` and produced no screenshot.
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963bdbd70c4832686ce0fba88e05424)