### PR TITLE
Show stop modal backdrop and realtime elapsed time

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -73,6 +73,9 @@ const scheduledEndMs = computed(() => {
   return Number.isNaN(startAtMs) ? undefined : getScheduledEndMs(startAtMs)
 })
 
+const stopConfirmOpen = ref(false)
+const stopConfirmMessage = ref('')
+
 const isChatEnabled = computed(() => lifecycleStatus.value === 'ON_AIR')
 const isProductEnabled = computed(() => {
   if (lifecycleStatus.value === 'ON_AIR') return true
@@ -111,7 +114,7 @@ const endedCountdownLabel = computed(() => {
 })
 const playerMessage = computed(() => {
   if (lifecycleStatus.value === 'STOPPED') {
-    return '방송이 운영정책 위반으로 송출 중지되었습니다.'
+    return '방송 운영 정책 위반으로 송출 중지되었습니다.'
   }
   if (lifecycleStatus.value === 'ENDED') {
     return '방송이 종료되었습니다.'
@@ -488,14 +491,18 @@ const buildStopConfirmMessage = () => {
   return '방송 운영 정책 위반으로 방송이 중지되었습니다.\n방송에서 나가시겠습니까?'
 }
 
-const handleStopDecision = (message: string) => {
-  const ok = window.confirm(message)
-  if (ok) {
-    router.push({ name: 'live' }).catch(() => {})
-    return
-  }
+const handleStopConfirm = () => {
+  router.push({ name: 'live' }).catch(() => {})
+}
+
+const handleStopCancel = () => {
   isStopRestricted.value = true
   showChat.value = false
+}
+
+const handleStopDecision = (message: string) => {
+  stopConfirmMessage.value = message
+  stopConfirmOpen.value = true
 }
 
 const promptStoppedEntry = () => {
@@ -1054,6 +1061,7 @@ onBeforeUnmount(() => {
 
 <template>
   <PageContainer>
+    <div v-if="stopConfirmOpen" class="stop-blocker" aria-hidden="true"></div>
     <ConfirmModal
       v-model="showWatchHistoryConsent"
       title="시청 기록 수집 안내"
@@ -1062,6 +1070,15 @@ onBeforeUnmount(() => {
       cancel-text="취소"
       @confirm="handleConfirmWatchHistory"
       @cancel="handleCancelWatchHistory"
+    />
+    <ConfirmModal
+      v-model="stopConfirmOpen"
+      title="방송 송출 중지"
+      :description="stopConfirmMessage"
+      confirm-text="나가기"
+      cancel-text="계속 보기"
+      @confirm="handleStopConfirm"
+      @cancel="handleStopCancel"
     />
     <PageHeader eyebrow="DESKIT LIVE" title="라이브 상세" />
 
@@ -1106,7 +1123,7 @@ onBeforeUnmount(() => {
             <div v-show="hasSubscriberStream" ref="viewerContainerRef" class="player-frame__viewer"></div>
             <div v-if="['READY', 'ENDED', 'STOPPED'].includes(lifecycleStatus)" class="player-frame__placeholder">
               <img
-                v-if="waitingScreenUrl"
+                v-if="waitingScreenUrl && lifecycleStatus !== 'STOPPED'"
                 class="player-frame__image"
                 :src="waitingScreenUrl"
                 alt="대기 화면"
@@ -1298,6 +1315,13 @@ onBeforeUnmount(() => {
 </template>
 
 <style scoped>
+.stop-blocker {
+  position: fixed;
+  inset: 0;
+  background: var(--surface);
+  z-index: 1300;
+}
+
 .live-detail-layout {
   display: flex;
   flex-direction: column;

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -324,9 +324,14 @@ const endedCountdownLabel = computed(() => {
   const seconds = totalSeconds % 60
   return `종료까지 ${minutes}분 ${String(seconds).padStart(2, '0')}초`
 })
+const elapsedLabel = computed(() => {
+  if (!detail.value?.startedAt) return '00:00:00'
+  now.value
+  return formatElapsed(detail.value.startedAt)
+})
 const playerMessage = computed(() => {
   if (lifecycleStatus.value === 'STOPPED') {
-    return '방송이 운영정책 위반으로 송출 중지되었습니다.'
+    return '방송 운영 정책 위반으로 송출 중지되었습니다.'
   }
   if (lifecycleStatus.value === 'ENDED') {
     return '방송이 종료되었습니다.'
@@ -858,7 +863,7 @@ watch(streamToken, () => {
               <div class="player-frame" :class="{ 'player-frame--fullscreen': isFullscreen }">
                 <div v-show="hasSubscriberStream" ref="viewerContainerRef" class="player-frame__viewer"></div>
                 <div class="player-overlay">
-                  <div class="overlay-item">⏱ {{ detail.elapsed }}</div>
+                  <div class="overlay-item">⏱ {{ elapsedLabel }}</div>
                   <div class="overlay-item">👥 {{ detail.viewers }}명</div>
                   <div class="overlay-item">❤ {{ detail.likes }}</div>
                   <div class="overlay-item">🚩 {{ detail.reports ?? 0 }}건</div>
@@ -887,7 +892,7 @@ watch(streamToken, () => {
                 </div>
                 <div v-if="isReadOnly" class="player-placeholder">
                   <img
-                    v-if="waitingScreenUrl"
+                    v-if="waitingScreenUrl && lifecycleStatus !== 'STOPPED'"
                     class="player-placeholder__image"
                     :src="waitingScreenUrl"
                     alt="대기 화면"

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -76,7 +76,6 @@ const isStopRestricted = ref(false)
 const showSettings = ref(false)
 const viewerCount = ref(0)
 const likeCount = ref(0)
-const elapsed = ref('00:00:00')
 const monitorRef = ref<HTMLElement | null>(null)
 const streamGridRef = ref<HTMLElement | null>(null)
 const streamCenterRef = ref<HTMLElement | null>(null)
@@ -160,6 +159,8 @@ const leaveRequested = ref(false)
 const mediaConfigReady = ref(false)
 const hasSavedMediaConfig = ref(false)
 let mediaSaveTimer: number | null = null
+const stopConfirmOpen = ref(false)
+const stopConfirmMessage = ref('')
 
 const streamId = computed(() => {
   const id = route.params.id
@@ -214,6 +215,12 @@ const sortedProducts = computed(() => {
 })
 
 const chatItems = computed(() => chatMessages.value)
+
+const elapsedLabel = computed(() => {
+  if (!latestDetail.value?.startedAt) return '00:00:00'
+  now.value
+  return formatElapsed(latestDetail.value.startedAt)
+})
 
 const hasSidePanels = computed(() => !isStopRestricted.value && (showProducts.value || showChat.value))
 const gridStyles = computed(() => ({
@@ -274,7 +281,7 @@ const readyCountdownLabel = computed(() => {
 })
 const streamPlaceholderMessage = computed(() => {
   if (lifecycleStatus.value === 'STOPPED') {
-    return '방송이 운영정책 위반으로 송출 중지되었습니다.'
+    return '방송 운영 정책 위반으로 송출 중지되었습니다.'
   }
   if (lifecycleStatus.value === 'ENDED') {
     return '방송이 종료되었습니다.'
@@ -667,7 +674,6 @@ const hydrateStream = async () => {
     chatMessages.value = []
     viewerCount.value = 0
     likeCount.value = 0
-    elapsed.value = '00:00:00'
     streamStatus.value = 'RESERVED'
     scheduleStartAtMs.value = null
     scheduleEndAtMs.value = null
@@ -684,7 +690,6 @@ const hydrateStream = async () => {
     stream.value = null
     viewerCount.value = 0
     likeCount.value = 0
-    elapsed.value = '00:00:00'
     streamStatus.value = 'RESERVED'
     scheduleStartAtMs.value = null
     scheduleEndAtMs.value = null
@@ -743,7 +748,6 @@ const hydrateStream = async () => {
 
     viewerCount.value = stats?.viewerCount ?? detail.totalViews ?? 0
     likeCount.value = stats?.likeCount ?? detail.totalLikes ?? 0
-    elapsed.value = formatElapsed(detail.startedAt)
 
     if (mediaConfig) {
       selectedMic.value = resolveMediaSelection(mediaConfig.microphoneId, '기본 마이크')
@@ -776,7 +780,6 @@ const hydrateStream = async () => {
     chatMessages.value = []
     viewerCount.value = 0
     likeCount.value = 0
-    elapsed.value = '00:00:00'
     streamStatus.value = 'RESERVED'
     scheduleStartAtMs.value = null
     scheduleEndAtMs.value = null
@@ -870,16 +873,20 @@ const buildStopConfirmMessage = () => {
   return '방송 운영 정책 위반으로 방송이 중지되었습니다.\n방송에서 나가겠습니까?'
 }
 
-const handleStopDecision = (message: string) => {
-  const ok = window.confirm(message)
-  if (ok) {
-    handleGoToList()
-    return
-  }
+const handleStopConfirm = () => {
+  handleGoToList()
+}
+
+const handleStopCancel = () => {
   isStopRestricted.value = true
   showChat.value = false
   showProducts.value = false
   showSettings.value = false
+}
+
+const handleStopDecision = (message: string) => {
+  stopConfirmMessage.value = message
+  stopConfirmOpen.value = true
 }
 
 const promptStoppedEntry = () => {
@@ -1394,6 +1401,7 @@ const toggleFullscreen = async () => {
 
 <template>
   <PageContainer>
+    <div v-if="stopConfirmOpen" class="stop-blocker" aria-hidden="true"></div>
     <header class="stream-header">
       <div>
         <h2 class="section-title">{{ displayTitle }}</h2>
@@ -1487,7 +1495,7 @@ const toggleFullscreen = async () => {
               class="stream-player__publisher"
             ></div>
             <div class="stream-overlay stream-overlay--stack">
-              <div class="stream-overlay__row">⏱ 경과 {{ elapsed }}</div>
+              <div class="stream-overlay__row">⏱ 경과 {{ elapsedLabel }}</div>
               <div class="stream-overlay__row">👥 {{ viewerCount.toLocaleString('ko-KR') }}명</div>
               <div class="stream-overlay__row">❤ {{ likeCount.toLocaleString('ko-KR') }}</div>
             </div>
@@ -1556,14 +1564,14 @@ const toggleFullscreen = async () => {
               :class="{ 'stream-placeholder--waiting': lifecycleStatus !== 'ON_AIR' }"
             >
               <img
-                v-if="waitingScreenUrl && lifecycleStatus !== 'ON_AIR'"
+                v-if="waitingScreenUrl && lifecycleStatus !== 'ON_AIR' && lifecycleStatus !== 'STOPPED'"
                 class="stream-placeholder__image"
                 :src="waitingScreenUrl"
                 alt="대기 화면"
               />
               <p class="stream-title">{{ streamPlaceholderMessage }}</p>
               <p v-if="lifecycleStatus === 'ON_AIR'" class="stream-sub">현재 송출 중인 화면이 표시됩니다.</p>
-              <p v-else-if="!waitingScreenUrl" class="stream-sub">대기 화면 이미지가 없습니다.</p>
+              <p v-else-if="!waitingScreenUrl && lifecycleStatus !== 'STOPPED'" class="stream-sub">대기 화면 이미지가 없습니다.</p>
             </div>
           </div>
         </div>
@@ -1701,6 +1709,15 @@ const toggleFullscreen = async () => {
     </section>
     <Teleport :to="modalHostTarget">
       <ConfirmModal
+        v-model="stopConfirmOpen"
+        title="방송 송출 중지"
+        :description="stopConfirmMessage"
+        confirm-text="나가기"
+        cancel-text="계속 보기"
+        @confirm="handleStopConfirm"
+        @cancel="handleStopCancel"
+      />
+      <ConfirmModal
         v-model="confirmState.open"
         :title="confirmState.title"
         :description="confirmState.description"
@@ -1724,6 +1741,13 @@ const toggleFullscreen = async () => {
 </template>
 
 <style scoped>
+.stop-blocker {
+  position: fixed;
+  inset: 0;
+  background: var(--surface);
+  z-index: 1300;
+}
+
 .stream-header {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
### Motivation
- Make stop notifications more prominent by showing a modal with a blanked backdrop instead of native `window.confirm` so the page behind the alert is hidden for viewer and seller pages.
- Ensure the stop wording is consistent and visible: `방송 운영 정책 위반으로 송출 중지되었습니다.`.
- Avoid rendering the waiting-screen image or its hint when a broadcast is `STOPPED` so the stop message is the primary information shown.
- Display live elapsed time in real time on admin and seller live overlays so the "경과" time updates while viewing a stopped/live broadcast.

### Description
- Replaced `window.confirm` stop prompts with `ConfirmModal` usage and a page-blanking backdrop by adding `stopConfirmOpen`/`stopConfirmMessage` state and a `.stop-blocker` element in `LiveDetail.vue` and `seller/LiveStream.vue`.
- Standardized stop message text to `방송 운영 정책 위반으로 송출 중지되었습니다.` in `LiveDetail.vue`, `admin/live/LiveDetail.vue`, and `seller/LiveStream.vue` and prevented waiting-screen rendering when lifecycle status is `STOPPED` by adding `lifecycleStatus !== 'STOPPED'` checks.
- Added a reactive `elapsedLabel` computed property in `seller/LiveStream.vue` and `admin/live/LiveDetail.vue` (driven by `useNow`) and replaced instances of `elapsed`/`detail.elapsed` in overlays with `elapsedLabel` so elapsed time updates every second.
- Adjusted stop handling callbacks: added `handleStopConfirm`/`handleStopCancel` to either navigate away or blank the page and hide side panels, and updated SSE stop-handling to open the modal instead of blocking with `confirm()`.

### Testing
- Attempted a Playwright screenshot run to capture the stop modal, but the browser crashed during launch in this environment and the screenshot step failed; no screenshot was produced.  (Playwright exit error: chromium process SIGSEGV.)
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963bdbd70c4832686ce0fba88e05424)