### PR TITLE
Start/stop OpenVidu recording on broadcast lifecycle

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -498,7 +498,9 @@ public class BroadcastService {
 
             try {
                 Map<String, Object> params = Map.of("role", "HOST", "sellerId", sellerId);
-                return openViduService.createToken(broadcastId, params);
+                String token = openViduService.createToken(broadcastId, params);
+                openViduService.startRecording(broadcastId);
+                return token;
             } catch (Exception e) {
                 throw new BusinessException(ErrorCode.OPENVIDU_ERROR);
             }
@@ -563,6 +565,11 @@ public class BroadcastService {
 
             validateTransition(broadcast.getStatus(), BroadcastStatus.ENDED);
             broadcast.endBroadcast();
+            try {
+                openViduService.stopRecording(broadcastId);
+            } catch (Exception e) {
+                log.error("방송 녹화 종료 실패: broadcastId={}, msg={}", broadcastId, e.getMessage());
+            }
             openViduService.closeSession(broadcastId);
             sseService.notifyBroadcastUpdate(broadcastId, "BROADCAST_ENDED", "ended");
         } finally {


### PR DESCRIPTION
### Motivation

- Broadcast recordings were not being started/stopped together with the broadcast lifecycle, which can cause missing VOD artifacts.
- Ensure OpenVidu recording is started when a broadcast goes ON_AIR and stopped when it ends to produce VODs reliably.

### Description

- Updated `BroadcastService.startBroadcast` to call `openViduService.createToken` and then `openViduService.startRecording` after transitioning the broadcast to `ON_AIR` and returning the host token.
- Updated `BroadcastService.endBroadcast` to attempt `openViduService.stopRecording` (with error logging on failure) before calling `openViduService.closeSession` when ending a broadcast.
- Changes are contained in `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963be7d51ac83269cb5afc0998e4b19)