### PR TITLE
Emphasize stopped broadcast messages

### DIFF
--- a/front/src/components/LiveCard.vue
+++ b/front/src/components/LiveCard.vue
@@ -121,12 +121,16 @@ const viewerLabel = computed(() => {
   return ''
 })
 
-const isCtaDisabled = computed(() => status.value === 'UPCOMING' || status.value === 'STOPPED')
+const isCtaDisabled = computed(() => status.value === 'UPCOMING')
 
 const router = useRouter()
 
 const handleWatchNow = () => {
   if (status.value === 'LIVE' || status.value === 'READY') {
+    router.push({ name: 'live-detail', params: { id: props.item.id } })
+    return
+  }
+  if (status.value === 'STOPPED') {
     router.push({ name: 'live-detail', params: { id: props.item.id } })
     return
   }
@@ -148,6 +152,7 @@ const handleWatchNow = () => {
         <span v-if="status === 'LIVE'" class="badge badge-live">LIVE</span>
         <span v-else-if="status === 'READY'" class="badge badge-ready">READY</span>
         <span v-else-if="status === 'UPCOMING'" class="badge badge-upcoming">예약</span>
+        <span v-else-if="status === 'STOPPED'" class="badge badge-stopped">송출 중지</span>
         <span
           v-if="status === 'LIVE' && props.item.viewerCount != null"
           class="badge badge-viewers"
@@ -165,6 +170,7 @@ const handleWatchNow = () => {
       <p class="desc">{{ props.item.description }}</p>
       <div class="info-row">
         <span v-if="timeLabel" class="info-chip">{{ timeLabel }}</span>
+        <span v-if="status === 'STOPPED'" class="info-chip">경과 {{ elapsed }}</span>
         <span v-if="viewerLabel" class="info-chip">{{ viewerLabel }}</span>
       </div>
       <div class="meta-row">
@@ -246,6 +252,10 @@ const handleWatchNow = () => {
 
 .badge-upcoming {
   background: rgba(139, 122, 94, 0.9);
+}
+
+.badge-stopped {
+  background: rgba(239, 68, 68, 0.9);
 }
 
 .top-badges {

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -324,9 +324,14 @@ const endedCountdownLabel = computed(() => {
   const seconds = totalSeconds % 60
   return `종료까지 ${minutes}분 ${String(seconds).padStart(2, '0')}초`
 })
+const elapsedLabel = computed(() => {
+  if (!detail.value?.startedAt) return '00:00:00'
+  now.value
+  return formatElapsed(detail.value.startedAt)
+})
 const playerMessage = computed(() => {
   if (lifecycleStatus.value === 'STOPPED') {
-    return '방송이 운영정책 위반으로 송출 중지되었습니다.'
+    return '방송 운영 정책 위반으로 송출 중지되었습니다.'
   }
   if (lifecycleStatus.value === 'ENDED') {
     return '방송이 종료되었습니다.'
@@ -858,7 +863,7 @@ watch(streamToken, () => {
               <div class="player-frame" :class="{ 'player-frame--fullscreen': isFullscreen }">
                 <div v-show="hasSubscriberStream" ref="viewerContainerRef" class="player-frame__viewer"></div>
                 <div class="player-overlay">
-                  <div class="overlay-item">⏱ {{ detail.elapsed }}</div>
+                  <div class="overlay-item">⏱ {{ elapsedLabel }}</div>
                   <div class="overlay-item">👥 {{ detail.viewers }}명</div>
                   <div class="overlay-item">❤ {{ detail.likes }}</div>
                   <div class="overlay-item">🚩 {{ detail.reports ?? 0 }}건</div>
@@ -887,7 +892,7 @@ watch(streamToken, () => {
                 </div>
                 <div v-if="isReadOnly" class="player-placeholder">
                   <img
-                    v-if="waitingScreenUrl"
+                    v-if="waitingScreenUrl && lifecycleStatus !== 'STOPPED'"
                     class="player-placeholder__image"
                     :src="waitingScreenUrl"
                     alt="대기 화면"
@@ -1187,10 +1192,11 @@ watch(streamToken, () => {
 }
 
 .player-placeholder__message {
-  color: #f8fafc;
-  font-weight: 800;
-  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+  color: #ffffff;
+  font-weight: 900;
+  text-shadow: 0 3px 12px rgba(0, 0, 0, 0.45);
   max-width: min(520px, 100%);
+  font-size: 1.35rem;
 }
 
 .player-overlay {

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -76,7 +76,6 @@ const isStopRestricted = ref(false)
 const showSettings = ref(false)
 const viewerCount = ref(0)
 const likeCount = ref(0)
-const elapsed = ref('00:00:00')
 const monitorRef = ref<HTMLElement | null>(null)
 const streamGridRef = ref<HTMLElement | null>(null)
 const streamCenterRef = ref<HTMLElement | null>(null)
@@ -160,6 +159,8 @@ const leaveRequested = ref(false)
 const mediaConfigReady = ref(false)
 const hasSavedMediaConfig = ref(false)
 let mediaSaveTimer: number | null = null
+const stopConfirmOpen = ref(false)
+const stopConfirmMessage = ref('')
 
 const streamId = computed(() => {
   const id = route.params.id
@@ -214,6 +215,12 @@ const sortedProducts = computed(() => {
 })
 
 const chatItems = computed(() => chatMessages.value)
+
+const elapsedLabel = computed(() => {
+  if (!latestDetail.value?.startedAt) return '00:00:00'
+  now.value
+  return formatElapsed(latestDetail.value.startedAt)
+})
 
 const hasSidePanels = computed(() => !isStopRestricted.value && (showProducts.value || showChat.value))
 const gridStyles = computed(() => ({
@@ -274,7 +281,7 @@ const readyCountdownLabel = computed(() => {
 })
 const streamPlaceholderMessage = computed(() => {
   if (lifecycleStatus.value === 'STOPPED') {
-    return '방송이 운영정책 위반으로 송출 중지되었습니다.'
+    return '방송 운영 정책 위반으로 송출 중지되었습니다.'
   }
   if (lifecycleStatus.value === 'ENDED') {
     return '방송이 종료되었습니다.'
@@ -667,7 +674,6 @@ const hydrateStream = async () => {
     chatMessages.value = []
     viewerCount.value = 0
     likeCount.value = 0
-    elapsed.value = '00:00:00'
     streamStatus.value = 'RESERVED'
     scheduleStartAtMs.value = null
     scheduleEndAtMs.value = null
@@ -684,7 +690,6 @@ const hydrateStream = async () => {
     stream.value = null
     viewerCount.value = 0
     likeCount.value = 0
-    elapsed.value = '00:00:00'
     streamStatus.value = 'RESERVED'
     scheduleStartAtMs.value = null
     scheduleEndAtMs.value = null
@@ -743,7 +748,6 @@ const hydrateStream = async () => {
 
     viewerCount.value = stats?.viewerCount ?? detail.totalViews ?? 0
     likeCount.value = stats?.likeCount ?? detail.totalLikes ?? 0
-    elapsed.value = formatElapsed(detail.startedAt)
 
     if (mediaConfig) {
       selectedMic.value = resolveMediaSelection(mediaConfig.microphoneId, '기본 마이크')
@@ -776,7 +780,6 @@ const hydrateStream = async () => {
     chatMessages.value = []
     viewerCount.value = 0
     likeCount.value = 0
-    elapsed.value = '00:00:00'
     streamStatus.value = 'RESERVED'
     scheduleStartAtMs.value = null
     scheduleEndAtMs.value = null
@@ -870,16 +873,20 @@ const buildStopConfirmMessage = () => {
   return '방송 운영 정책 위반으로 방송이 중지되었습니다.\n방송에서 나가겠습니까?'
 }
 
-const handleStopDecision = (message: string) => {
-  const ok = window.confirm(message)
-  if (ok) {
-    handleGoToList()
-    return
-  }
+const handleStopConfirm = () => {
+  handleGoToList()
+}
+
+const handleStopCancel = () => {
   isStopRestricted.value = true
   showChat.value = false
   showProducts.value = false
   showSettings.value = false
+}
+
+const handleStopDecision = (message: string) => {
+  stopConfirmMessage.value = message
+  stopConfirmOpen.value = true
 }
 
 const promptStoppedEntry = () => {
@@ -1394,6 +1401,7 @@ const toggleFullscreen = async () => {
 
 <template>
   <PageContainer>
+    <div v-if="stopConfirmOpen" class="stop-blocker" aria-hidden="true"></div>
     <header class="stream-header">
       <div>
         <h2 class="section-title">{{ displayTitle }}</h2>
@@ -1487,7 +1495,7 @@ const toggleFullscreen = async () => {
               class="stream-player__publisher"
             ></div>
             <div class="stream-overlay stream-overlay--stack">
-              <div class="stream-overlay__row">⏱ 경과 {{ elapsed }}</div>
+              <div class="stream-overlay__row">⏱ 경과 {{ elapsedLabel }}</div>
               <div class="stream-overlay__row">👥 {{ viewerCount.toLocaleString('ko-KR') }}명</div>
               <div class="stream-overlay__row">❤ {{ likeCount.toLocaleString('ko-KR') }}</div>
             </div>
@@ -1556,14 +1564,14 @@ const toggleFullscreen = async () => {
               :class="{ 'stream-placeholder--waiting': lifecycleStatus !== 'ON_AIR' }"
             >
               <img
-                v-if="waitingScreenUrl && lifecycleStatus !== 'ON_AIR'"
+                v-if="waitingScreenUrl && lifecycleStatus !== 'ON_AIR' && lifecycleStatus !== 'STOPPED'"
                 class="stream-placeholder__image"
                 :src="waitingScreenUrl"
                 alt="대기 화면"
               />
               <p class="stream-title">{{ streamPlaceholderMessage }}</p>
               <p v-if="lifecycleStatus === 'ON_AIR'" class="stream-sub">현재 송출 중인 화면이 표시됩니다.</p>
-              <p v-else-if="!waitingScreenUrl" class="stream-sub">대기 화면 이미지가 없습니다.</p>
+              <p v-else-if="!waitingScreenUrl && lifecycleStatus !== 'STOPPED'" class="stream-sub">대기 화면 이미지가 없습니다.</p>
             </div>
           </div>
         </div>
@@ -1701,6 +1709,15 @@ const toggleFullscreen = async () => {
     </section>
     <Teleport :to="modalHostTarget">
       <ConfirmModal
+        v-model="stopConfirmOpen"
+        title="방송 송출 중지"
+        :description="stopConfirmMessage"
+        confirm-text="나가기"
+        cancel-text="계속 보기"
+        @confirm="handleStopConfirm"
+        @cancel="handleStopCancel"
+      />
+      <ConfirmModal
         v-model="confirmState.open"
         :title="confirmState.title"
         :description="confirmState.description"
@@ -1724,6 +1741,13 @@ const toggleFullscreen = async () => {
 </template>
 
 <style scoped>
+.stop-blocker {
+  position: fixed;
+  inset: 0;
+  background: var(--surface);
+  z-index: 1300;
+}
+
 .stream-header {
   display: flex;
   align-items: flex-start;
@@ -2085,6 +2109,12 @@ const toggleFullscreen = async () => {
   font-weight: 900;
   color: var(--text-strong);
   font-size: 1.1rem;
+}
+
+.stream-placeholder--waiting .stream-title {
+  color: #ffffff;
+  font-size: 1.35rem;
+  text-shadow: 0 3px 12px rgba(0, 0, 0, 0.45);
 }
 
 .stream-sub {


### PR DESCRIPTION
### Motivation
- Make the stop/ended placeholder messages more visible and legible across viewer, admin, and seller pages so users clearly see when a broadcast has been stopped. 
- Keep the stopped-entry confirmation flow and dimming blocker intact while ensuring the message remains prominent when waiting images are hidden. 
- Surface elapsed timing consistently alongside viewer counts for better context on stopped/ended broadcasts. 

### Description
- Increased prominence of stop/ended messages by updating `player-frame__message` and `player-placeholder__message` to use `#ffffff`, heavier `font-weight`, larger `font-size`, and stronger `text-shadow`. 
- Added seller-side styling override `.stream-placeholder--waiting .stream-title` to render a larger white title when showing stopped/waiting placeholders. 
- Wired a stop confirmation flow and backdrop by adding `stopConfirmOpen`, `stopConfirmMessage`, a `.stop-blocker` overlay, and a `ConfirmModal` instance with handlers `handleStopConfirm`, `handleStopCancel`, and `handleStopDecision` in relevant pages. 
- Exposed and used `elapsedLabel` / `viewerExtraLabel` and updated `LiveCard.vue` to show a `송출 중지` badge, allow CTA routing for `STOPPED`, and render an `경과 {{ elapsed }}` info-chip. 

### Testing
- Attempted a Playwright screenshot to verify the stopped placeholder, but navigation to `http://127.0.0.1:5173` failed with `net::ERR_EMPTY_RESPONSE` and produced no screenshot. 
- No other automated tests or CI runs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963bdbd70c4832686ce0fba88e05424)