### PR TITLE
Redirect to list on scheduled broadcast end and refine stopped-broadcast UX

### DIFF
--- a/front/src/components/LiveCard.vue
+++ b/front/src/components/LiveCard.vue
@@ -121,12 +121,16 @@ const viewerLabel = computed(() => {
   return ''
 })
 
-const isCtaDisabled = computed(() => status.value === 'UPCOMING' || status.value === 'STOPPED')
+const isCtaDisabled = computed(() => status.value === 'UPCOMING')
 
 const router = useRouter()
 
 const handleWatchNow = () => {
   if (status.value === 'LIVE' || status.value === 'READY') {
+    router.push({ name: 'live-detail', params: { id: props.item.id } })
+    return
+  }
+  if (status.value === 'STOPPED') {
     router.push({ name: 'live-detail', params: { id: props.item.id } })
     return
   }
@@ -148,6 +152,7 @@ const handleWatchNow = () => {
         <span v-if="status === 'LIVE'" class="badge badge-live">LIVE</span>
         <span v-else-if="status === 'READY'" class="badge badge-ready">READY</span>
         <span v-else-if="status === 'UPCOMING'" class="badge badge-upcoming">예약</span>
+        <span v-else-if="status === 'STOPPED'" class="badge badge-stopped">송출 중지</span>
         <span
           v-if="status === 'LIVE' && props.item.viewerCount != null"
           class="badge badge-viewers"
@@ -165,6 +170,7 @@ const handleWatchNow = () => {
       <p class="desc">{{ props.item.description }}</p>
       <div class="info-row">
         <span v-if="timeLabel" class="info-chip">{{ timeLabel }}</span>
+        <span v-if="status === 'STOPPED'" class="info-chip">경과 {{ elapsed }}</span>
         <span v-if="viewerLabel" class="info-chip">{{ viewerLabel }}</span>
       </div>
       <div class="meta-row">
@@ -246,6 +252,10 @@ const handleWatchNow = () => {
 
 .badge-upcoming {
   background: rgba(139, 122, 94, 0.9);
+}
+
+.badge-stopped {
+  background: rgba(239, 68, 68, 0.9);
 }
 
 .top-badges {

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -73,6 +73,9 @@ const scheduledEndMs = computed(() => {
   return Number.isNaN(startAtMs) ? undefined : getScheduledEndMs(startAtMs)
 })
 
+const stopConfirmOpen = ref(false)
+const stopConfirmMessage = ref('')
+
 const isChatEnabled = computed(() => lifecycleStatus.value === 'ON_AIR')
 const isProductEnabled = computed(() => {
   if (lifecycleStatus.value === 'ON_AIR') return true
@@ -100,6 +103,21 @@ const readyCountdownLabel = computed(() => {
   const seconds = totalSeconds % 60
   return `${minutes}분 ${String(seconds).padStart(2, '0')}초 뒤 방송 시작`
 })
+const elapsedLabel = computed(() => {
+  if (!liveItem.value?.startAt) return ''
+  const started = parseLiveDate(liveItem.value.startAt)
+  if (Number.isNaN(started.getTime())) return ''
+  const diffMs = Math.max(0, now.value.getTime() - started.getTime())
+  const totalSeconds = Math.floor(diffMs / 1000)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  const pad = (value: number) => String(value).padStart(2, '0')
+  if (hours > 0) {
+    return `${pad(hours)}:${pad(minutes)}`
+  }
+  return `${pad(minutes)}:${pad(seconds)}`
+})
 const endedCountdownLabel = computed(() => {
   if (lifecycleStatus.value !== 'ENDED' || !scheduledEndMs.value) return ''
   const diffMs = scheduledEndMs.value - now.value.getTime()
@@ -111,13 +129,22 @@ const endedCountdownLabel = computed(() => {
 })
 const playerMessage = computed(() => {
   if (lifecycleStatus.value === 'STOPPED') {
-    return '방송이 운영정책 위반으로 송출 중지되었습니다.'
+    return '방송 운영 정책 위반으로 송출 중지되었습니다.'
   }
   if (lifecycleStatus.value === 'ENDED') {
     return '방송이 종료되었습니다.'
   }
   if (lifecycleStatus.value === 'READY') {
     return readyCountdownLabel.value || '방송 시작 대기 중'
+  }
+  return ''
+})
+const viewerExtraLabel = computed(() => {
+  if (lifecycleStatus.value === 'READY') {
+    return readyCountdownLabel.value || '방송 시작 대기 중'
+  }
+  if (['ON_AIR', 'STOPPED', 'ENDED'].includes(lifecycleStatus.value)) {
+    return elapsedLabel.value ? `경과 ${elapsedLabel.value}` : ''
   }
   return ''
 })
@@ -488,14 +515,18 @@ const buildStopConfirmMessage = () => {
   return '방송 운영 정책 위반으로 방송이 중지되었습니다.\n방송에서 나가시겠습니까?'
 }
 
-const handleStopDecision = (message: string) => {
-  const ok = window.confirm(message)
-  if (ok) {
-    router.push({ name: 'live' }).catch(() => {})
-    return
-  }
+const handleStopConfirm = () => {
+  router.push({ name: 'live' }).catch(() => {})
+}
+
+const handleStopCancel = () => {
   isStopRestricted.value = true
   showChat.value = false
+}
+
+const handleStopDecision = (message: string) => {
+  stopConfirmMessage.value = message
+  stopConfirmOpen.value = true
 }
 
 const promptStoppedEntry = () => {
@@ -538,9 +569,8 @@ const handleSseEvent = (event: MessageEvent) => {
       scheduleRefresh()
       break
     case 'BROADCAST_SCHEDULED_END':
-      if (window.confirm('방송이 종료되었습니다.')) {
-        router.push({ name: 'live' }).catch(() => {})
-      }
+      alert('방송이 종료되었습니다.')
+      router.push({ name: 'live' }).catch(() => {})
       break
     case 'BROADCAST_STOPPED':
       if (liveItem.value) {
@@ -1054,6 +1084,7 @@ onBeforeUnmount(() => {
 
 <template>
   <PageContainer>
+    <div v-if="stopConfirmOpen" class="stop-blocker" aria-hidden="true"></div>
     <ConfirmModal
       v-model="showWatchHistoryConsent"
       title="시청 기록 수집 안내"
@@ -1062,6 +1093,15 @@ onBeforeUnmount(() => {
       cancel-text="취소"
       @confirm="handleConfirmWatchHistory"
       @cancel="handleCancelWatchHistory"
+    />
+    <ConfirmModal
+      v-model="stopConfirmOpen"
+      title="방송 송출 중지"
+      :description="stopConfirmMessage"
+      confirm-text="나가기"
+      cancel-text="계속 보기"
+      @confirm="handleStopConfirm"
+      @cancel="handleStopCancel"
     />
     <PageHeader eyebrow="DESKIT LIVE" title="라이브 상세" />
 
@@ -1086,6 +1126,7 @@ onBeforeUnmount(() => {
               </span>
               <span v-if="liveItem.viewerCount != null" class="status-viewers">
                 {{ liveItem.viewerCount.toLocaleString() }}명 시청 중
+                <span v-if="viewerExtraLabel"> · {{ viewerExtraLabel }}</span>
               </span>
               <span v-else-if="lifecycleStatus === 'RESERVED'" class="status-schedule">
                 {{ scheduledLabel }}
@@ -1106,7 +1147,7 @@ onBeforeUnmount(() => {
             <div v-show="hasSubscriberStream" ref="viewerContainerRef" class="player-frame__viewer"></div>
             <div v-if="['READY', 'ENDED', 'STOPPED'].includes(lifecycleStatus)" class="player-frame__placeholder">
               <img
-                v-if="waitingScreenUrl"
+                v-if="waitingScreenUrl && lifecycleStatus !== 'STOPPED'"
                 class="player-frame__image"
                 :src="waitingScreenUrl"
                 alt="대기 화면"
@@ -1298,6 +1339,13 @@ onBeforeUnmount(() => {
 </template>
 
 <style scoped>
+.stop-blocker {
+  position: fixed;
+  inset: 0;
+  background: var(--surface);
+  z-index: 1300;
+}
+
 .live-detail-layout {
   display: flex;
   flex-direction: column;
@@ -1561,10 +1609,11 @@ onBeforeUnmount(() => {
 }
 
 .player-frame__message {
-  font-weight: 700;
-  color: #f5f7ff;
-  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  font-weight: 900;
+  color: #ffffff;
+  text-shadow: 0 3px 12px rgba(0, 0, 0, 0.45);
   max-width: min(560px, 100%);
+  font-size: 1.35rem;
 }
 
 .player-actions {

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -324,9 +324,14 @@ const endedCountdownLabel = computed(() => {
   const seconds = totalSeconds % 60
   return `종료까지 ${minutes}분 ${String(seconds).padStart(2, '0')}초`
 })
+const elapsedLabel = computed(() => {
+  if (!detail.value?.startedAt) return '00:00:00'
+  now.value
+  return formatElapsed(detail.value.startedAt)
+})
 const playerMessage = computed(() => {
   if (lifecycleStatus.value === 'STOPPED') {
-    return '방송이 운영정책 위반으로 송출 중지되었습니다.'
+    return '방송 운영 정책 위반으로 송출 중지되었습니다.'
   }
   if (lifecycleStatus.value === 'ENDED') {
     return '방송이 종료되었습니다.'
@@ -495,9 +500,8 @@ const handleSseEvent = (event: MessageEvent) => {
       void refreshDetail(idValue)
       break
     case 'BROADCAST_SCHEDULED_END':
-      if (window.confirm('방송이 종료되었습니다.')) {
-        goToList()
-      }
+      alert('방송이 종료되었습니다.')
+      goToList()
       break
     case 'BROADCAST_STOPPED':
       if (detail.value) {
@@ -858,7 +862,7 @@ watch(streamToken, () => {
               <div class="player-frame" :class="{ 'player-frame--fullscreen': isFullscreen }">
                 <div v-show="hasSubscriberStream" ref="viewerContainerRef" class="player-frame__viewer"></div>
                 <div class="player-overlay">
-                  <div class="overlay-item">⏱ {{ detail.elapsed }}</div>
+                  <div class="overlay-item">⏱ {{ elapsedLabel }}</div>
                   <div class="overlay-item">👥 {{ detail.viewers }}명</div>
                   <div class="overlay-item">❤ {{ detail.likes }}</div>
                   <div class="overlay-item">🚩 {{ detail.reports ?? 0 }}건</div>
@@ -887,7 +891,7 @@ watch(streamToken, () => {
                 </div>
                 <div v-if="isReadOnly" class="player-placeholder">
                   <img
-                    v-if="waitingScreenUrl"
+                    v-if="waitingScreenUrl && lifecycleStatus !== 'STOPPED'"
                     class="player-placeholder__image"
                     :src="waitingScreenUrl"
                     alt="대기 화면"
@@ -1187,10 +1191,11 @@ watch(streamToken, () => {
 }
 
 .player-placeholder__message {
-  color: #f8fafc;
-  font-weight: 800;
-  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+  color: #ffffff;
+  font-weight: 900;
+  text-shadow: 0 3px 12px rgba(0, 0, 0, 0.45);
   max-width: min(520px, 100%);
+  font-size: 1.35rem;
 }
 
 .player-overlay {


### PR DESCRIPTION
### Motivation
- Ensure viewer, seller, and admin users on a live broadcast page are notified and redirected to the broadcast list when a scheduled end occurs.
- Make stopped/ended placeholder messages more visible and legible across pages so users clearly notice policy-enforced stops.
- Provide a clearer confirmation flow and blocking overlay when a broadcast is stopped for policy reasons.

### Description
- Replace `window.confirm` handling for `BROADCAST_SCHEDULED_END` with `alert('방송이 종료되었습니다.')` followed by a redirect to the broadcast list in `front/src/pages/LiveDetail.vue`, `front/src/pages/admin/live/LiveDetail.vue`, and `front/src/pages/seller/LiveStream.vue`.
- Add a stop-confirmation modal flow using `stopConfirmOpen`/`stopConfirmMessage`, a `.stop-blocker` overlay and `ConfirmModal` instances, with handlers `handleStopConfirm`, `handleStopCancel`, and `handleStopDecision` to manage entry/exit on `BROADCAST_STOPPED` events.
- Improve stopped/ended UI by updating `LiveCard.vue` to render a `송출 중지` badge and show an `경과 {{ elapsed }}` info-chip, expose `elapsedLabel`/`viewerExtraLabel`, and increase prominence of placeholder messages via updated styles for `player-frame__message`, `player-placeholder__message`, and `.stream-placeholder--waiting .stream-title`.

### Testing
- An earlier Playwright screenshot attempt to verify stopped placeholders failed with `net::ERR_EMPTY_RESPONSE` and produced no screenshot.
- No other automated tests or CI runs were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963bdbd70c4832686ce0fba88e05424)