### PR TITLE
Fix optional path handling in file name extraction

### DIFF
--- a/front/src/components/BasicInfoEditModal.vue
+++ b/front/src/components/BasicInfoEditModal.vue
@@ -50,7 +50,7 @@ const isOpen = computed(() => props.modelValue)
 
 const extractFileName = (source: string) => {
   if (!source || source.startsWith('data:')) return ''
-  const [path] = source.split('?')
+  const [path = ''] = source.split('?')
   const segments = path.split('/')
   const last = segments[segments.length - 1] ?? ''
   return decodeURIComponent(last)


### PR DESCRIPTION
### Motivation
- The `extractFileName` function could trigger a TypeScript/Vue error reporting that `path` is possibly `undefined` when destructuring the result of `source.split('?')`.
- This can cause build/type-check failures or runtime issues when parsing image URLs for uploads.
- The change aims to make filename extraction robust against missing query parts and satisfy the type checker.

### Description
- Added a default value in the destructuring assignment in `extractFileName` to `const [path = ''] = source.split('?')` to prevent `undefined` values.
- The modification was made in `front/src/components/BasicInfoEditModal.vue` inside the `extractFileName` helper.

### Testing
- No automated tests were run against this change.
- Local repository commands were used to view and update the file and a commit was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963cf282e888326bcbc437f9439892e)