### PR TITLE
Fix filename extraction and add fallback for --danger-color in VodDetail

### DIFF
--- a/front/src/components/BasicInfoEditModal.vue
+++ b/front/src/components/BasicInfoEditModal.vue
@@ -50,7 +50,7 @@ const isOpen = computed(() => props.modelValue)
 
 const extractFileName = (source: string) => {
   if (!source || source.startsWith('data:')) return ''
-  const [path] = source.split('?')
+  const [path = ''] = source.split('?')
   const segments = path.split('/')
   const last = segments[segments.length - 1] ?? ''
   return decodeURIComponent(last)

--- a/front/src/pages/admin/live/VodDetail.vue
+++ b/front/src/pages/admin/live/VodDetail.vue
@@ -682,7 +682,7 @@ watch(vodId, () => {
 }
 
 .icon-pill.danger {
-  color: var(--danger-color);
+  color: var(--danger-color, #dc2626);
   border-color: rgba(220, 38, 38, 0.4);
 }
 


### PR DESCRIPTION
### Motivation
- The `extractFileName` helper could yield `undefined` when destructuring the result of `source.split('?')`, causing TypeScript/Vue type-check or runtime issues.
- The admin Vod detail stylesheet referenced an unresolved CSS custom property `--danger-color`, causing a "Cannot resolve '--danger-color'" error.

### Description
- In `front/src/components/BasicInfoEditModal.vue` make the destructured path safe by using `const [path = ''] = source.split('?')` to avoid `undefined`.
- In `front/src/pages/admin/live/VodDetail.vue` provide a fallback for the CSS variable with `color: var(--danger-color, #dc2626)` to prevent unresolved custom property errors.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963cf282e888326bcbc437f9439892e)