### PR TITLE
Fix LiveDetail typing and quality options, add danger color fallbacks

### DIFF
--- a/front/src/components/BasicInfoEditModal.vue
+++ b/front/src/components/BasicInfoEditModal.vue
@@ -50,7 +50,7 @@ const isOpen = computed(() => props.modelValue)
 
 const extractFileName = (source: string) => {
   if (!source || source.startsWith('data:')) return ''
-  const [path] = source.split('?')
+  const [path = ''] = source.split('?')
   const segments = path.split('/')
   const last = segments[segments.length - 1] ?? ''
   return decodeURIComponent(last)

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -1,5 +1,5 @@
 ﻿<script setup lang="ts">
-import { OpenVidu, type Session, type Subscriber } from 'openvidu-browser'
+import { OpenVidu, type Session } from 'openvidu-browser'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Client, type StompSubscription } from '@stomp/stompjs'
@@ -43,7 +43,9 @@ const leaveRequested = ref(false)
 const viewerContainerRef = ref<HTMLDivElement | null>(null)
 const openviduInstance = ref<OpenVidu | null>(null)
 const openviduSession = ref<Session | null>(null)
-const openviduSubscriber = ref<Subscriber | null>(null)
+type OpenViduSubscriber = Parameters<Session['unsubscribe']>[0]
+
+const openviduSubscriber = ref<OpenViduSubscriber | null>(null)
 const openviduConnected = ref(false)
 
 const FALLBACK_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
@@ -332,12 +334,19 @@ const settingsPanelRef = ref<HTMLElement | null>(null)
 const selectedQuality = ref<'auto' | '1080p' | '720p' | '480p'>('auto')
 const qualityObserver = ref<MutationObserver | null>(null)
 
-const qualityOptions = [
+type QualityOption = {
+  value: 'auto' | '1080p' | '720p' | '480p'
+  label: string
+  width?: number
+  height?: number
+}
+
+const qualityOptions: QualityOption[] = [
   { value: 'auto', label: '자동' },
   { value: '1080p', label: '1080p', width: 1920, height: 1080 },
   { value: '720p', label: '720p', width: 1280, height: 720 },
   { value: '480p', label: '480p', width: 854, height: 480 },
-] as const
+]
 
 const applyVideoQuality = async (value: typeof selectedQuality.value) => {
   try {
@@ -406,9 +415,9 @@ const connectSubscriber = async (token: string) => {
         openviduSubscriber.value = null
         clearViewerContainer()
       }
-      openviduSubscriber.value = openviduSession.value.subscribe(event.stream, viewerContainerRef.value, {
-        insertMode: 'append',
-      })
+    openviduSubscriber.value = openviduSession.value.subscribe(event.stream, viewerContainerRef.value, {
+      insertMode: 'append',
+    }) as OpenViduSubscriber
     })
     openviduSession.value.on('streamDestroyed', () => {
       openviduSubscriber.value = null
@@ -1412,6 +1421,7 @@ onBeforeUnmount(() => {
   flex-direction: column;
   gap: 18px;
   overflow-x: hidden;
+  --danger-color: #dc2626;
 }
 
 .live-detail-main {

--- a/front/src/pages/admin/live/VodDetail.vue
+++ b/front/src/pages/admin/live/VodDetail.vue
@@ -682,7 +682,7 @@ watch(vodId, () => {
 }
 
 .icon-pill.danger {
-  color: var(--danger-color);
+  color: var(--danger-color, #dc2626);
   border-color: rgba(220, 38, 38, 0.4);
 }
 


### PR DESCRIPTION
### Motivation
- Prevent TypeScript/Vue type errors when handling OpenVidu subscribers by aligning the local subscriber type with the session API.
- Avoid TypeScript errors when selecting video quality options by making `width`/`height` optional in the quality option type.
- Prevent unresolved CSS custom property errors for `--danger-color` in live/VOD pages by providing a fallback.
- Avoid potential `undefined` when extracting filenames from URLs by making destructuring safe in the file helper.

### Description
- Replace the direct `Subscriber` import with `type OpenViduSubscriber = Parameters<Session['unsubscribe']>[0]` and cast the result of `session.subscribe(...)` to that type in `front/src/pages/LiveDetail.vue` to satisfy typing expectations.
- Introduce a `QualityOption` type and change `qualityOptions` to `QualityOption[]` so `width`/`height` are optional and `applyVideoQuality` checks for those values safely in `front/src/pages/LiveDetail.vue`.
- Add a local fallback for `--danger-color` in `.live-detail-layout` and use `var(--danger-color, #dc2626)` for `.icon-pill.danger` to avoid unresolved CSS variable errors in `front/src/pages/LiveDetail.vue` and `front/src/pages/admin/live/VodDetail.vue`.
- Make destructuring safe in `extractFileName` by using `const [path = ''] = source.split('?')` to avoid returning `undefined` in `front/src/components/BasicInfoEditModal.vue`.

### Testing
- No automated tests were run for these changes.
- No typecheck/build was executed as part of this PR validation.
- Manual runtime verification is suggested for OpenVidu subscription behavior and CSS appearance after applying the patch.
- Recommend running `yarn build` or `npm run build` and `vue-tsc -b` to confirm TypeScript/Vue checks locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963cf282e888326bcbc437f9439892e)