### PR TITLE
Add OpenVidu recording fallback & Redis delayed retry for VOD processing

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/dto/request/OpenViduRecordingWebhook.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/request/OpenViduRecordingWebhook.java
@@ -1,11 +1,13 @@
 package com.deskit.deskit.livehost.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @ToString
 public class OpenViduRecordingWebhook {
     // 이벤트 타입 (recordingStatusChanged)
@@ -33,4 +35,3 @@ public class OpenViduRecordingWebhook {
     private String url;
     // (참고) OpenVidu 버전에 따라 resolution, hasAudio 등이 올 수 있음
 }
-

--- a/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
@@ -1,11 +1,24 @@
 package com.deskit.deskit.livehost.service;
 
-import io.openvidu.java.client.*;
+import io.openvidu.java.client.Connection;
+import io.openvidu.java.client.ConnectionProperties;
+import io.openvidu.java.client.ConnectionType;
+import io.openvidu.java.client.OpenVidu;
+import io.openvidu.java.client.OpenViduHttpException;
+import io.openvidu.java.client.OpenViduJavaClientException;
+import io.openvidu.java.client.OpenViduRole;
+import io.openvidu.java.client.Recording;
+import io.openvidu.java.client.RecordingMode;
+import io.openvidu.java.client.RecordingProperties;
+import io.openvidu.java.client.Session;
+import io.openvidu.java.client.SessionProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
@@ -97,6 +110,17 @@ public class OpenViduService {
                 log.error("세션 종료 중 오류: {}", e.getMessage());
             }
         }
+    }
+
+    public Optional<Recording> findRecordingBySessionId(String sessionId)
+            throws OpenViduJavaClientException, OpenViduHttpException {
+        List<Recording> recordings = openVidu.listRecordings();
+        if (recordings == null || recordings.isEmpty()) {
+            return Optional.empty();
+        }
+        return recordings.stream()
+                .filter(recording -> sessionId.equals(recording.getSessionId()))
+                .findFirst();
     }
 
     public void forceDisconnect(Long broadcastId, String connectionId) {


### PR DESCRIPTION
### Motivation

- Ensure VOD creation is triggered even when the OpenVidu `recordingStatusChanged` webhook is missed or delayed for scheduled ends.  
- Provide a safe fallback path to query OpenVidu for recordings and trigger existing VOD processing logic.  
- Prevent duplicate VOD creation by guarding `processVod` and clearing retry state when processing succeeds.  
- Add a Redis-backed delayed retry mechanism to re-check recording status with exponential backoff when needed.

### Description

- Add `findRecordingBySessionId` to `OpenViduService` to list recordings and locate one for a `sessionId` via the OpenVidu client.  
- Extend `RedisService` with ZSET-based delayed queue and attempt tracking methods: `getRecordingRetryQueueKey`, `getRecordingRetryAttemptKey`, `scheduleRecordingRetry`, `popDueRecordingRetries`, `incrementRecordingRetryAttempt`, and `clearRecordingRetry`.  
- Update `BroadcastService` to trigger a fallback after `openViduService.closeSession(...)` on scheduled end, implement `triggerRecordingFallback` which queries OpenVidu and synthesizes an `OpenViduRecordingWebhook` payload when `ready`, schedule retries with exponential delay up to a max attempts threshold, and add a scheduled `processRecordingFallbackQueue` to dequeue and process retries.  
- Make `OpenViduRecordingWebhook` constructible with an all-args constructor so the fallback can create a payload programmatically, and guard `processVod` to skip duplicate VOD processing and clear retry state on success.

### Testing

- No automated tests were executed for these changes.  
- Runtime/compilation checks were not run as part of this change set.  
- Integration with an OpenVidu instance and Redis-backed retry queue should be verified in staging to validate end-to-end behavior.  
- Manual verification recommended for `processRecordingFallbackQueue` scheduling and retry limits against real recording outcomes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963ce744ed88326a362569d989df8a1)