### PR TITLE
Save broadcast_result snapshot on admin force-stop and scheduled end

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/AdminService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/AdminService.java
@@ -20,6 +20,7 @@ public class AdminService {
     private final RedisService redisService;
     private final SseService sseService;
     private final SanctionService sanctionService;
+    private final BroadcastService broadcastService;
 
     @Transactional(readOnly = true)
     public SanctionStatisticsResponse getSanctionStatistics(String period) {
@@ -48,6 +49,7 @@ public class AdminService {
             validateTransition(broadcast.getStatus(), BroadcastStatus.STOPPED);
             broadcast.forceStopByAdmin(reason);
 
+            broadcastService.saveBroadcastResultSnapshot(broadcast);
             openViduService.closeSession(broadcastId);
             redisService.deleteBroadcastKeys(broadcastId);
             sseService.notifyBroadcastUpdate(broadcastId, "BROADCAST_STOPPED", reason);


### PR DESCRIPTION
### Motivation

- Ensure `broadcast_result` contains minimum final statistics when a broadcast is force-stopped or reaches its scheduled end.
- Capture aggregated metrics that live in Redis and DB to avoid losing realtime counters when a broadcast is terminated by admin or scheduled completion.
- Reuse a single implementation to avoid duplication between admin actions and scheduled processing.

### Description

- Added a public transactional method `saveBroadcastResultSnapshot(Broadcast)` to `BroadcastService` that collects stats from Redis and DB (unique viewers, likes, reports, max viewers/time, average watch time, chat count and sales) and upserts `BroadcastResult` accordingly.
- The snapshot logic merges Redis-derived values with existing DB values and preserves the larger/most-relevant values when updating an existing `BroadcastResult`.
- Invoked `saveBroadcastResultSnapshot(...)` from `AdminService.forceStopBroadcast(...)` after applying `broadcast.forceStopByAdmin(...)` and from `BroadcastService.syncBroadcastSchedules()` when scheduled ends are processed.
- Added `BroadcastService` injection into `AdminService` to call the shared saver and persisted the result via `broadcastResultRepository.save(...)`.

### Testing

- No automated tests were executed as part of this change.
- Static checks or build were not run in this rollout.
- Manual compilation/commit was performed and changes were committed locally.
- Further unit/integration tests should be added to validate upsert behavior and merged-statistics logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d5054e948326805beb2c16219289)