### PR TITLE
Add scheduled recovery for missing VOD or broadcast results

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/repository/BroadcastRepository.java
+++ b/src/main/java/com/deskit/deskit/livehost/repository/BroadcastRepository.java
@@ -14,4 +14,14 @@ public interface BroadcastRepository extends JpaRepository<Broadcast, Long>, Bro
     long countBySellerIdAndStatus(@Param("sellerId") Long sellerId, @Param("status") BroadcastStatus status);
 
     List<Broadcast> findByStatusAndStartedAtBefore(BroadcastStatus status, LocalDateTime threshold);
+
+    @Query("""
+            SELECT DISTINCT b
+            FROM Broadcast b
+            LEFT JOIN Vod v ON v.broadcast = b
+            LEFT JOIN BroadcastResult br ON br.broadcast = b
+            WHERE b.status IN :statuses
+              AND (v IS NULL OR br IS NULL)
+            """)
+    List<Broadcast> findMissingVodOrResultByStatus(@Param("statuses") List<BroadcastStatus> statuses);
 }


### PR DESCRIPTION
### Motivation

- Ensure broadcasts that ended or were stopped but lack a VOD entity or a `broadcast_result` row are discovered and recovered automatically.
- Provide a periodic routine to attempt VOD processing fallback and to backfill broadcast result snapshots when missing.
- Reuse existing recording fallback and retry logic to avoid duplicating retry policies and error handling.

### Description

- Added `findMissingVodOrResultByStatus` JPQL query to `BroadcastRepository` to select broadcasts in given statuses where either `Vod` or `BroadcastResult` is missing.
- Added scheduled task `recoverMissingVodOrResult` in `BroadcastService` (annotated with `@Scheduled(fixedDelay = 300000)`) that queries for `ENDED`/`STOPPED` broadcasts and for each target triggers recovery actions.
- For each target the task invokes the existing `triggerRecordingFallback(broadcastId, ...)` when VOD is missing and calls `saveBroadcastResultSnapshot(broadcast)` when broadcast result is missing, with logging for detected cases.
- The implementation reuses existing transactional boundaries and the existing recording retry/scheduling logic (`triggerRecordingFallback` / `scheduleRecordingRetry`) so retry policies are preserved.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d5f49f188326b351be327facb7c1)