### PR TITLE
Fix live list polling precedence

### DIFF
--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -509,7 +509,7 @@ const vodItemsWithStatus = computed(() => vodItems.value.map(withLifecycleStatus
 
 const liveDisplayItems = computed(() => {
   const byId = new Map<string, LiveItem>()
-  ;[...liveItemsWithStatus.value, ...scheduledItemsWithStatus.value].forEach((item) => {
+  ;[...scheduledItemsWithStatus.value, ...liveItemsWithStatus.value].forEach((item) => {
     const status = getLifecycleStatus(item)
     if (!LIVE_SECTION_STATUSES.includes(status)) return
     if (status === 'STOPPED' && isPastScheduledEnd(item)) return

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -368,7 +368,7 @@ const liveItemsWithStatus = computed(() => liveItems.value.map(withLifecycleStat
 const scheduledWithStatus = computed(() => scheduledItems.value.map(withLifecycleStatus))
 
 const liveStageItems = computed(() => {
-  const merged = [...liveItemsWithStatus.value, ...scheduledWithStatus.value]
+  const merged = [...scheduledWithStatus.value, ...liveItemsWithStatus.value]
   const byId = new Map<string, LiveItem>()
   merged.forEach((item) => {
     const lifecycleStatus = normalizeBroadcastStatus(item.lifecycleStatus ?? item.status)


### PR DESCRIPTION
### Motivation
- Real-time viewer counts polled every 5 seconds were not reflected when the same broadcast existed in both live and scheduled lists because the merge favored scheduled items.
- The goal is to ensure the most up-to-date live data overrides scheduled duplicates so polling updates take effect in UI lists.

### Description
- Change the merge order so scheduled items are merged first and live items are applied last, letting `live` entries overwrite duplicates when building display lists in `seller/Live.vue` and `admin/AdminLive.vue`.
- Updated `liveStageItems` in `front/src/pages/seller/Live.vue` and `liveDisplayItems` in `front/src/pages/admin/AdminLive.vue` to iterate `[...scheduled, ...live]` instead of `[...live, ...scheduled]`.
- This ensures computed lists prefer the live item data (viewers/likes/reports) when IDs collide.

### Testing
- No automated tests were executed as part of this change.
- The change is limited to computed merging logic and should be covered by existing UI/watch behaviors and polling timers (`startStatsPolling`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d8d3f0a4832683e975b291b9af96)