### PR TITLE
Apply polled live stats to merged live/scheduled lists

### DIFF
--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -483,16 +483,21 @@ const updateLiveViewerCounts = async () => {
     }
   })
   if (!statsMap.size) return
-  liveItems.value = liveItems.value.map((item) => {
-    const stats = statsMap.get(item.id)
-    if (!stats) return item
-    return {
-      ...item,
-      viewers: stats.viewerCount ?? item.viewers ?? 0,
-      likes: stats.likeCount ?? item.likes ?? 0,
-      reports: stats.reportCount ?? item.reports ?? 0,
-    }
-  })
+  const applyStats = (items: LiveItem[]) =>
+    items.map((item) => {
+      const stats = statsMap.get(item.id)
+      if (!stats) return item
+      const viewers = stats.viewerCount ?? item.viewers ?? 0
+      return {
+        ...item,
+        viewers,
+        viewerBadge: `${viewers}명 시청 중`,
+        likes: stats.likeCount ?? item.likes ?? 0,
+        reports: stats.reportCount ?? item.reports ?? 0,
+      }
+    })
+  liveItems.value = applyStats(liveItems.value)
+  scheduledItems.value = applyStats(scheduledItems.value)
 }
 
 const loadCategories = async () => {
@@ -509,7 +514,7 @@ const vodItemsWithStatus = computed(() => vodItems.value.map(withLifecycleStatus
 
 const liveDisplayItems = computed(() => {
   const byId = new Map<string, LiveItem>()
-  ;[...liveItemsWithStatus.value, ...scheduledItemsWithStatus.value].forEach((item) => {
+  ;[...scheduledItemsWithStatus.value, ...liveItemsWithStatus.value].forEach((item) => {
     const status = getLifecycleStatus(item)
     if (!LIVE_SECTION_STATUSES.includes(status)) return
     if (status === 'STOPPED' && isPastScheduledEnd(item)) return

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -368,7 +368,7 @@ const liveItemsWithStatus = computed(() => liveItems.value.map(withLifecycleStat
 const scheduledWithStatus = computed(() => scheduledItems.value.map(withLifecycleStatus))
 
 const liveStageItems = computed(() => {
-  const merged = [...liveItemsWithStatus.value, ...scheduledWithStatus.value]
+  const merged = [...scheduledWithStatus.value, ...liveItemsWithStatus.value]
   const byId = new Map<string, LiveItem>()
   merged.forEach((item) => {
     const lifecycleStatus = normalizeBroadcastStatus(item.lifecycleStatus ?? item.status)
@@ -466,18 +466,21 @@ const updateLiveViewerCounts = async () => {
     }
   })
   if (!statsMap.size) return
-  liveItems.value = liveItems.value.map((item) => {
-    const stats = statsMap.get(item.id)
-    if (!stats) return item
-    const viewers = stats.viewerCount ?? item.viewers ?? 0
-    return {
-      ...item,
-      viewers,
-      viewerBadge: `${viewers}명 시청 중`,
-      likes: stats.likeCount ?? item.likes ?? 0,
-      reports: stats.reportCount ?? item.reports ?? 0,
-    }
-  })
+  const applyStats = (items: LiveItem[]) =>
+    items.map((item) => {
+      const stats = statsMap.get(item.id)
+      if (!stats) return item
+      const viewers = stats.viewerCount ?? item.viewers ?? 0
+      return {
+        ...item,
+        viewers,
+        viewerBadge: `${viewers}명 시청 중`,
+        likes: stats.likeCount ?? item.likes ?? 0,
+        reports: stats.reportCount ?? item.reports ?? 0,
+      }
+    })
+  liveItems.value = applyStats(liveItems.value)
+  scheduledItems.value = applyStats(scheduledItems.value)
 }
 
 const startStatsPolling = () => {


### PR DESCRIPTION
### Motivation
- Ensure polled real-time viewer/like/report counts update list badges consistently for seller and admin views.
- Keep list badges meaningful by applying live stats to both live and scheduled representations of the same broadcast.

### Description
- In `front/src/pages/seller/Live.vue` and `front/src/pages/admin/AdminLive.vue` apply polled stats to both `liveItems` and `scheduledItems` by introducing an `applyStats` mapper used in `updateLiveViewerCounts`.
- Update viewer counts, `viewerBadge`, `likes`, and `reports` from polling results so badges reflect latest stats.
- Change merge order in `liveDisplayItems` / `liveStageItems` to iterate `[...]scheduled, ...live` so live entries overwrite scheduled duplicates when building display lists.
- Files modified: `front/src/pages/seller/Live.vue`, `front/src/pages/admin/AdminLive.vue`.

### Testing
- No automated tests were executed for this change.
- Changes are limited to computed merging and polling/update logic and should be observable via the UI polling behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d8d3f0a4832683e975b291b9af96)