### PR TITLE
Fix seller live stream publisher connection timing

### DIFF
--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -1230,6 +1230,14 @@ watch(lifecycleStatus, () => {
   disconnectOpenVidu()
 })
 
+watch([lifecycleStatus, publisherContainerRef], ([status, container]) => {
+  if (status !== 'ON_AIR') return
+  if (!container) return
+  const idValue = streamId.value ? Number(streamId.value) : NaN
+  if (Number.isNaN(idValue)) return
+  void ensurePublisherConnected(idValue)
+})
+
 onBeforeRouteLeave(async () => {
   if (!isInteractive.value) return true
   return await confirmLeaveBroadcast()


### PR DESCRIPTION
### Motivation
- Sellers reported that the broadcast preview never appears for them while admins and viewers see the stream, likely because the OpenVidu publisher connection was attempted before the publisher container was ready.
- The existing logic only attempts to connect when lifecycle status becomes `ON_AIR`, which can miss cases where the DOM container mounts later.

### Description
- Added a watcher combining `lifecycleStatus` and `publisherContainerRef` to retry the publisher connection when the page is `ON_AIR` and the publisher container becomes available.
- The new watcher calls `ensurePublisherConnected` when both conditions are satisfied to guarantee the publisher attaches once the container exists.
- Change location: `front/src/pages/seller/LiveStream.vue` (new `watch([lifecycleStatus, publisherContainerRef], ...)`).

### Testing
- No automated tests were executed for this change.
- Verified behavior relies on existing `ensurePublisherConnected` and existing SSE/connection flows, with no other code paths modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963ddaa3e2083268ef763e39b650e2e)