### PR TITLE
Start and stop OpenVidu recording for broadcasts

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -507,7 +507,9 @@ public class BroadcastService {
 
             try {
                 Map<String, Object> params = Map.of("role", "HOST", "sellerId", sellerId);
-                return openViduService.createToken(broadcastId, params);
+                String token = openViduService.createToken(broadcastId, params);
+                openViduService.startRecording(broadcastId);
+                return token;
             } catch (Exception e) {
                 throw new BusinessException(ErrorCode.OPENVIDU_ERROR);
             }
@@ -572,6 +574,11 @@ public class BroadcastService {
 
             validateTransition(broadcast.getStatus(), BroadcastStatus.ENDED);
             broadcast.endBroadcast();
+            try {
+                openViduService.stopRecording(broadcastId);
+            } catch (Exception e) {
+                log.warn("Failed to stop OpenVidu recording: broadcastId={}, message={}", broadcastId, e.getMessage());
+            }
             openViduService.closeSession(broadcastId);
             sseService.notifyBroadcastUpdate(broadcastId, "BROADCAST_ENDED", "ended");
         } finally {


### PR DESCRIPTION
### Motivation
- Ensure OpenVidu recording is started automatically when a broadcast transitions to ON_AIR so live sessions are recorded.
- Ensure recordings are stopped when a broadcast ends to finalize VODs and release resources.

### Description
- After validating and transitioning a broadcast to `ON_AIR`, the host token is created via `openViduService.createToken` and recording is started with `openViduService.startRecording` before returning the token.
- When ending a broadcast the service now calls `openViduService.stopRecording` and logs a warning on failure, then closes the OpenVidu session with `openViduService.closeSession`.
- The new `stopRecording` call is wrapped in a try/catch to avoid failing the broadcast end flow if recording stop fails.
- Changes are implemented in `BroadcastService` around the `startBroadcast` and `endBroadcast` flows.

### Testing
- No automated tests were executed for this change.
- Manual run or CI verification was not performed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963e00149188326a6a863cb4de67a1a)