### PR TITLE
[FEAT] 상품 상태 전이 정책 반영 및 조회/주문 제약 정리

### DIFF
--- a/src/main/java/com/deskit/deskit/order/service/OrderService.java
+++ b/src/main/java/com/deskit/deskit/order/service/OrderService.java
@@ -81,7 +81,7 @@ public class OrderService {
 
     Map<Long, Product> productsById = new HashMap<>();
     for (Long productId : productIds) {
-      Product product = productRepository.findByIdForUpdate(productId)
+      Product product = productRepository.findByIdForUpdateAndStatus(productId, Product.Status.ON_SALE)
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "product not found"));
       int requestedQty = quantityByProductId.get(productId);
       Integer stockQty = product.getStockQty();

--- a/src/main/java/com/deskit/deskit/product/controller/SellerProductController.java
+++ b/src/main/java/com/deskit/deskit/product/controller/SellerProductController.java
@@ -6,15 +6,18 @@ import com.deskit.deskit.account.repository.SellerRepository;
 import com.deskit.deskit.product.dto.ProductCreateRequest;
 import com.deskit.deskit.product.dto.ProductCreateResponse;
 import com.deskit.deskit.product.dto.ProductImageResponse;
+import com.deskit.deskit.product.dto.ProductResponse;
 import com.deskit.deskit.product.dto.ProductTagUpdateRequest;
 import com.deskit.deskit.product.entity.ProductImage.ImageType;
 import com.deskit.deskit.product.service.ProductImageService;
 import com.deskit.deskit.product.service.ProductService;
 import com.deskit.deskit.product.service.ProductTagService;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -51,6 +54,14 @@ public class SellerProductController {
   ) {
     Long sellerId = resolveSellerId(user);
     return ResponseEntity.ok(productService.createProduct(sellerId, request));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<ProductResponse>> getSellerProducts(
+          @AuthenticationPrincipal CustomOAuth2User user
+  ) {
+    Long sellerId = resolveSellerId(user);
+    return ResponseEntity.ok(productService.getSellerProducts(sellerId));
   }
 
   @PostMapping("/{productId}/images")

--- a/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
@@ -77,10 +77,31 @@ public class ProductResponse {
    * - 엔티티 필드명(productName 등)과 응답 필드명(name 등)을 여기서 매핑
    */
   public static ProductResponse from(Product product, ProductTags tags, List<String> tagsFlat) {
+    Product.Status status = product.getStatus();
+    if (product.isLimitedSale()) {
+      status = Product.Status.LIMITED_SALE;
+    }
     return new ProductResponse(
             product.getId(),
             product.getSellerId(),
             product.getProductName(), // 엔티티 productName -> 응답 name
+            product.getShortDesc(),
+            product.getDetailHtml(),
+            product.getPrice(),
+            product.getCostPrice(),
+            status,
+            product.getStockQty(),
+            product.getSafetyStock(),
+            tags,
+            tagsFlat
+    );
+  }
+
+  public static ProductResponse fromForSeller(Product product, ProductTags tags, List<String> tagsFlat) {
+    return new ProductResponse(
+            product.getId(),
+            product.getSellerId(),
+            product.getProductName(),
             product.getShortDesc(),
             product.getDetailHtml(),
             product.getPrice(),

--- a/src/main/java/com/deskit/deskit/product/repository/ProductRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductRepository.java
@@ -26,6 +26,13 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
    */
   List<Product> findAllByDeletedAtIsNullOrderByIdAsc();
 
+  List<Product> findAllByStatusAndDeletedAtIsNullOrderByIdAsc(Product.Status status);
+
+  List<Product> findAllBySellerIdAndStatusInAndDeletedAtIsNullOrderByIdAsc(
+    Long sellerId,
+    List<Product.Status> statuses
+  );
+
   /**
    * 특정 id의 상품을 조회하되, deleted_at 이 NULL인 경우만 조회
    * 결과가 없을 수 있으니 Optional로 감쌈
@@ -34,9 +41,16 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
    */
   Optional<Product> findByIdAndDeletedAtIsNull(Long id);
 
+  Optional<Product> findByIdAndStatusAndDeletedAtIsNull(Long id, Product.Status status);
+
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select p from Product p where p.id = :id and p.deletedAt is null")
   Optional<Product> findByIdForUpdate(@Param("id") Long id);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select p from Product p where p.id = :id and p.status = :status and p.deletedAt is null")
+  Optional<Product> findByIdForUpdateAndStatus(@Param("id") Long id,
+                                               @Param("status") Product.Status status);
 
   @Query(value = """
       SELECT


### PR DESCRIPTION
## 📌 관련 이슈
- closes #226 

## 📝 작업 내용
- ProductStatus enum 정책 기준으로 재정의
- 상태 전이 규칙(canTransitionTo) 및 changeStatus 도입
- 상품 생성 시 상태를 DRAFT로 강제
- LIMITED_SALE을 재고 기반 계산 상태로 분리 처리
- 사용자용 조회 API: ON_SALE(+ LIMITED_SALE 표시)만 노출
- 판매자용 조회 API: DRAFT / READY / ON_SALE / SOLD_OUT / PAUSED / HIDDEN 노출
- 주문 생성 시 ON_SALE 상태 상품만 허용하도록 서버 레벨 제한