### PR TITLE
Fix OpenVidu subscriber typing in viewer LiveDetail

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -1,5 +1,5 @@
 ﻿<script setup lang="ts">
-import { OpenVidu, type Session } from 'openvidu-browser'
+import { OpenVidu, type Session, type Subscriber } from 'openvidu-browser'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Client, type StompSubscription } from '@stomp/stompjs'
@@ -43,9 +43,7 @@ const leaveRequested = ref(false)
 const viewerContainerRef = ref<HTMLDivElement | null>(null)
 const openviduInstance = ref<OpenVidu | null>(null)
 const openviduSession = ref<Session | null>(null)
-type OpenViduSubscriber = Parameters<Session['unsubscribe']>[0]
-
-const openviduSubscriber = ref<OpenViduSubscriber | null>(null)
+const openviduSubscriber = ref<Subscriber | null>(null)
 const openviduConnected = ref(false)
 
 const FALLBACK_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
@@ -417,7 +415,7 @@ const connectSubscriber = async (token: string) => {
       }
     openviduSubscriber.value = openviduSession.value.subscribe(event.stream, viewerContainerRef.value, {
       insertMode: 'append',
-    }) as OpenViduSubscriber
+    })
     })
     openviduSession.value.on('streamDestroyed', () => {
       openviduSubscriber.value = null


### PR DESCRIPTION
### Motivation
- Fix a TypeScript type error where a value returned by `Session.subscribe` was not assignable to the `Subscriber` parameter used by `Session.unsubscribe`.
- Align the viewer `LiveDetail.vue` typing with the admin viewer implementation that already uses the exported `Subscriber` type.
- Remove an unsafe cast and custom alias that caused Vue/TS to report missing properties on the subscriber object.

### Description
- Import the `Subscriber` type from `openvidu-browser` with `import { ..., type Subscriber } from 'openvidu-browser'`.
- Replace the local `OpenViduSubscriber` alias and cast by declaring `openviduSubscriber` as `ref<Subscriber | null>`.
- Remove the `as OpenViduSubscriber` cast from the `openviduSession.subscribe(...)` call so the returned value uses the official `Subscriber` type.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963e3fee5148326a5cb059f5fdbeb47)