### PR TITLE
SSE: emit cancel & product-unpin events and preserve product ordering on UI

### DIFF
--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -455,6 +455,11 @@ export const pinSellerBroadcastProduct = async (broadcastId: number, productId: 
   return ensureSuccess(data)
 }
 
+export const unpinSellerBroadcastProduct = async (broadcastId: number) => {
+  const { data } = await http.delete<ApiResult<void>>(`/api/seller/broadcasts/${broadcastId}/pin`)
+  return ensureSuccess(data)
+}
+
 export const fetchSellerStatistics = async (period: string): Promise<StatisticsResponse> => {
   const { data } = await http.get<ApiResult<StatisticsResponse>>('/api/seller/broadcasts/statistics', { params: { period } })
   return ensureSuccess(data)

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -253,12 +253,13 @@ const loadProducts = async () => {
 const products = ref<BroadcastProductItem[]>([])
 const sortedProducts = computed(() => {
   const list = products.value.slice()
+  const orderMap = new Map(list.map((product, index) => [product.id, index]))
   return list.sort((a, b) => {
     if (a.isSoldOut && !b.isSoldOut) return 1
     if (!a.isSoldOut && b.isSoldOut) return -1
     if (a.isPinned && !b.isPinned) return -1
     if (!a.isPinned && b.isPinned) return 1
-    return a.name.localeCompare(b.name)
+    return (orderMap.get(a.id) ?? 0) - (orderMap.get(b.id) ?? 0)
   })
 })
 
@@ -594,6 +595,7 @@ const handleSseEvent = (event: MessageEvent) => {
       scheduleRefresh()
       break
     case 'PRODUCT_PINNED':
+    case 'PRODUCT_UNPINNED':
     case 'PRODUCT_SOLD_OUT':
       scheduleRefresh()
       break
@@ -675,6 +677,7 @@ const connectSse = (id: number) => {
     'BROADCAST_UPDATED',
     'BROADCAST_STARTED',
     'PRODUCT_PINNED',
+    'PRODUCT_UNPINNED',
     'PRODUCT_SOLD_OUT',
     'SANCTION_ALERT',
     'BROADCAST_ENDING_SOON',

--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -397,6 +397,7 @@ const handleSseEvent = (event: MessageEvent) => {
     case 'BROADCAST_UPDATED':
     case 'BROADCAST_STARTED':
     case 'PRODUCT_PINNED':
+    case 'PRODUCT_UNPINNED':
     case 'PRODUCT_SOLD_OUT':
     case 'SANCTION_UPDATED':
     case 'BROADCAST_CANCELED':
@@ -431,6 +432,7 @@ const connectSse = () => {
     'BROADCAST_UPDATED',
     'BROADCAST_STARTED',
     'PRODUCT_PINNED',
+    'PRODUCT_UNPINNED',
     'PRODUCT_SOLD_OUT',
     'SANCTION_UPDATED',
     'BROADCAST_CANCELED',

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -166,12 +166,14 @@ const mapLiveProduct = (item: {
 }
 
 const sortedLiveProducts = computed(() => {
-  return [...liveProducts.value].sort((a, b) => {
+  const list = [...liveProducts.value]
+  const orderMap = new Map(list.map((product, index) => [product.id, index]))
+  return list.sort((a, b) => {
     const aSoldOut = a.status === '품절'
     const bSoldOut = b.status === '품절'
     if (aSoldOut !== bSoldOut) return aSoldOut ? 1 : -1
     if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1
-    return 0
+    return (orderMap.get(a.id) ?? 0) - (orderMap.get(b.id) ?? 0)
   })
 })
 
@@ -489,6 +491,7 @@ const handleSseEvent = (event: MessageEvent) => {
       scheduleRefresh(idValue)
       break
     case 'PRODUCT_PINNED':
+    case 'PRODUCT_UNPINNED':
     case 'PRODUCT_SOLD_OUT':
       scheduleRefresh(idValue)
       break
@@ -540,6 +543,7 @@ const connectSse = (broadcastId: number) => {
     'BROADCAST_UPDATED',
     'BROADCAST_STARTED',
     'PRODUCT_PINNED',
+    'PRODUCT_UNPINNED',
     'PRODUCT_SOLD_OUT',
     'SANCTION_UPDATED',
     'BROADCAST_ENDING_SOON',

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -504,6 +504,7 @@ const handleSseEvent = (event: MessageEvent) => {
     case 'BROADCAST_UPDATED':
     case 'BROADCAST_STARTED':
     case 'PRODUCT_PINNED':
+    case 'PRODUCT_UNPINNED':
     case 'PRODUCT_SOLD_OUT':
     case 'SANCTION_UPDATED':
     case 'BROADCAST_CANCELED':
@@ -538,6 +539,7 @@ const connectSse = () => {
     'BROADCAST_UPDATED',
     'BROADCAST_STARTED',
     'PRODUCT_PINNED',
+    'PRODUCT_UNPINNED',
     'PRODUCT_SOLD_OUT',
     'SANCTION_UPDATED',
     'BROADCAST_CANCELED',

--- a/src/main/java/com/deskit/deskit/livehost/controller/seller/BroadcastSellerController.java
+++ b/src/main/java/com/deskit/deskit/livehost/controller/seller/BroadcastSellerController.java
@@ -164,6 +164,15 @@ public class BroadcastSellerController {
         return ResponseEntity.ok(ApiResult.success(null));
     }
 
+    @DeleteMapping("/{broadcastId}/pin")
+    public ResponseEntity<ApiResult<Void>> unpinProduct(
+            @PathVariable Long broadcastId
+    ) {
+        Seller seller = liveAuthUtils.getCurrentSeller();
+        broadcastService.unpinProduct(seller.getSellerId(), broadcastId);
+        return ResponseEntity.ok(ApiResult.success(null));
+    }
+
     @PostMapping("/{broadcastId}/sanctions")
     public ResponseEntity<ApiResult<Void>> sanctionUser(
             @PathVariable Long broadcastId,

--- a/src/main/java/com/deskit/deskit/livehost/service/AdminService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/AdminService.java
@@ -78,6 +78,7 @@ public class AdminService {
 
             validateTransition(broadcast.getStatus(), BroadcastStatus.CANCELED);
             broadcast.cancelBroadcast(reason);
+            sseService.notifyBroadcastUpdate(broadcastId, "BROADCAST_CANCELED", reason);
         } finally {
             redisService.releaseLock(lockKey);
         }


### PR DESCRIPTION
### Motivation

- Ensure broadcast status changes (including cancellations) are reflected immediately via SSE so lists don't require manual refresh. 
- Support sellers unpinning a product and notify viewers/admins via SSE so UI updates automatically. 
- Keep product card ordering stable for viewers/admins while still prioritizing a pinned item and pushing sold-out items to the end. 
- Reduce UI jitter when pin/unpin events arrive by preserving original product order instead of always sorting by name.

### Description

- Backend: emit SSE `BROADCAST_CANCELED` when an admin or seller cancels a broadcast by calling `SseService.notifyBroadcastUpdate` in `AdminService.cancelBroadcast` and `BroadcastService.cancelBroadcast`. 
- Backend: added `unpinProduct` service and seller endpoint `DELETE /api/seller/broadcasts/{broadcastId}/pin` that resets pinned state and emits a `PRODUCT_UNPINNED` event. 
- Frontend API: added `unpinSellerBroadcastProduct` wrapper for the new delete endpoint in `front/src/lib/live/api.ts`. 
- Frontend: handle `PRODUCT_UNPINNED` SSE across seller/admin/viewer pages and wire `setPinnedProduct` in `LiveStream.vue` to call `unpinSellerBroadcastProduct` when unpinning; updated product sorting (viewer/admin panels) to preserve original server order via an `orderMap` while still prioritizing `pinned` and placing `sold out` items last. 

### Testing

- No automated tests were run for this change. 
- Behavior covered by code changes: SSE events handled in `Live`, `LiveStream`, `LiveDetail`, `admin` live pages and backend endpoints added/updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963e38964448326874687f2f699c698)