### PR TITLE
Fix TypeScript typing for OpenVidu unsubscribe in LiveDetail

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -391,7 +391,7 @@ const disconnectOpenVidu = () => {
   if (openviduSession.value) {
     try {
       if (openviduSubscriber.value) {
-        openviduSession.value.unsubscribe(openviduSubscriber.value)
+        openviduSession.value.unsubscribe(openviduSubscriber.value as Subscriber)
       }
       openviduSession.value.disconnect()
     } catch {
@@ -410,7 +410,7 @@ const connectSubscriber = async (token: string) => {
     openviduSession.value.on('streamCreated', (event) => {
       if (!viewerContainerRef.value || !openviduSession.value) return
       if (openviduSubscriber.value) {
-        openviduSession.value.unsubscribe(openviduSubscriber.value)
+        openviduSession.value.unsubscribe(openviduSubscriber.value as Subscriber)
         openviduSubscriber.value = null
         clearViewerContainer()
       }


### PR DESCRIPTION
### Motivation
- The viewer `LiveDetail` page produced TypeScript errors when calling `unsubscribe` because the value passed was not recognized as a `Subscriber` type, breaking type checking.

### Description
- Cast `openviduSubscriber` to `Subscriber` when calling `unsubscribe` to satisfy the TypeScript signature in `front/src/pages/LiveDetail.vue`.
- The casts were added in `disconnectOpenVidu` and inside the `streamCreated` handler in `connectSubscriber` to ensure proper unsubscription behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963e6f75f888326a139240b5d9f018b)