### PR TITLE
Ensure live stats polling runs continuously

### DIFF
--- a/front/src/pages/Home.vue
+++ b/front/src/pages/Home.vue
@@ -125,9 +125,7 @@ onMounted(() => {
   loadPopulars()
   loadLiveItems()
   liveRefreshTimer = window.setInterval(() => {
-    if (document.visibilityState === 'visible') {
-      void updateLiveViewerCounts()
-    }
+    void updateLiveViewerCounts()
   }, 5000)
 })
 

--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -457,9 +457,7 @@ const connectSse = () => {
 const startStatsPolling = () => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
-    if (document.visibilityState === 'visible') {
-      void updateLiveViewerCounts()
-    }
+    void updateLiveViewerCounts()
   }, 5000)
 }
 

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -486,9 +486,6 @@ const updateLiveViewerCounts = async () => {
 const startStatsPolling = () => {
   if (statsTimer.value) window.clearInterval(statsTimer.value)
   statsTimer.value = window.setInterval(() => {
-    if (document.visibilityState !== 'visible') {
-      return
-    }
     void updateLiveViewerCounts()
     const current = currentLive.value
     if (current) {


### PR DESCRIPTION
### Motivation

- Live viewer/like/report counts were not updating unless the page was visible or manually refreshed, causing stale data in lists and summaries.  
- The intent is to keep live statistics up-to-date for Home, seller, and admin broadcast lists even when the tab is backgrounded.  

### Description

- Removed `document.visibilityState` checks that prevented polling from running in `front/src/pages/Home.vue`, `front/src/pages/seller/Live.vue`, and `front/src/pages/admin/AdminLive.vue`.  
- `setInterval`-based polling for live stats now always calls `updateLiveViewerCounts()` on a 5-second interval.  
- Kept existing behavior of loading current live details in seller `Live.vue` after stats update.  

### Testing

- No automated tests were executed for this change.  
- Changes were validated by inspecting the updated polling logic in `Home.vue`, `seller/Live.vue`, and `admin/AdminLive.vue`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963e5642c8c8326b847d1c9f40d3426)