### PR TITLE
[FEAT] ProductStatus 기반 프론트 UI 노출 정책 공통화

### DIFF
--- a/front/src/lib/home-data.ts
+++ b/front/src/lib/home-data.ts
@@ -1,5 +1,6 @@
 import type { ProductTags } from './products-data'
 import { productsData } from './products-data'
+import { isSoldOut, isVisibleToUser } from '../utils/productStatusPolicy'
 import { setupsData } from './setups-data'
 
 export type SetupItem = {
@@ -27,7 +28,7 @@ export const popularSetups: SetupItem[] = setupsData.slice(0, 6).map((setup) => 
 }))
 
 export const popularProducts: ProductItem[] = productsData
-  .filter((product) => product.status === 'ON_SALE' || product.status === 'LIMITED_SALE')
+  .filter((product) => isVisibleToUser(product.status))
   .sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0))
   .slice(0, 12)
   .map((product) => ({
@@ -37,5 +38,5 @@ export const popularProducts: ProductItem[] = productsData
     price: product.price,
     originalPrice: product.cost_price > product.price ? product.cost_price : undefined,
     tags: product.tags ?? { space: [], tone: [], situation: [], mood: [] },
-    isSoldOut: product.status === 'SOLD_OUT',
+    isSoldOut: isSoldOut(product.status),
   }))

--- a/front/src/lib/products-data.ts
+++ b/front/src/lib/products-data.ts
@@ -1,12 +1,4 @@
-export type ProductStatus =
-  | 'DRAFT'
-  | 'PENDING_APPROVAL'
-  | 'READY'
-  | 'ON_SALE'
-  | 'LIMITED_SALE'
-  | 'SOLD_OUT'
-  | 'HIDDEN'
-  | 'DELETED'
+import type { ProductStatus } from '../utils/productStatusPolicy'
 
 export type TagCategoryKey = 'space' | 'tone' | 'situation' | 'mood'
 export type ProductTags = Record<TagCategoryKey, string[]>

--- a/front/src/lib/products-mapper.ts
+++ b/front/src/lib/products-mapper.ts
@@ -1,4 +1,5 @@
 import { flattenTags, type DbProduct, type ProductTags } from './products-data'
+import { isSoldOut, isVisibleToUser } from '../utils/productStatusPolicy'
 
 export type UiProduct = {
   id: string
@@ -38,7 +39,7 @@ const categoryFromId = (categoryId?: number | null): 'furniture' | 'computer' | 
 
 export const mapProducts = (items: DbProduct[]): UiProduct[] =>
   items
-    .filter((product) => product.status !== 'DELETED')
+    .filter((product) => isVisibleToUser(product.status))
     .map((product, index) => {
       const productCategory = product.productCategory ?? categoryFromId(product.category_id)
       const tags: ProductTags = product.tags ?? { space: [], tone: [], situation: [], mood: [] }
@@ -57,7 +58,7 @@ export const mapProducts = (items: DbProduct[]): UiProduct[] =>
         tags,
         tagsFlat: product.tagsFlat ?? flattenTags(tags),
         status: product.status,
-        isSoldOut: product.status === 'SOLD_OUT',
+        isSoldOut: isSoldOut(product.status),
         order: index,
       }
     })

--- a/front/src/utils/productStatusPolicy.ts
+++ b/front/src/utils/productStatusPolicy.ts
@@ -1,0 +1,42 @@
+export type ProductStatus =
+  | 'DRAFT'
+  | 'READY'
+  | 'ON_SALE'
+  | 'LIMITED_SALE'
+  | 'SOLD_OUT'
+  | 'PAUSED'
+  | 'HIDDEN'
+  | 'DELETED'
+
+export const isVisibleToUser = (status?: ProductStatus): boolean =>
+  status === 'ON_SALE' ||
+  status === 'LIMITED_SALE' ||
+  status === 'SOLD_OUT' ||
+  status === 'PAUSED'
+
+export const isVisibleToSeller = (status?: ProductStatus): boolean =>
+  status === 'DRAFT' ||
+  status === 'READY' ||
+  status === 'ON_SALE' ||
+  status === 'LIMITED_SALE' ||
+  status === 'SOLD_OUT' ||
+  status === 'PAUSED' ||
+  status === 'HIDDEN'
+
+export const canEdit = (status?: ProductStatus): boolean =>
+  status === 'DRAFT' ||
+  status === 'READY' ||
+  status === 'PAUSED' ||
+  status === 'HIDDEN'
+
+export const canStartSale = (status?: ProductStatus): boolean =>
+  status === 'READY' || status === 'PAUSED' || status === 'SOLD_OUT'
+
+export const canPause = (status?: ProductStatus): boolean => status === 'ON_SALE'
+
+export const canResume = (status?: ProductStatus): boolean =>
+  status === 'PAUSED' || status === 'SOLD_OUT'
+
+export const isSoldOut = (status?: ProductStatus): boolean => status === 'SOLD_OUT'
+
+export const isLimitedSale = (status?: ProductStatus): boolean => status === 'LIMITED_SALE'


### PR DESCRIPTION
## 📌 관련 이슈
- closes #227 

## 📝 작업 내용
- ProductStatus 기반 UI 노출 정책을 공통 유틸로 정의
- 일반 사용자 / 판매자 기준 노출 상태 명확화
- SOLD_OUT / PAUSED / LIMITED_SALE 상태 UX 분기 정리
- 상태 분기를 데이터 레이어로 집중시켜 컴포넌트 분기 제거