### PR TITLE
Retry OpenVidu recording start on 406 and add start-retry queue

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -101,6 +101,9 @@ public class BroadcastService {
     private static final int RECORDING_RETRY_MAX_ATTEMPTS = 5;
     private static final Duration RECORDING_RETRY_TTL = Duration.ofHours(6);
     private static final Duration RECORDING_RETRY_BASE_DELAY = Duration.ofSeconds(30);
+    private static final int RECORDING_START_RETRY_MAX_ATTEMPTS = 10;
+    private static final Duration RECORDING_START_RETRY_TTL = Duration.ofMinutes(30);
+    private static final Duration RECORDING_START_RETRY_BASE_DELAY = Duration.ofSeconds(5);
 
     private final BroadcastRepository broadcastRepository;
     private final BroadcastProductRepository broadcastProductRepository;
@@ -520,8 +523,22 @@ public class BroadcastService {
             try {
                 Map<String, Object> params = Map.of("role", "HOST", "sellerId", sellerId);
                 String token = openViduService.createToken(broadcastId, params);
-                openViduService.startRecording(broadcastId);
+                try {
+                    openViduService.startRecording(broadcastId);
+                } catch (OpenViduHttpException e) {
+                    int status = e.getStatus();
+                    if (status == 406) {
+                        scheduleRecordingStartRetry(broadcastId, "start_broadcast", status);
+                    } else if (status == 409) {
+                        log.info("OpenVidu recording already started: broadcastId={}", broadcastId);
+                    } else {
+                        throw e;
+                    }
+                }
                 return token;
+            } catch (OpenViduJavaClientException | OpenViduHttpException e) {
+                log.error("OpenVidu error during broadcast start: broadcastId={}, message={}", broadcastId, e.getMessage());
+                throw new BusinessException(ErrorCode.OPENVIDU_ERROR);
             } catch (Exception e) {
                 throw new BusinessException(ErrorCode.OPENVIDU_ERROR);
             }
@@ -1424,6 +1441,14 @@ public class BroadcastService {
         }
     }
 
+    @Scheduled(fixedDelay = 5000)
+    @Transactional
+    public void processRecordingStartRetryQueue() {
+        for (Long broadcastId : redisService.popDueRecordingStartRetries(20)) {
+            attemptStartRecordingRetry(broadcastId, "retry_queue");
+        }
+    }
+
     @Scheduled(fixedDelay = 300000)
     @Transactional
     public void recoverMissingVodOrResult() {
@@ -1511,6 +1536,48 @@ public class BroadcastService {
         Duration delay = RECORDING_RETRY_BASE_DELAY.multipliedBy(attempt);
         redisService.scheduleRecordingRetry(broadcastId, delay);
         log.info("Recording fallback scheduled: broadcastId={}, reason={}, status={}, attempt={}, delay={}s",
+                broadcastId, reason, status, attempt, delay.toSeconds());
+    }
+
+    private void attemptStartRecordingRetry(Long broadcastId, String reason) {
+        Broadcast broadcast = broadcastRepository.findById(broadcastId).orElse(null);
+        if (broadcast == null || broadcast.getStatus() != BroadcastStatus.ON_AIR) {
+            redisService.clearRecordingStartRetry(broadcastId);
+            return;
+        }
+        try {
+            openViduService.startRecording(broadcastId);
+            redisService.clearRecordingStartRetry(broadcastId);
+            log.info("OpenVidu recording start succeeded after retry: broadcastId={}, reason={}", broadcastId, reason);
+        } catch (OpenViduHttpException e) {
+            int status = e.getStatus();
+            if (status == 406) {
+                scheduleRecordingStartRetry(broadcastId, reason, status);
+                return;
+            }
+            if (status == 409) {
+                redisService.clearRecordingStartRetry(broadcastId);
+                log.info("OpenVidu recording already started during retry: broadcastId={}, reason={}", broadcastId, reason);
+                return;
+            }
+            redisService.clearRecordingStartRetry(broadcastId);
+            log.error("OpenVidu recording start retry failed: broadcastId={}, reason={}, status={}",
+                    broadcastId, reason, status);
+        } catch (OpenViduJavaClientException e) {
+            scheduleRecordingStartRetry(broadcastId, reason, 0);
+        }
+    }
+
+    private void scheduleRecordingStartRetry(Long broadcastId, String reason, int status) {
+        int attempt = redisService.incrementRecordingStartRetryAttempt(broadcastId, RECORDING_START_RETRY_TTL);
+        if (attempt > RECORDING_START_RETRY_MAX_ATTEMPTS) {
+            log.warn("Recording start retries exceeded: broadcastId={}, reason={}, status={}", broadcastId, reason, status);
+            redisService.clearRecordingStartRetry(broadcastId);
+            return;
+        }
+        Duration delay = RECORDING_START_RETRY_BASE_DELAY.multipliedBy(attempt);
+        redisService.scheduleRecordingStartRetry(broadcastId, delay);
+        log.info("Recording start retry scheduled: broadcastId={}, reason={}, status={}, attempt={}, delay={}s",
                 broadcastId, reason, status, attempt, delay.toSeconds());
     }
 

--- a/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
@@ -87,7 +87,22 @@ public class OpenViduService {
     }
 
     public void startRecording(Long broadcastId) throws OpenViduJavaClientException, OpenViduHttpException {
-        openVidu.startRecording(sessionMap.get(broadcastId));
+        String sessionId = sessionMap.get(broadcastId);
+        if (sessionId == null) {
+            sessionId = createSession(broadcastId);
+        }
+
+        Optional<Recording> existing = findRecordingBySessionId(sessionId);
+        if (existing.isPresent()) {
+            String status = String.valueOf(existing.get().getStatus()).toLowerCase();
+            if ("starting".equals(status) || "started".equals(status)) {
+                log.info("OpenVidu recording already active: broadcastId={}, sessionId={}, status={}",
+                        broadcastId, sessionId, status);
+                return;
+            }
+        }
+
+        openVidu.startRecording(sessionId);
     }
 
     public void stopRecording(Long broadcastId) throws OpenViduJavaClientException, OpenViduHttpException {


### PR DESCRIPTION
### Motivation
- Make OpenVidu recording start resilient to transient 406 responses so broadcasts can proceed even when the media server is temporarily unable to start recording. 
- Avoid noisy errors and duplicate-recording attempts by treating already-started or starting recordings idempotently. 
- Provide an automated retry mechanism with bounds to recover recording starts without manual intervention. 
- Surface and log OpenVidu errors clearly so failures are visible in application logs.

### Description
- Make `OpenViduService.startRecording` create a session when missing and return early if an existing recording for the session has status `starting` or `started`, avoiding duplicate starts. 
- Update `BroadcastService.startBroadcast` to handle `OpenViduHttpException` from `startRecording`: schedule retries on `406`, treat `409` as already-started, and rethrow other errors; introduce `processRecordingStartRetryQueue`, `attemptStartRecordingRetry`, and `scheduleRecordingStartRetry` with retry limits/delays. 
- Add Redis utilities in `RedisService` for a dedicated recording-start retry queue and attempt counters (`getRecordingStartRetryQueueKey`, `scheduleRecordingStartRetry`, `popDueRecordingStartRetries`, `incrementRecordingStartRetryAttempt`, `clearRecordingStartRetry`). 
- Add configuration/constants for retry behavior (`RECORDING_START_RETRY_MAX_ATTEMPTS`, `RECORDING_START_RETRY_TTL`, `RECORDING_START_RETRY_BASE_DELAY`) and informative logging around retry scheduling and outcomes.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f4a6b6d083269d82f5a89985e32a)