### PR TITLE
Start recordings after publisher stream is live

### DIFF
--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -423,6 +423,11 @@ export const startSellerBroadcast = async (broadcastId: number): Promise<string>
   return ensureSuccess(data)
 }
 
+export const startSellerRecording = async (broadcastId: number): Promise<void> => {
+  const { data } = await http.post<ApiResult<void>>(`/api/seller/broadcasts/${broadcastId}/recording/start`)
+  ensureSuccess(data)
+}
+
 export const endSellerBroadcast = async (broadcastId: number): Promise<void> => {
   const { data } = await http.post<ApiResult<void>>(`/api/seller/broadcasts/${broadcastId}/end`)
   return ensureSuccess(data)

--- a/src/main/java/com/deskit/deskit/livehost/controller/seller/BroadcastSellerController.java
+++ b/src/main/java/com/deskit/deskit/livehost/controller/seller/BroadcastSellerController.java
@@ -145,6 +145,15 @@ public class BroadcastSellerController {
         return ResponseEntity.ok(ApiResult.success(token));
     }
 
+    @PostMapping("/{broadcastId}/recording/start")
+    public ResponseEntity<ApiResult<Void>> startRecording(
+            @PathVariable Long broadcastId
+    ) {
+        Seller seller = liveAuthUtils.getCurrentSeller();
+        broadcastService.startRecording(seller.getSellerId(), broadcastId);
+        return ResponseEntity.ok(ApiResult.success(null));
+    }
+
     @PostMapping("/{broadcastId}/end")
     public ResponseEntity<ApiResult<Void>> endBroadcast(
             @PathVariable Long broadcastId


### PR DESCRIPTION
### Motivation
- Recording should be started only after the host/publisher stream is actually published, not implicitly during broadcast start. 
- Decouple OpenVidu recording start from the broadcast start flow to make retries and error handling explicit.

### Description
- Removed automatic `openViduService.startRecording` call from the broadcast start path and introduced a dedicated `startRecording` service method in `BroadcastService`. 
- Added seller controller endpoint `POST /api/seller/broadcasts/{broadcastId}/recording/start` to trigger recording from the client. 
- Frontend: added `startSellerRecording` API helper and updated `LiveStream.vue` to request recording after the publisher is connected/published by changing `connectPublisher` to accept `broadcastId` and call `requestStartRecording` on successful publish; added `recordingStartRequested` flag and `requestStartRecording` helper to avoid duplicate requests. 
- Error handling: `startRecording` handles `OpenViduHttpException` (schedules retry on 406, logs on 409) and schedules retries for client exceptions.

### Testing
- No automated tests were executed for this change.
- Manual/local validation was not recorded in automated test logs.
- Existing scheduling/retry flows are preserved and will enqueue retries when OpenVidu returns transient errors.
- Backend compilation and basic wiring verified by local commit (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963fff73a8c832682785bdb72ceddbf)