### PR TITLE
Fix null max_views_at when saving broadcast results

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -835,6 +835,7 @@ public class BroadcastService {
         int totalChats = countBroadcastChats(broadcastId);
 
         BroadcastResult result = broadcastResultRepository.findById(broadcastId).orElse(null);
+        LocalDateTime peakTime = resolveMaxViewsAt(broadcast, peak);
         if (result == null) {
             result = BroadcastResult.builder()
                     .broadcast(broadcast)
@@ -843,7 +844,7 @@ public class BroadcastService {
                     .totalReports(reports)
                     .avgWatchTime(avg != null ? avg.intValue() : 0)
                     .maxViews(mv)
-                    .pickViewsAt(peak)
+                    .pickViewsAt(peakTime)
                     .totalChats(totalChats)
                     .totalSales(salesSummary.totalSales())
                     .build();
@@ -854,7 +855,7 @@ public class BroadcastService {
                     reports,
                     avg != null ? avg.intValue() : 0,
                     mv,
-                    peak,
+                    peakTime,
                     totalChats,
                     salesSummary.totalSales()
             );
@@ -1336,6 +1337,7 @@ public class BroadcastService {
             }
         }
 
+        peakTime = resolveMaxViewsAt(broadcast, peakTime);
         if (result == null) {
             result = BroadcastResult.builder()
                     .broadcast(broadcast)
@@ -1361,6 +1363,19 @@ public class BroadcastService {
             );
         }
         broadcastResultRepository.save(result);
+    }
+
+    private LocalDateTime resolveMaxViewsAt(Broadcast broadcast, LocalDateTime peakTime) {
+        if (peakTime != null) {
+            return peakTime;
+        }
+        if (broadcast.getStartedAt() != null) {
+            return broadcast.getStartedAt();
+        }
+        if (broadcast.getCreatedAt() != null) {
+            return broadcast.getCreatedAt();
+        }
+        return LocalDateTime.now();
     }
 
     private record SalesSummary(BigDecimal totalSales, Map<Long, SalesMetric> productMetrics) {

--- a/src/main/java/com/deskit/deskit/livehost/service/VodStatsService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/VodStatsService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +43,7 @@ public class VodStatsService {
                     .totalReports(0)
                     .avgWatchTime(0)
                     .maxViews(0)
+                    .pickViewsAt(resolveMaxViewsAt(broadcast))
                     .totalChats(0)
                     .totalSales(BigDecimal.ZERO)
                     .build();
@@ -56,5 +58,15 @@ public class VodStatsService {
                 vod.applyReportDelta(delta.reportDelta());
             }
         }
+    }
+
+    private LocalDateTime resolveMaxViewsAt(Broadcast broadcast) {
+        if (broadcast.getStartedAt() != null) {
+            return broadcast.getStartedAt();
+        }
+        if (broadcast.getCreatedAt() != null) {
+            return broadcast.getCreatedAt();
+        }
+        return LocalDateTime.now();
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent SQL constraint failures caused by inserting null into the `max_views_at` column when saving `broadcast_result` rows.
- Ensure both live snapshot and VOD-stat flows always produce a non-null peak timestamp for downstream consumers and DB inserts.
- Preserve existing peak/time selection logic while providing deterministic fallbacks when Redis or broadcast timestamps are unavailable.

### Description
- Added `resolveMaxViewsAt(Broadcast, LocalDateTime)` to `BroadcastService` and used its result (`peakTime`) when building/updating `BroadcastResult` to guarantee `pickViewsAt` is non-null.
- Added `resolveMaxViewsAt(Broadcast)` to `VodStatsService` and set `.pickViewsAt(resolveMaxViewsAt(broadcast))` when creating VOD `BroadcastResult` entries.
- Imported `LocalDateTime` where required and switched builders to use the resolved `peakTime` to avoid inserting null into `max_views_at`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69642256201c8326bfbe038d8a5ab3cf)