### PR TITLE
Fix viewer VOD playback URL

### DIFF
--- a/front/src/pages/Vod.vue
+++ b/front/src/pages/Vod.vue
@@ -170,7 +170,7 @@ const scheduledLabel = computed(() => {
   return `${month}.${date} (${day}) ${hours}:${minutes} 예정`
 })
 
-const buildVodItem = (detail: { broadcastId: number; title: string; notice?: string; thumbnailUrl?: string; scheduledAt?: string; startedAt?: string; sellerName?: string }) => {
+const buildVodItem = (detail: { broadcastId: number; title: string; notice?: string; thumbnailUrl?: string; scheduledAt?: string; startedAt?: string; sellerName?: string; vodUrl?: string }) => {
   const startAt = detail.startedAt ?? detail.scheduledAt ?? ''
   const startAtMs = startAt ? parseLiveDate(startAt).getTime() : NaN
   const endAtMs = Number.isNaN(startAtMs) ? undefined : getScheduledEndMs(startAtMs)
@@ -182,6 +182,7 @@ const buildVodItem = (detail: { broadcastId: number; title: string; notice?: str
     thumbnailUrl: detail.thumbnailUrl ?? '',
     startAt,
     endAt,
+    vodUrl: detail.vodUrl ?? '',
     sellerName: detail.sellerName ?? '',
   }
 }


### PR DESCRIPTION
### Motivation
- The viewer VOD page showed "VOD 준비 중" because the public broadcast `vodUrl` from the API response was not being mapped into the page item used by the player.
- The admin result page already renders a VOD player, so the viewer page should also receive the playback URL to render the player.

### Description
- Update `buildVodItem` in `front/src/pages/Vod.vue` to accept `vodUrl?: string` and include `vodUrl: detail.vodUrl ?? ''` in the returned item.
- This change ensures the viewer page's template can render an `<iframe>` or `<video>` when `vodUrl` is present.

### Testing
- No automated tests were run for this change.
- Linting or build checks were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69642e5b252c832682c12bbc659a9c60)