### PR TITLE
Persist VOD reaction keys, stop expiring like/report sets, and clean up runtime-only keys

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/AdminService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/AdminService.java
@@ -51,7 +51,7 @@ public class AdminService {
 
             broadcastService.saveBroadcastResultSnapshot(broadcast);
             openViduService.closeSession(broadcastId);
-            redisService.deleteBroadcastKeys(broadcastId);
+            redisService.deleteBroadcastRuntimeKeys(broadcastId);
             sseService.notifyBroadcastUpdate(broadcastId, "BROADCAST_STOPPED", reason);
         } finally {
             redisService.releaseLock(lockKey);

--- a/src/main/java/com/deskit/deskit/livehost/service/RedisService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/RedisService.java
@@ -70,7 +70,7 @@ public class RedisService {
     }
 
     public String getVodLikeUsersKey(Long broadcastId) {
-        return "vod:" + broadcastId + ":like_users";
+        return getLikeUsersKey(broadcastId);
     }
 
     public String getVodLikeDeltaKey(Long broadcastId) {
@@ -78,7 +78,7 @@ public class RedisService {
     }
 
     public String getVodReportUsersKey(Long broadcastId) {
-        return "vod:" + broadcastId + ":report_users";
+        return getReportUsersKey(broadcastId);
     }
 
     public String getVodReportDeltaKey(Long broadcastId) {
@@ -253,7 +253,6 @@ public class RedisService {
         }
 
         redisTemplate.opsForSet().add(key, String.valueOf(memberId));
-        expireKey(key);
         return true;
     }
 
@@ -270,7 +269,6 @@ public class RedisService {
 
         if (added != null && added == 1) {
             redisTemplate.opsForValue().increment(countKey);
-            redisTemplate.expire(userKey, Duration.ofDays(1));
             return true;
         }
 
@@ -295,7 +293,7 @@ public class RedisService {
     }
 
     public boolean toggleVodLike(Long broadcastId, Long memberId) {
-        String key = getVodLikeUsersKey(broadcastId);
+        String key = getLikeUsersKey(broadcastId);
         String memberKey = String.valueOf(memberId);
 
         Boolean isMember = redisTemplate.opsForSet().isMember(key, memberKey);
@@ -317,7 +315,7 @@ public class RedisService {
     }
 
     public boolean reportVod(Long broadcastId, Long memberId) {
-        String userKey = getVodReportUsersKey(broadcastId);
+        String userKey = getReportUsersKey(broadcastId);
         String memberKey = String.valueOf(memberId);
 
         Long added = redisTemplate.opsForSet().add(userKey, memberKey);
@@ -410,6 +408,32 @@ public class RedisService {
         redisTemplate.delete(getReportCountKey(broadcastId));
         redisTemplate.delete(getMaxViewersKey(broadcastId));
         redisTemplate.delete(getMaxViewersTimeKey(broadcastId));
+    }
+
+    public void deleteBroadcastRuntimeKeys(Long broadcastId) {
+        redisTemplate.delete(getRealtimeViewKey(broadcastId));
+        redisTemplate.delete(getSessionCountKey(broadcastId));
+        redisTemplate.delete(getTotalUvKey(broadcastId));
+        redisTemplate.delete(getSanctionKey(broadcastId));
+        redisTemplate.delete(getMaxViewersKey(broadcastId));
+        redisTemplate.delete(getMaxViewersTimeKey(broadcastId));
+    }
+
+    public void persistVodReactionKeys(Long broadcastId) {
+        redisTemplate.persist(getLikeUsersKey(broadcastId));
+        redisTemplate.persist(getReportUsersKey(broadcastId));
+        redisTemplate.persist(getReportCountKey(broadcastId));
+    }
+
+    public void deleteVodKeys(Long broadcastId) {
+        redisTemplate.delete(getLikeUsersKey(broadcastId));
+        redisTemplate.delete(getReportUsersKey(broadcastId));
+        redisTemplate.delete(getReportCountKey(broadcastId));
+        redisTemplate.delete(getVodViewersKey(broadcastId));
+        redisTemplate.delete(getVodViewDeltaKey(broadcastId));
+        redisTemplate.delete(getVodLikeDeltaKey(broadcastId));
+        redisTemplate.delete(getVodReportDeltaKey(broadcastId));
+        redisTemplate.opsForSet().remove(getVodStatsDirtyKey(), String.valueOf(broadcastId));
     }
 
     private void expireKey(String key) {

--- a/src/main/java/com/deskit/deskit/livehost/service/VodMaintenanceService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/VodMaintenanceService.java
@@ -19,6 +19,8 @@ public class VodMaintenanceService {
 
     private final VodRepository vodRepository;
     private final AwsS3Service s3Service;
+    private final VodStatsService vodStatsService;
+    private final RedisService redisService;
 
     @Scheduled(cron = "0 0 3 * * *")
     @Transactional
@@ -33,6 +35,9 @@ public class VodMaintenanceService {
                 if (vod.getVodUrl() != null && !vod.getVodUrl().isBlank()) {
                     s3Service.deleteObjectByUrl(vod.getVodUrl());
                 }
+                Long broadcastId = vod.getBroadcast().getBroadcastId();
+                vodStatsService.flushVodStats(broadcastId);
+                redisService.deleteVodKeys(broadcastId);
                 vod.markDeleted();
             } catch (Exception e) {
                 log.error("VOD 자동 삭제 실패: vodId={}", vod.getVodId(), e);


### PR DESCRIPTION
### Motivation

- Ensure likes/reports persist across live -> VOD so per-user constraints remain consistent and reaction data is not lost when a live ends. 
- Prevent inadvertent expiration of like/report user sets by removing TTL handling. 
- Separate runtime-only Redis keys from persistent reaction keys so stopping a broadcast doesn't remove VOD reaction data. 
- Ensure VOD statistics are flushed to DB and all related Redis keys are cleaned when a VOD is deleted or auto-purged.

### Description

- Updated `RedisService` to stop expiring like/report user keys, reuse live keys for VOD reactions (made `getVodLikeUsersKey`/`getVodReportUsersKey` return the live keys), and added `deleteBroadcastRuntimeKeys`, `persistVodReactionKeys`, and `deleteVodKeys` helper methods. 
- Modified `toggleLike`, `reportBroadcast`, `toggleVodLike`, and `reportVod` to no longer set TTLs and to operate on the shared live keys for VOD reactions. 
- Changed `BroadcastService` to inject `VodStatsService`, call `persistVodReactionKeys` when persisting a VOD, use `deleteBroadcastRuntimeKeys` after broadcast end, and call `vodStatsService.flushVodStats` + `redisService.deleteVodKeys` when removing a VOD. 
- Updated `AdminService` to clear only runtime keys on admin `forceStopBroadcast` by calling `deleteBroadcastRuntimeKeys`, and extended `VodMaintenanceService` to flush stats and delete VOD keys when purging expired VODs.

### Testing

- No automated tests were executed for these changes.
- Code changes were compiled and committed to the working branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964401c55988324bc58216e409f5bb1)