### PR TITLE
Position VOD actions inside player and use watchEffect for polling with unavailable-VOD handling

### DIFF
--- a/front/src/pages/Vod.vue
+++ b/front/src/pages/Vod.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, watch, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import PageContainer from '../components/PageContainer.vue'
 import PageHeader from '../components/PageHeader.vue'
@@ -67,16 +67,15 @@ const handleImageError = (event: Event) => {
 
 
 const showChat = ref(true)
-const isFullscreen = ref(false)
-const stageRef = ref<HTMLElement | null>(null)
 const isLiked = ref(false)
 const likeCount = ref(0)
 const likeInFlight = ref(false)
 const reportInFlight = ref(false)
 const hasReported = ref(false)
-const isSettingsOpen = ref(false)
-const settingsButtonRef = ref<HTMLElement | null>(null)
-const settingsPanelRef = ref<HTMLElement | null>(null)
+const totalViews = ref<number | null>(null)
+const isVodUnavailable = ref(false)
+const refreshTimerId = ref<number | null>(null)
+const redirectPending = ref(false)
 
 const isLoggedIn = computed(() => Boolean(getAuthUser()))
 
@@ -104,6 +103,10 @@ const toggleLike = async () => {
 
 const submitReport = async () => {
   if (!vodItem.value || reportInFlight.value || !requireMemberAction()) return
+  if (hasReported.value) {
+    alert('이미 신고 완료되어 1회만 신고 가능합니다.')
+    return
+  }
   reportInFlight.value = true
   try {
     const result = await reportBroadcast(Number(vodItem.value.id))
@@ -111,7 +114,7 @@ const submitReport = async () => {
     if (result.reported) {
       alert('신고가 접수되었습니다.')
     } else {
-      alert('이미 신고한 VOD입니다.')
+      alert('이미 신고 완료되어 1회만 신고 가능합니다.')
     }
   } catch {
     return
@@ -123,27 +126,6 @@ const submitReport = async () => {
 const toggleChat = () => {
   showChat.value = !showChat.value
 }
-
-const toggleSettings = () => {
-  isSettingsOpen.value = !isSettingsOpen.value
-}
-
-const toggleFullscreen = async () => {
-  const el = stageRef.value
-  if (!el) return
-  try {
-    if (document.fullscreenElement) {
-      await document.exitFullscreen()
-      isFullscreen.value = false
-    } else if (el.requestFullscreen) {
-      await el.requestFullscreen()
-      isFullscreen.value = true
-    }
-  } catch {
-    return
-  }
-}
-
 
 const products = ref<BroadcastProductItem[]>([])
 
@@ -200,11 +182,21 @@ const loadVodDetail = async () => {
     likeCount.value = detail.totalLikes ?? 0
     isLiked.value = false
     hasReported.value = false
+    totalViews.value = detail.totalViews ?? null
+    isVodUnavailable.value = false
     await loadProducts(numeric)
     const viewerId = resolveViewerId(getAuthUser())
     void recordVodView(numeric, viewerId)
   } catch {
     vodItem.value = null
+    totalViews.value = null
+    if (!isVodUnavailable.value) {
+      isVodUnavailable.value = true
+      if (!redirectPending.value) {
+        redirectPending.value = true
+        alert('VOD가 삭제되어 방송 목록으로 이동합니다.')
+      }
+    }
   }
 }
 
@@ -278,43 +270,30 @@ onMounted(() => {
   scrollChatToBottom()
 })
 
-const handleDocumentClick = (event: MouseEvent) => {
-  if (!isSettingsOpen.value) {
+watchEffect((onCleanup) => {
+  if (redirectPending.value) {
     return
   }
-  const target = event.target as Node | null
-  if (
-    settingsButtonRef.value?.contains(target) ||
-    settingsPanelRef.value?.contains(target)
-  ) {
-    return
-  }
-  isSettingsOpen.value = false
-}
-
-const handleDocumentKeydown = (event: KeyboardEvent) => {
-  if (!isSettingsOpen.value) {
-    return
-  }
-  if (event.key === 'Escape') {
-    isSettingsOpen.value = false
-  }
-}
-
-const handleFullscreenChange = () => {
-  isFullscreen.value = Boolean(document.fullscreenElement)
-}
-
-onBeforeUnmount(() => {
-  document.removeEventListener('click', handleDocumentClick)
-  document.removeEventListener('keydown', handleDocumentKeydown)
-  document.removeEventListener('fullscreenchange', handleFullscreenChange)
+  const id = window.setInterval(() => {
+    void loadVodDetail()
+  }, 30000)
+  refreshTimerId.value = id
+  onCleanup(() => {
+    window.clearInterval(id)
+    if (refreshTimerId.value === id) {
+      refreshTimerId.value = null
+    }
+  })
 })
 
-onMounted(() => {
-  document.addEventListener('click', handleDocumentClick)
-  document.addEventListener('keydown', handleDocumentKeydown)
-  document.addEventListener('fullscreenchange', handleFullscreenChange)
+watch(redirectPending, async (next) => {
+  if (!next) return
+  if (refreshTimerId.value !== null) {
+    window.clearInterval(refreshTimerId.value)
+    refreshTimerId.value = null
+  }
+  await nextTick()
+  router.replace('/live').catch(() => {})
 })
 
 watch(showChat, (visible) => {
@@ -347,10 +326,12 @@ watch(showChat, (visible) => {
               <span v-if="status === 'LIVE' && vodItem.viewerCount" class="status-viewers">
                 {{ vodItem.viewerCount.toLocaleString() }}명 시청 중
               </span>
+              <span v-else-if="totalViews !== null" class="status-views">
+                누적 조회수 {{ totalViews.toLocaleString('ko-KR') }}회
+              </span>
               <span v-else-if="status === 'UPCOMING'" class="status-schedule">
                 {{ scheduledLabel }}
               </span>
-              <span v-else-if="status === 'ENDED'" class="status-ended">방송 종료</span>
             </div>
             <h3 class="player-title">{{ vodItem.title }}</h3>
             <span> {{ formatSchedule(vodItem.startAt, vodItem.endAt)}}</span>
@@ -358,7 +339,7 @@ watch(showChat, (visible) => {
             <p v-if="vodItem.sellerName" class="player-seller">{{ vodItem.sellerName }}</p>
           </div>
 
-          <div class="player-frame" ref="stageRef" :class="{ 'player-frame--fullscreen': isFullscreen }">
+          <div class="player-frame">
             <span v-if="status === 'UPCOMING'" class="player-frame__label">아직 시작 전입니다</span>
             <span v-else-if="!vodItem.vodUrl" class="player-frame__label">VOD 준비 중</span>
             <iframe
@@ -369,113 +350,70 @@ watch(showChat, (visible) => {
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen
             />
-            <video v-else class="player-video" :src="vodItem.vodUrl" controls />
-
+            <video
+              v-else
+              class="player-video"
+              :src="vodItem.vodUrl"
+              controls
+              controlslist="nodownload"
+              @contextmenu.prevent
+            />
             <div class="player-actions">
-              <div class="icon-action">
+              <div class="player-reactions">
                 <button
                   type="button"
                   class="icon-circle"
-                  :class="{ active: isLiked }"
-                  aria-label="좋아요"
-                  :disabled="likeInFlight"
-                  @click="toggleLike"
+                  :class="{ active: showChat }"
+                  aria-label="채팅 패널 토글"
+                  @click="toggleChat"
                 >
                   <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                    <path
-                      v-if="isLiked"
-                      d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
-                      fill="currentColor"
-                    />
-                    <path
-                      v-else
-                      d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.8"
-                    />
+                    <path d="M3 20l1.62-3.24A2 2 0 0 1 6.42 16H20a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v15z" fill="none" stroke="currentColor" stroke-width="1.8" />
+                    <path d="M7 9h10M7 12h6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
                   </svg>
                 </button>
-                <span class="icon-count">{{ likeCount.toLocaleString('ko-KR') }}</span>
-              </div>
-              <div class="icon-action">
-                <button
-                  type="button"
-                  class="icon-circle"
-                  aria-label="신고하기"
-                  :disabled="reportInFlight || hasReported"
-                  @click="submitReport"
-                >
-                  <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M6 3v18" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
-                    <path d="M6 4h11l-2 4 2 4H6z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" />
-                  </svg>
-                </button>
-                <span class="icon-label">신고</span>
-              </div>
-              <button
-                type="button"
-                class="icon-circle"
-                :class="{ active: showChat }"
-                aria-label="채팅 패널 토글"
-                @click="toggleChat"
-              >
-                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M3 20l1.62-3.24A2 2 0 0 1 6.42 16H20a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v15z" fill="none" stroke="currentColor" stroke-width="1.8" />
-                  <path d="M7 9h10M7 12h6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
-                </svg>
-              </button>
-              <div class="player-settings">
-                <button
-                  ref="settingsButtonRef"
-                  type="button"
-                  class="icon-circle"
-                  aria-controls="player-settings"
-                  :aria-expanded="isSettingsOpen ? 'true' : 'false'"
-                  aria-label="설정"
-                  @click="toggleSettings"
-                >
-                  <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M4 6h16M4 12h16M4 18h16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
-                    <circle cx="9" cy="6" r="2" fill="none" stroke="currentColor" stroke-width="1.8" />
-                    <circle cx="14" cy="12" r="2" fill="none" stroke="currentColor" stroke-width="1.8" />
-                    <circle cx="7" cy="18" r="2" fill="none" stroke="currentColor" stroke-width="1.8" />
-                  </svg>
-                </button>
-                <div
-                  v-if="isSettingsOpen"
-                  id="player-settings"
-                  ref="settingsPanelRef"
-                  class="settings-popover"
-                >
-                  <label class="settings-row">
-                    <span class="settings-label">볼륨</span>
-                    <input
-                      class="toolbar-slider"
-                      type="range"
-                      min="0"
-                      max="100"
-                      value="60"
-                      aria-label="볼륨 조절"
-                      disabled
-                    />
-                  </label>
-                  <label class="settings-row">
-                    <span class="settings-label">화질</span>
-                    <select class="settings-select" aria-label="화질" disabled>
-                      <option>자동</option>
-                      <option>1080p</option>
-                      <option>720p</option>
-                      <option>480p</option>
-                    </select>
-                  </label>
+                <div class="icon-action">
+                  <button
+                    type="button"
+                    class="icon-circle"
+                    :class="{ active: isLiked }"
+                    aria-label="좋아요"
+                    :disabled="likeInFlight"
+                    @click="toggleLike"
+                  >
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path
+                        v-if="isLiked"
+                        d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
+                        fill="currentColor"
+                      />
+                      <path
+                        v-else
+                        d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.8"
+                      />
+                    </svg>
+                  </button>
+                  <span class="icon-text">{{ likeCount.toLocaleString('ko-KR') }}</span>
+                </div>
+                <div class="icon-action">
+                  <button
+                    type="button"
+                    class="icon-circle"
+                    aria-label="신고하기"
+                    :disabled="reportInFlight || hasReported"
+                    @click="submitReport"
+                  >
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M6 3v18" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+                      <path d="M6 4h11l-2 4 2 4H6z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" />
+                    </svg>
+                  </button>
+                  <span class="icon-text">신고</span>
                 </div>
               </div>
-              <button type="button" class="icon-circle" aria-label="전체 화면" @click="toggleFullscreen">
-                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M4 9V4h5M20 9V4h-5M4 15v5h5M20 15v5h-5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </button>
             </div>
           </div>
         </section>
@@ -736,8 +674,8 @@ watch(showChat, (visible) => {
   font-weight: 700;
 }
 
-.status-ended {
-  color: var(--text-soft);
+.status-views {
+  color: var(--text-muted);
   font-weight: 700;
 }
 
@@ -774,21 +712,6 @@ watch(showChat, (visible) => {
   overflow: hidden;
 }
 
-.player-frame--fullscreen,
-.player-frame:fullscreen {
-  width: min(100vw, calc(100vh * (16 / 9)));
-  height: min(100vh, calc(100vw * (9 / 16)));
-  max-height: 100vh;
-  max-width: 100vw;
-  border-radius: 0;
-  background: #000;
-}
-
-.player-frame:fullscreen .player-embed,
-.player-frame:fullscreen .player-video {
-  object-fit: contain;
-}
-
 .player-frame__label {
   position: absolute;
   z-index: 2;
@@ -812,8 +735,8 @@ watch(showChat, (visible) => {
 
 .player-actions {
   position: absolute;
-  right: 14px;
-  bottom: 14px;
+  right: 16px;
+  bottom: 72px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -821,79 +744,23 @@ watch(showChat, (visible) => {
   z-index: 3;
 }
 
-.icon-action {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: #fff;
-  font-weight: 700;
-}
-
-.icon-count,
-.icon-label {
-  font-size: 0.85rem;
-}
-
-.player-settings {
-  position: relative;
+.player-reactions {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  gap: 12px;
 }
 
-.settings-popover {
-  position: absolute;
-  top: 0;
-  right: calc(100% + 10px);
-  background: var(--surface);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  padding: 12px;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.12);
-  min-width: 220px;
-  display: grid;
-  gap: 10px;
-}
-
-.settings-select {
-  border: 1px solid var(--border-color);
-  background: var(--surface);
-  color: var(--text-strong);
-  border-radius: 10px;
-  height: 36px;
-  padding: 0 12px;
-  font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
-}
-
-.settings-select:hover {
-  border-color: var(--primary-color);
-}
-
-.settings-select:focus-visible,
-.toolbar-slider:focus-visible {
-  outline: 2px solid var(--primary-color);
-  outline-offset: 2px;
-}
-
-.toolbar-slider {
-  accent-color: var(--primary-color);
-  width: 140px;
-}
-
-.settings-row {
+.icon-action {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  gap: 6px;
+  font-weight: 700;
 }
 
-.settings-label {
-  font-weight: 800;
-  color: var(--text-strong);
+.icon-text {
+  font-size: 0.85rem;
 }
 
 .icon-circle {
@@ -911,6 +778,22 @@ watch(showChat, (visible) => {
 }
 
 .icon-circle.active {
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+  background: rgba(var(--primary-rgb), 0.12);
+}
+
+.player-actions .icon-action {
+  color: #fff;
+}
+
+.player-actions .icon-circle {
+  border-color: var(--border-color);
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+}
+
+.player-actions .icon-circle.active {
   border-color: var(--primary-color);
   color: var(--primary-color);
   background: rgba(var(--primary-rgb), 0.12);


### PR DESCRIPTION
### Motivation
- Place the chat/like/report action stack inside the VOD player so icons appear at the bottom-right of the player without overlapping native controls.  
- Replace fragile `onBeforeUnmount`-based cleanup for the polling interval to avoid lifecycle runtime errors.  
- Ensure the VOD polling stops and the user is redirected once when a VOD is detected as deleted, and avoid repeated alerts.  
- Remove unused fullscreen/settings UI and related global event listeners to simplify the player logic.

### Description
- Moved the action UI into the player frame and added `.player-actions` positioned with `right: 16px; bottom: 72px` and an internal `.player-reactions` stack.  
- Restyled action elements (`.player-actions`, `.player-reactions`, `.icon-action`, `.icon-circle`, `.icon-text`) for better contrast and vertical layout on the video surface.  
- Replaced the interval cleanup with a `watchEffect` that creates the `setInterval` and clears it via `onCleanup`, and introduced `refreshTimerId` and `redirectPending` with a `watch(redirectPending)` that performs `router.replace('/live')` after clearing timers and `nextTick`.  
- Added `totalViews` and `isVodUnavailable` state, updated `loadVodDetail` to set view counts and to set `redirectPending`/show a single alert when the VOD is missing, and short-circuited `submitReport` when `hasReported` is already true.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, during which Vite reported an unresolved dependency `openvidu-browser` in an unrelated admin file but the server still served pages.  
- Ran a Playwright script that navigated to `/vod/1` and successfully captured a screenshot saved as `artifacts/vod-actions-inside.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964477bc1208324b0e0d2e7f923cdb2)