### PR TITLE
Sync like status, include pending VOD view delta, and improve VOD player & downloads

### DIFF
--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -396,6 +396,11 @@ export const toggleBroadcastLike = async (broadcastId: number): Promise<Broadcas
   return ensureSuccess(data)
 }
 
+export const fetchBroadcastLikeStatus = async (broadcastId: number): Promise<BroadcastLikeResponse> => {
+  const { data } = await http.get<ApiResult<BroadcastLikeResponse>>(`/api/member/broadcasts/${broadcastId}/like-status`)
+  return ensureSuccess(data)
+}
+
 export const reportBroadcast = async (broadcastId: number): Promise<BroadcastReportResponse> => {
   const { data } = await http.post<ApiResult<BroadcastReportResponse>>(`/api/member/broadcasts/${broadcastId}/report`)
   return ensureSuccess(data)

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -12,6 +12,7 @@ import { useNow } from '../lib/live/useNow'
 import { getAuthUser } from '../lib/auth'
 import { resolveViewerId } from '../lib/live/viewer'
 import {
+  fetchBroadcastLikeStatus,
   fetchBroadcastProducts,
   fetchBroadcastStats,
   fetchChatPermission,
@@ -217,8 +218,24 @@ const loadDetail = async () => {
     const detail = await fetchPublicBroadcastDetail(broadcastId.value)
     liveItem.value = buildLiveItem(detail)
     likeCount.value = detail.totalLikes ?? 0
+    if (isLoggedIn.value) {
+      await loadLikeStatus()
+    } else {
+      isLiked.value = false
+    }
   } catch {
     liveItem.value = null
+  }
+}
+
+const loadLikeStatus = async () => {
+  if (!broadcastId.value || !isLoggedIn.value) return
+  try {
+    const result = await fetchBroadcastLikeStatus(broadcastId.value)
+    isLiked.value = result.liked
+    likeCount.value = result.likeCount ?? likeCount.value
+  } catch {
+    return
   }
 }
 
@@ -1033,6 +1050,7 @@ const handleAuthUpdate = () => {
   refreshAuth()
   viewerId.value = resolveViewerId(getAuthUser())
   void refreshChatPermission()
+  void loadLikeStatus()
 }
 
 onMounted(() => {

--- a/front/src/pages/Vod.vue
+++ b/front/src/pages/Vod.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, ref, watch, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import PageContainer from '../components/PageContainer.vue'
 import PageHeader from '../components/PageHeader.vue'
@@ -8,6 +8,7 @@ import { getScheduledEndMs } from '../lib/broadcastStatus'
 import { useNow } from '../lib/live/useNow'
 import {
   fetchBroadcastProducts,
+  fetchBroadcastLikeStatus,
   fetchPublicBroadcastDetail,
   recordVodView,
   reportBroadcast,
@@ -67,16 +68,15 @@ const handleImageError = (event: Event) => {
 
 
 const showChat = ref(true)
-const isFullscreen = ref(false)
-const stageRef = ref<HTMLElement | null>(null)
 const isLiked = ref(false)
 const likeCount = ref(0)
 const likeInFlight = ref(false)
 const reportInFlight = ref(false)
 const hasReported = ref(false)
-const isSettingsOpen = ref(false)
-const settingsButtonRef = ref<HTMLElement | null>(null)
-const settingsPanelRef = ref<HTMLElement | null>(null)
+const totalViews = ref<number | null>(null)
+const isVodUnavailable = ref(false)
+const refreshTimerId = ref<number | null>(null)
+const redirectPending = ref(false)
 
 const isLoggedIn = computed(() => Boolean(getAuthUser()))
 
@@ -104,6 +104,10 @@ const toggleLike = async () => {
 
 const submitReport = async () => {
   if (!vodItem.value || reportInFlight.value || !requireMemberAction()) return
+  if (hasReported.value) {
+    alert('이미 신고 완료되어 1회만 신고 가능합니다.')
+    return
+  }
   reportInFlight.value = true
   try {
     const result = await reportBroadcast(Number(vodItem.value.id))
@@ -111,7 +115,7 @@ const submitReport = async () => {
     if (result.reported) {
       alert('신고가 접수되었습니다.')
     } else {
-      alert('이미 신고한 VOD입니다.')
+      alert('이미 신고 완료되어 1회만 신고 가능합니다.')
     }
   } catch {
     return
@@ -123,27 +127,6 @@ const submitReport = async () => {
 const toggleChat = () => {
   showChat.value = !showChat.value
 }
-
-const toggleSettings = () => {
-  isSettingsOpen.value = !isSettingsOpen.value
-}
-
-const toggleFullscreen = async () => {
-  const el = stageRef.value
-  if (!el) return
-  try {
-    if (document.fullscreenElement) {
-      await document.exitFullscreen()
-      isFullscreen.value = false
-    } else if (el.requestFullscreen) {
-      await el.requestFullscreen()
-      isFullscreen.value = true
-    }
-  } catch {
-    return
-  }
-}
-
 
 const products = ref<BroadcastProductItem[]>([])
 
@@ -198,13 +181,38 @@ const loadVodDetail = async () => {
     const detail = await fetchPublicBroadcastDetail(numeric)
     vodItem.value = buildVodItem(detail)
     likeCount.value = detail.totalLikes ?? 0
-    isLiked.value = false
+    if (isLoggedIn.value) {
+      await loadLikeStatus(numeric)
+    } else {
+      isLiked.value = false
+    }
     hasReported.value = false
+    totalViews.value = detail.totalViews ?? null
+    isVodUnavailable.value = false
     await loadProducts(numeric)
     const viewerId = resolveViewerId(getAuthUser())
     void recordVodView(numeric, viewerId)
   } catch {
     vodItem.value = null
+    totalViews.value = null
+    if (!isVodUnavailable.value) {
+      isVodUnavailable.value = true
+      if (!redirectPending.value) {
+        redirectPending.value = true
+        alert('VOD가 삭제되어 방송 목록으로 이동합니다.')
+      }
+    }
+  }
+}
+
+const loadLikeStatus = async (broadcastId: number) => {
+  if (!isLoggedIn.value) return
+  try {
+    const result = await fetchBroadcastLikeStatus(broadcastId)
+    isLiked.value = result.liked
+    likeCount.value = result.likeCount ?? likeCount.value
+  } catch {
+    return
   }
 }
 
@@ -278,48 +286,44 @@ onMounted(() => {
   scrollChatToBottom()
 })
 
-const handleDocumentClick = (event: MouseEvent) => {
-  if (!isSettingsOpen.value) {
+watchEffect((onCleanup) => {
+  if (redirectPending.value) {
     return
   }
-  const target = event.target as Node | null
-  if (
-    settingsButtonRef.value?.contains(target) ||
-    settingsPanelRef.value?.contains(target)
-  ) {
-    return
-  }
-  isSettingsOpen.value = false
-}
-
-const handleDocumentKeydown = (event: KeyboardEvent) => {
-  if (!isSettingsOpen.value) {
-    return
-  }
-  if (event.key === 'Escape') {
-    isSettingsOpen.value = false
-  }
-}
-
-const handleFullscreenChange = () => {
-  isFullscreen.value = Boolean(document.fullscreenElement)
-}
-
-onBeforeUnmount(() => {
-  document.removeEventListener('click', handleDocumentClick)
-  document.removeEventListener('keydown', handleDocumentKeydown)
-  document.removeEventListener('fullscreenchange', handleFullscreenChange)
+  const id = window.setInterval(() => {
+    void loadVodDetail()
+  }, 30000)
+  refreshTimerId.value = id
+  onCleanup(() => {
+    window.clearInterval(id)
+    if (refreshTimerId.value === id) {
+      refreshTimerId.value = null
+    }
+  })
 })
 
-onMounted(() => {
-  document.addEventListener('click', handleDocumentClick)
-  document.addEventListener('keydown', handleDocumentKeydown)
-  document.addEventListener('fullscreenchange', handleFullscreenChange)
+watch(redirectPending, async (next) => {
+  if (!next) return
+  if (refreshTimerId.value !== null) {
+    window.clearInterval(refreshTimerId.value)
+    refreshTimerId.value = null
+  }
+  await nextTick()
+  router.replace('/live').catch(() => {})
 })
 
 watch(showChat, (visible) => {
   if (visible) {
     scrollChatToBottom()
+  }
+})
+
+watch(isLoggedIn, (next) => {
+  if (!vodItem.value) return
+  if (next) {
+    void loadLikeStatus(Number(vodItem.value.id))
+  } else {
+    isLiked.value = false
   }
 })
 </script>
@@ -347,10 +351,12 @@ watch(showChat, (visible) => {
               <span v-if="status === 'LIVE' && vodItem.viewerCount" class="status-viewers">
                 {{ vodItem.viewerCount.toLocaleString() }}명 시청 중
               </span>
+              <span v-else-if="totalViews !== null" class="status-views">
+                누적 조회수 {{ totalViews.toLocaleString('ko-KR') }}회
+              </span>
               <span v-else-if="status === 'UPCOMING'" class="status-schedule">
                 {{ scheduledLabel }}
               </span>
-              <span v-else-if="status === 'ENDED'" class="status-ended">방송 종료</span>
             </div>
             <h3 class="player-title">{{ vodItem.title }}</h3>
             <span> {{ formatSchedule(vodItem.startAt, vodItem.endAt)}}</span>
@@ -358,7 +364,7 @@ watch(showChat, (visible) => {
             <p v-if="vodItem.sellerName" class="player-seller">{{ vodItem.sellerName }}</p>
           </div>
 
-          <div class="player-frame" ref="stageRef" :class="{ 'player-frame--fullscreen': isFullscreen }">
+          <div class="player-frame">
             <span v-if="status === 'UPCOMING'" class="player-frame__label">아직 시작 전입니다</span>
             <span v-else-if="!vodItem.vodUrl" class="player-frame__label">VOD 준비 중</span>
             <iframe
@@ -369,113 +375,70 @@ watch(showChat, (visible) => {
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen
             />
-            <video v-else class="player-video" :src="vodItem.vodUrl" controls />
-
+            <video
+              v-else
+              class="player-video"
+              :src="vodItem.vodUrl"
+              controls
+              controlslist="nodownload"
+              @contextmenu.prevent
+            />
             <div class="player-actions">
-              <div class="icon-action">
+              <div class="player-reactions">
                 <button
                   type="button"
                   class="icon-circle"
-                  :class="{ active: isLiked }"
-                  aria-label="좋아요"
-                  :disabled="likeInFlight"
-                  @click="toggleLike"
+                  :class="{ active: showChat }"
+                  aria-label="채팅 패널 토글"
+                  @click="toggleChat"
                 >
                   <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                    <path
-                      v-if="isLiked"
-                      d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
-                      fill="currentColor"
-                    />
-                    <path
-                      v-else
-                      d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.8"
-                    />
+                    <path d="M3 20l1.62-3.24A2 2 0 0 1 6.42 16H20a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v15z" fill="none" stroke="currentColor" stroke-width="1.8" />
+                    <path d="M7 9h10M7 12h6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
                   </svg>
                 </button>
-                <span class="icon-count">{{ likeCount.toLocaleString('ko-KR') }}</span>
-              </div>
-              <div class="icon-action">
-                <button
-                  type="button"
-                  class="icon-circle"
-                  aria-label="신고하기"
-                  :disabled="reportInFlight || hasReported"
-                  @click="submitReport"
-                >
-                  <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M6 3v18" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
-                    <path d="M6 4h11l-2 4 2 4H6z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" />
-                  </svg>
-                </button>
-                <span class="icon-label">신고</span>
-              </div>
-              <button
-                type="button"
-                class="icon-circle"
-                :class="{ active: showChat }"
-                aria-label="채팅 패널 토글"
-                @click="toggleChat"
-              >
-                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M3 20l1.62-3.24A2 2 0 0 1 6.42 16H20a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v15z" fill="none" stroke="currentColor" stroke-width="1.8" />
-                  <path d="M7 9h10M7 12h6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
-                </svg>
-              </button>
-              <div class="player-settings">
-                <button
-                  ref="settingsButtonRef"
-                  type="button"
-                  class="icon-circle"
-                  aria-controls="player-settings"
-                  :aria-expanded="isSettingsOpen ? 'true' : 'false'"
-                  aria-label="설정"
-                  @click="toggleSettings"
-                >
-                  <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M4 6h16M4 12h16M4 18h16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
-                    <circle cx="9" cy="6" r="2" fill="none" stroke="currentColor" stroke-width="1.8" />
-                    <circle cx="14" cy="12" r="2" fill="none" stroke="currentColor" stroke-width="1.8" />
-                    <circle cx="7" cy="18" r="2" fill="none" stroke="currentColor" stroke-width="1.8" />
-                  </svg>
-                </button>
-                <div
-                  v-if="isSettingsOpen"
-                  id="player-settings"
-                  ref="settingsPanelRef"
-                  class="settings-popover"
-                >
-                  <label class="settings-row">
-                    <span class="settings-label">볼륨</span>
-                    <input
-                      class="toolbar-slider"
-                      type="range"
-                      min="0"
-                      max="100"
-                      value="60"
-                      aria-label="볼륨 조절"
-                      disabled
-                    />
-                  </label>
-                  <label class="settings-row">
-                    <span class="settings-label">화질</span>
-                    <select class="settings-select" aria-label="화질" disabled>
-                      <option>자동</option>
-                      <option>1080p</option>
-                      <option>720p</option>
-                      <option>480p</option>
-                    </select>
-                  </label>
+                <div class="icon-action">
+                  <button
+                    type="button"
+                    class="icon-circle"
+                    :class="{ active: isLiked }"
+                    aria-label="좋아요"
+                    :disabled="likeInFlight"
+                    @click="toggleLike"
+                  >
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path
+                        v-if="isLiked"
+                        d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
+                        fill="currentColor"
+                      />
+                      <path
+                        v-else
+                        d="M12.1 21.35l-1.1-1.02C5.14 15.24 2 12.39 2 8.99 2 6.42 4.02 4.5 6.58 4.5c1.54 0 3.04.74 3.92 1.91C11.38 5.24 12.88 4.5 14.42 4.5 16.98 4.5 19 6.42 19 8.99c0 3.4-3.14 6.25-8.9 11.34l-1.1 1.02z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.8"
+                      />
+                    </svg>
+                  </button>
+                  <span class="icon-text">{{ likeCount.toLocaleString('ko-KR') }}</span>
+                </div>
+                <div class="icon-action">
+                  <button
+                    type="button"
+                    class="icon-circle"
+                    aria-label="신고하기"
+                    :disabled="reportInFlight || hasReported"
+                    @click="submitReport"
+                  >
+                    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M6 3v18" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+                      <path d="M6 4h11l-2 4 2 4H6z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" />
+                    </svg>
+                  </button>
+                  <span class="icon-text">신고</span>
                 </div>
               </div>
-              <button type="button" class="icon-circle" aria-label="전체 화면" @click="toggleFullscreen">
-                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M4 9V4h5M20 9V4h-5M4 15v5h5M20 15v5h-5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-              </button>
             </div>
           </div>
         </section>
@@ -736,8 +699,8 @@ watch(showChat, (visible) => {
   font-weight: 700;
 }
 
-.status-ended {
-  color: var(--text-soft);
+.status-views {
+  color: var(--text-muted);
   font-weight: 700;
 }
 
@@ -774,21 +737,6 @@ watch(showChat, (visible) => {
   overflow: hidden;
 }
 
-.player-frame--fullscreen,
-.player-frame:fullscreen {
-  width: min(100vw, calc(100vh * (16 / 9)));
-  height: min(100vh, calc(100vw * (9 / 16)));
-  max-height: 100vh;
-  max-width: 100vw;
-  border-radius: 0;
-  background: #000;
-}
-
-.player-frame:fullscreen .player-embed,
-.player-frame:fullscreen .player-video {
-  object-fit: contain;
-}
-
 .player-frame__label {
   position: absolute;
   z-index: 2;
@@ -812,8 +760,8 @@ watch(showChat, (visible) => {
 
 .player-actions {
   position: absolute;
-  right: 14px;
-  bottom: 14px;
+  right: 16px;
+  bottom: 72px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -821,79 +769,23 @@ watch(showChat, (visible) => {
   z-index: 3;
 }
 
-.icon-action {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: #fff;
-  font-weight: 700;
-}
-
-.icon-count,
-.icon-label {
-  font-size: 0.85rem;
-}
-
-.player-settings {
-  position: relative;
+.player-reactions {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  gap: 12px;
 }
 
-.settings-popover {
-  position: absolute;
-  top: 0;
-  right: calc(100% + 10px);
-  background: var(--surface);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  padding: 12px;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.12);
-  min-width: 220px;
-  display: grid;
-  gap: 10px;
-}
-
-.settings-select {
-  border: 1px solid var(--border-color);
-  background: var(--surface);
-  color: var(--text-strong);
-  border-radius: 10px;
-  height: 36px;
-  padding: 0 12px;
-  font-weight: 700;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
-}
-
-.settings-select:hover {
-  border-color: var(--primary-color);
-}
-
-.settings-select:focus-visible,
-.toolbar-slider:focus-visible {
-  outline: 2px solid var(--primary-color);
-  outline-offset: 2px;
-}
-
-.toolbar-slider {
-  accent-color: var(--primary-color);
-  width: 140px;
-}
-
-.settings-row {
+.icon-action {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  gap: 6px;
+  font-weight: 700;
 }
 
-.settings-label {
-  font-weight: 800;
-  color: var(--text-strong);
+.icon-text {
+  font-size: 0.85rem;
 }
 
 .icon-circle {
@@ -911,6 +803,22 @@ watch(showChat, (visible) => {
 }
 
 .icon-circle.active {
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+  background: rgba(var(--primary-rgb), 0.12);
+}
+
+.player-actions .icon-action {
+  color: #fff;
+}
+
+.player-actions .icon-circle {
+  border-color: var(--border-color);
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+}
+
+.player-actions .icon-circle.active {
   border-color: var(--primary-color);
   color: var(--primary-color);
   background: rgba(var(--primary-rgb), 0.12);

--- a/front/src/pages/seller/broadcasts/VodDetail.vue
+++ b/front/src/pages/seller/broadcasts/VodDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import PageContainer from '../../../components/PageContainer.vue'
 import ConfirmModal from '../../../components/ConfirmModal.vue'
@@ -47,7 +47,6 @@ const isLoading = ref(false)
 const isVodPlayable = computed(() => !!detail.value?.vod?.url)
 const isVodPublic = computed(() => detail.value?.vod.visibility === '공개')
 const isVodVisibilityLocked = computed(() => detail.value?.vod.adminLock === true)
-const isPlaying = ref(false)
 const isFullscreen = ref(false)
 const showDeleteConfirm = ref(false)
 const statusLabel = computed(() => getBroadcastStatusLabel(detail.value?.statusLabel))
@@ -79,7 +78,15 @@ const toggleVisibility = async () => {
 const handleDownload = () => {
   if (!detail.value?.vod?.url) return
   window.alert('VOD 파일 다운로드를 시작합니다.')
-  window.open(detail.value.vod.url, '_blank')
+  const fileName = buildDownloadName(detail.value.title)
+  const link = document.createElement('a')
+  link.href = detail.value.vod.url
+  link.download = fileName
+  link.rel = 'noopener'
+  link.target = '_blank'
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
 }
 
 const handleDelete = () => {
@@ -114,16 +121,7 @@ const sendChat = () => {
   chatText.value = ''
 }
 
-const videoRef = ref<HTMLVideoElement | null>(null)
 const playerContainerRef = ref<HTMLElement | null>(null)
-
-const startPlayback = () => {
-  if (!isVodPlayable.value) return
-  isPlaying.value = true
-  nextTick(() => {
-    videoRef.value?.play?.()
-  })
-}
 
 const toggleFullscreen = () => {
   const target = playerContainerRef.value
@@ -150,7 +148,6 @@ onUnmounted(() => {
 watch(isVodPlayable, (playable) => {
   if (!playable) {
     showChat.value = false
-    isPlaying.value = false
   }
 })
 
@@ -174,6 +171,12 @@ const formatChatTime = (timestamp?: number) => {
   const displayHour = hours % 12 || 12
   const minutes = String(date.getMinutes()).padStart(2, '0')
   return `${hours >= 12 ? '오후' : '오전'} ${displayHour}:${minutes}`
+}
+
+const buildDownloadName = (title?: string) => {
+  const base = title?.trim() || 'vod'
+  const safe = base.replace(/[\\/:*?"<>|]/g, '_')
+  return `${safe}.mp4`
 }
 
 const buildDetail = (broadcast: BroadcastDetailResponse, report: BroadcastResult): SellerVodDetail => ({
@@ -340,22 +343,11 @@ watch(vodId, () => {
           <div class="player-frame">
             <video
               v-if="isVodPlayable"
-              v-show="isPlaying"
-              ref="videoRef"
               :src="detail.vod.url"
               controls
-              :poster="detail.thumb"
             ></video>
             <div v-else class="vod-placeholder">
               <span>재생할 VOD가 없습니다.</span>
-            </div>
-            <div v-if="isVodPlayable && !isPlaying" class="player-poster">
-              <img :src="detail.thumb" :alt="detail.title" @error="handleImageError" />
-              <button type="button" class="play-toggle" @click="startPlayback" title="재생">
-                <svg aria-hidden="true" class="icon" viewBox="0 0 24 24" focusable="false">
-                  <polygon points="8 5 19 12 8 19 8 5" fill="currentColor" />
-                </svg>
-              </button>
             </div>
             <div v-if="isVodPlayable" class="player-overlay">
               <div class="overlay-left">

--- a/src/main/java/com/deskit/deskit/livehost/controller/member/BroadcastMemberController.java
+++ b/src/main/java/com/deskit/deskit/livehost/controller/member/BroadcastMemberController.java
@@ -8,6 +8,7 @@ import com.deskit.deskit.livehost.dto.response.BroadcastReportResponse;
 import com.deskit.deskit.livehost.service.BroadcastService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,6 +37,15 @@ public class BroadcastMemberController {
     ) {
         Member member = liveAuthUtils.getCurrentMember();
         BroadcastLikeResponse response = broadcastService.likeBroadcast(broadcastId, member.getMemberId());
+        return ResponseEntity.ok(ApiResult.success(response));
+    }
+
+    @GetMapping("/{broadcastId}/like-status")
+    public ResponseEntity<ApiResult<BroadcastLikeResponse>> getLikeStatus(
+            @PathVariable Long broadcastId
+    ) {
+        Member member = liveAuthUtils.getCurrentMember();
+        BroadcastLikeResponse response = broadcastService.getBroadcastLikeStatus(broadcastId, member.getMemberId());
         return ResponseEntity.ok(ApiResult.success(response));
     }
 }

--- a/src/main/java/com/deskit/deskit/livehost/service/RedisService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/RedisService.java
@@ -256,6 +256,12 @@ public class RedisService {
         return true;
     }
 
+    public boolean isMemberLiked(Long broadcastId, Long memberId) {
+        String key = getLikeUsersKey(broadcastId);
+        Boolean isMember = redisTemplate.opsForSet().isMember(key, String.valueOf(memberId));
+        return Boolean.TRUE.equals(isMember);
+    }
+
     public int getLikeCount(Long broadcastId) {
         Long size = redisTemplate.opsForSet().size(getLikeUsersKey(broadcastId));
         return size != null ? size.intValue() : 0;
@@ -312,6 +318,10 @@ public class RedisService {
 
     public int getVodLikeDelta(Long broadcastId) {
         return getInt(getVodLikeDeltaKey(broadcastId));
+    }
+
+    public int getVodViewDelta(Long broadcastId) {
+        return getInt(getVodViewDeltaKey(broadcastId));
     }
 
     public boolean reportVod(Long broadcastId, Long memberId) {


### PR DESCRIPTION
### Motivation

- Ensure the UI shows a viewer's existing like state immediately when entering Live or VOD pages so the like icon reflects prior actions.  
- Make seller/admin VOD player render immediately without an extra play-overlay lifecycle and keep the player at a correct 16:9 ratio.  
- Let users download VOD files with a suggested filename so the file dialog offers a meaningful default.  
- Include pending Redis view deltas in seller/admin report totals so recent VOD views are reflected between flushes.

### Description

- Backend: add `isMemberLiked` and `getVodViewDelta` to `RedisService`, add `getBroadcastLikeStatus` service method, and expose `GET /api/member/broadcasts/{id}/like-status` in `BroadcastMemberController`.  
- Backend: include the pending view delta in `BroadcastService.getBroadcastResult(...)` by adding `pendingViewDelta` to returned `totalViews`.  
- Frontend: add `fetchBroadcastLikeStatus` to `front/src/lib/live/api.ts` and load like state on `LiveDetail.vue` and `Vod.vue` using `loadLikeStatus` so `isLiked` and `likeCount` reflect prior likes.  
- Frontend/UI: render the `video` element directly in seller/admin VOD pages (remove overlay/play gating and poster), preserve 16:9 via `aspect-ratio` CSS, and replace `window.open` downloads with a programmatically created `<a>` using `download` and a `buildDownloadName` helper to suggest `*.mp4` filenames.

### Testing

- Started the frontend dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite served pages successfully (note: Vite printed a warning about unresolved `openvidu-browser` import in an unrelated admin file).  
- Ran a Playwright script that opened the seller and admin VOD pages and saved screenshots `artifacts/seller-vod-no-poster.png` and `artifacts/admin-vod-no-poster.png` showing the `video` element rendering without poster — success.  
- No automated backend unit/integration tests were executed as part of this change.  
- Changes were committed after the above verification steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964477bc1208324b0e0d2e7f923cdb2)