### PR TITLE
Update LiveCard badge layout and refresh VOD viewer counts

### DIFF
--- a/front/src/components/LiveCard.vue
+++ b/front/src/components/LiveCard.vue
@@ -46,6 +46,15 @@ const status = computed(() => {
   if (lifecycleStatus.value === 'VOD') return 'VOD'
   return 'ENDED'
 })
+const statusBadge = computed(() => {
+  if (status.value === 'LIVE') return { label: 'LIVE', class: 'badge-live' }
+  if (status.value === 'READY') return { label: 'READY', class: 'badge-ready' }
+  if (status.value === 'UPCOMING') return { label: '예약', class: 'badge-upcoming' }
+  if (status.value === 'STOPPED') return { label: '송출 중지', class: 'badge-stopped' }
+  if (status.value === 'ENDED') return { label: 'ENDED', class: 'badge-ended' }
+  if (status.value === 'VOD') return { label: 'VOD', class: 'badge-vod' }
+  return null
+})
 const buttonLabel = computed(() => {
   if (status.value === 'LIVE' || status.value === 'READY') {
     return '입장하기'
@@ -88,6 +97,27 @@ const countdownLabel = computed(() => {
   return ''
 })
 
+const formatDuration = (diffMs: number) => {
+  if (diffMs <= 0) return ''
+  const hours = Math.floor(diffMs / (1000 * 60 * 60))
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60))
+  const seconds = Math.floor((diffMs % (1000 * 60)) / 1000)
+
+  const pad = (value: number) => value.toString().padStart(2, '0')
+
+  if (hours > 0) {
+    return `${pad(hours)}:${pad(minutes)}`
+  }
+  return `${pad(minutes)}:${pad(seconds)}`
+}
+
+const totalDurationLabel = computed(() => {
+  const start = parseLiveDate(props.item.startAt)
+  const end = parseLiveDate(props.item.endAt)
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return ''
+  return formatDuration(end.getTime() - start.getTime())
+})
+
 const timeLabel = computed(() => {
   if (status.value === 'LIVE') {
     return `방송 시간 ${elapsed.value}`
@@ -102,21 +132,26 @@ const timeLabel = computed(() => {
     return '송출 중지'
   }
   if (status.value === 'VOD') {
-    return 'VOD'
+    return totalDurationLabel.value ? `총 재생 ${totalDurationLabel.value}` : 'VOD'
   }
-  return '방송 종료'
+  return totalDurationLabel.value ? `경과 ${totalDurationLabel.value}` : '방송 종료'
 })
 
 const viewerLabel = computed(() => {
   if (props.item.viewerCount == null) return ''
-  if (status.value === 'LIVE' || status.value === 'READY') {
+  if (status.value === 'READY') {
+    return `시청자 ${props.item.viewerCount.toLocaleString()}명`
+  }
+  return ''
+})
+
+const topViewerLabel = computed(() => {
+  if (props.item.viewerCount == null) return ''
+  if (status.value === 'LIVE' || status.value === 'ENDED') {
     return `시청자 ${props.item.viewerCount.toLocaleString()}명`
   }
   if (status.value === 'VOD') {
     return `누적 시청자 ${props.item.viewerCount.toLocaleString()}명`
-  }
-  if (status.value === 'ENDED') {
-    return `시청자 ${props.item.viewerCount.toLocaleString()}명`
   }
   return ''
 })
@@ -149,22 +184,17 @@ const handleWatchNow = () => {
     <div class="media">
       <img :src="props.item.thumbnailUrl" :alt="props.item.title" />
       <div class="top-badges">
-        <span v-if="status === 'LIVE'" class="badge badge-live">LIVE</span>
-        <span v-else-if="status === 'READY'" class="badge badge-ready">READY</span>
-        <span v-else-if="status === 'UPCOMING'" class="badge badge-upcoming">예약</span>
-        <span v-else-if="status === 'STOPPED'" class="badge badge-stopped">송출 중지</span>
-        <span
-          v-if="status === 'LIVE' && props.item.viewerCount != null"
-          class="badge badge-viewers"
-        >
-          시청자 {{ props.item.viewerCount.toLocaleString() }}명
+        <span v-if="statusBadge" class="badge" :class="statusBadge.class">
+          {{ statusBadge.label }}
+        </span>
+        <span v-if="topViewerLabel" class="badge badge-viewers">
+          {{ topViewerLabel }}
         </span>
       </div>
     </div>
     <div class="content">
       <div class="eyebrow-row">
         <p v-if="status === 'LIVE'" class="eyebrow">현재 방송 중</p>
-        <span v-if="status === 'LIVE'" class="eyebrow-time">{{ elapsed }}</span>
       </div>
       <h3>{{ props.item.title }}</h3>
       <p class="desc">{{ props.item.description }}</p>
@@ -256,6 +286,14 @@ const handleWatchNow = () => {
 
 .badge-stopped {
   background: rgba(239, 68, 68, 0.9);
+}
+
+.badge-ended {
+  background: rgba(100, 116, 139, 0.9);
+}
+
+.badge-vod {
+  background: rgba(14, 116, 144, 0.9);
 }
 
 .top-badges {

--- a/front/src/pages/Home.vue
+++ b/front/src/pages/Home.vue
@@ -92,7 +92,7 @@ const loadLiveItems = async () => {
 
 const isStatsTarget = (item: LiveItem) => {
   const status = normalizeBroadcastStatus(item.status)
-  if (status === 'ON_AIR' || status === 'READY') return true
+  if (status === 'ON_AIR' || status === 'READY' || status === 'VOD') return true
   const startAtMs = parseLiveDate(item.startAt).getTime()
   if (Number.isNaN(startAtMs)) return false
   const endAtMs = parseLiveDate(item.endAt).getTime()


### PR DESCRIPTION
### Motivation
- Move status and viewer badges to the top of the broadcast card and remove duplicate viewer badge shown in the info area for live broadcasts.
- Display elapsed/total playback time as an info chip instead of duplicating it in the eyebrow/top area.
- For ENDED and VOD states, place status/viewer badges at the top and show elapsed or total playback time in the info chip area.
- Ensure VOD viewer counts are refreshed in the same periodic update used for live broadcasts so cumulative viewers stay up to date.

### Description
- Added `statusBadge`, `topViewerLabel`, `totalDurationLabel`, and `formatDuration` computed helpers and updated the template to render status/viewer badges in the `.top-badges` area (moved from bottom info row) in `front/src/components/LiveCard.vue`.
- Replaced the eyebrow-time display with info chips showing `방송 시간` / `총 재생` / `경과` as appropriate, and added `.badge-ended` and `.badge-vod` CSS classes for the new badges.
- Included `VOD` in the `isStatsTarget` check in `front/src/pages/Home.vue` so `updateLiveViewerCounts` also requests stats for VOD items.
- Kept button navigation logic unchanged but adjusted which labels are shown for various lifecycle states.

### Testing
- Ran `npm --prefix front install` locally and the install completed without errors.
- Started the dev server with `npm --prefix front run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready (server started).
- Executed a Playwright script which loaded the home page and produced a screenshot (`artifacts/live-home.png`) to verify the UI changes were rendered successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69645ece0b788324b068f07113a70ef9)