### PR TITLE
Fix admin live player aspect handling to avoid cropped overflow

### DIFF
--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -1146,7 +1146,7 @@ watch(streamToken, () => {
   aspect-ratio: 16 / 9;
   background: #0b0f1a;
   border-radius: 18px;
-  overflow: auto;
+  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1210,7 +1210,7 @@ watch(streamToken, () => {
 .player-placeholder__image {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .player-placeholder__message {


### PR DESCRIPTION
### Motivation
- Prevent the admin broadcast monitor from showing scrollbars and cropping when the stream aspect ratio differs from the container. 
- Ensure the waiting/placeholder image is fully visible without being cropped by the player frame. 
- Improve visual consistency for the admin live detail view so content scales instead of being cut off. 

### Description
- Changed `.player-frame` `overflow` from `auto` to `hidden` to remove scrollbars and clipped sliding behavior. 
- Updated `.player-placeholder__image` `object-fit` from `cover` to `contain` so waiting images preserve their aspect ratio and remain fully visible. 
- The changes are confined to `front/src/pages/admin/live/LiveDetail.vue` and are CSS-only adjustments to the player container and placeholder. 

### Testing
- Started the frontend dev server with `npm --prefix front run dev -- --host 0.0.0.0 --port 4173` and the server launched successfully. 
- Ran an automated Playwright script that loaded `/admin/live/now/1` and produced a screenshot to verify the player rendering, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69646dcc01208324a8f849636a566c29)