### PR TITLE
Constrain admin live player to 16:9 frame

### DIFF
--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -1138,15 +1138,14 @@ watch(streamToken, () => {
 
 .player-frame {
   position: relative;
-  width: 100%;
+  width: min(100%, calc((100vh - 120px) * (16 / 9)));
   height: auto;
-  max-width: calc((100vh - 120px) * (16 / 9));
   max-height: calc(100vh - 120px);
   min-height: clamp(360px, auto, 760px);
   aspect-ratio: 16 / 9;
   background: #0b0f1a;
   border-radius: 18px;
-  overflow: auto;
+  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1210,7 +1209,7 @@ watch(streamToken, () => {
 .player-placeholder__image {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .player-placeholder__message {


### PR DESCRIPTION
### Motivation
- Ensure the admin broadcast monitor stays at a consistent 16:9 frame so streams don't crop, slide, or produce scrollbars when their aspect ratio differs from the container.
- Keep waiting/placeholder imagery fully visible and not cropped by the player frame.
- Improve visual consistency for the admin live detail view across viewport sizes.

### Description
- Constrain `.player-frame` width to `min(100%, calc((100vh - 120px) * (16 / 9)))` so the frame preserves a 16:9 footprint relative to the viewport.
- Remove the previous `max-width` and rely on `aspect-ratio: 16 / 9` and `max-height` to control sizing and fit.
- Ensure the container no longer shows scrollbars by setting `overflow: hidden` on `.player-frame`.
- Use `object-fit: contain` for both the video and `.player-placeholder__image` so media preserves its aspect ratio and is not cropped.

### Testing
- Started the frontend dev server with `npm --prefix front run dev -- --host 0.0.0.0 --port 4173` and the server launched successfully.
- Ran a Playwright script that loaded `/admin/live/now/1` and produced a screenshot to verify the 16:9 player rendering, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69646dcc01208324a8f849636a566c29)