### PR TITLE
Prevent processVod from changing broadcast status

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -895,10 +895,6 @@ public class BroadcastService {
 
         redisService.persistVodReactionKeys(broadcastId);
         redisService.deleteBroadcastRuntimeKeys(broadcastId);
-        if (isStopped || broadcast.getStatus() == BroadcastStatus.ENDED) {
-            validateTransition(broadcast.getStatus(), BroadcastStatus.VOD);
-            broadcast.changeStatus(BroadcastStatus.VOD);
-        }
         redisService.clearRecordingRetry(broadcastId);
     }
 


### PR DESCRIPTION
### Motivation
- Prevent `processVod` from converting broadcasts to `VOD` so status transitions follow the scheduled end flow.
- Ensure `ENDED` broadcasts only transition according to the scheduled end handling and not immediately during VOD processing.
- Keep `STOPPED` broadcasts in their state unless an administrator explicitly makes the VOD public.
- Avoid allowing premature status changes before the scheduled broadcast end time.

### Description
- Removed the conditional block in `BroadcastService#processVod` that called `validateTransition(...)` and `broadcast.changeStatus(BroadcastStatus.VOD)` for `isStopped` or `BroadcastStatus.ENDED` cases.
- Left VOD persistence and cleanup logic intact, including `redisService.clearRecordingRetry(broadcastId)` and VOD upload/download flows.
- Change is located in `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java` and only removes the automatic status transition from the VOD processing path.
- No new status-transition logic was introduced; status changes are delegated to scheduled end or admin actions.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69646ffe271483249c4b3861ff9c1f16)