### PR TITLE
Reduce READY transition window to 3 minutes

### DIFF
--- a/front/src/lib/broadcastStatus.ts
+++ b/front/src/lib/broadcastStatus.ts
@@ -1,6 +1,6 @@
 export type BroadcastStatus = 'READY' | 'ON_AIR' | 'ENDED' | 'STOPPED' | 'RESERVED' | 'CANCELED' | 'VOD'
 
-export const READY_WINDOW_MS = 10 * 60 * 1000
+export const READY_WINDOW_MS = 3 * 60 * 1000
 export const BROADCAST_DURATION_MS = 30 * 60 * 1000
 
 export const normalizeBroadcastStatus = (status?: string | null): BroadcastStatus => {


### PR DESCRIPTION
### Motivation
- RESERVED broadcasts should transition to READY closer to the scheduled time (3 minutes before) instead of 10 minutes before.
- The change targets the lifecycle computation used by the UI in `computeLifecycleStatus` so on-page status badges and countdowns reflect the new timing.

### Description
- Update `READY_WINDOW_MS` from `10 * 60 * 1000` to `3 * 60 * 1000` in `front/src/lib/broadcastStatus.ts`.
- This is a single front-end change that alters the threshold used to classify `RESERVED` -> `READY`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69648444d5708324b7db7abd9f30f0db)