### PR TITLE
Adjust ready transition window and preserve STOPPED status

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/repository/BroadcastRepositoryImpl.java
+++ b/src/main/java/com/deskit/deskit/livehost/repository/BroadcastRepositoryImpl.java
@@ -139,7 +139,7 @@ public class BroadcastRepositoryImpl implements BroadcastRepositoryCustom {
     @Override
     public List<Long> findBroadcastIdsForReadyTransition(LocalDateTime now) {
         LocalDateTime start = now;
-        LocalDateTime end = now.plusMinutes(10);
+        LocalDateTime end = now.plusMinutes(3);
         return dsl.select(broadcastId)
                 .from(broadcastTable)
                 .where(

--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -1474,7 +1474,7 @@ public class BroadcastService {
                         openViduService.closeSession(schedule.broadcastId());
                         triggerRecordingFallback(schedule.broadcastId(), "scheduled_end");
                     }
-                    if (broadcast != null && (broadcast.getStatus() == BroadcastStatus.ENDED || broadcast.getStatus() == BroadcastStatus.STOPPED)) {
+                    if (broadcast != null && broadcast.getStatus() == BroadcastStatus.ENDED) {
                         validateTransition(broadcast.getStatus(), BroadcastStatus.VOD);
                         broadcast.changeStatus(BroadcastStatus.VOD);
                     }


### PR DESCRIPTION
### Motivation
- The reserved->READY transition timing needs to follow the updated rule and be shorter than before.
- STOPPED broadcasts must remain in the `STOPPED` state at scheduled end and not auto-transition to VOD.

### Description
- Shorten the ready transition window in `findBroadcastIdsForReadyTransition` from 10 minutes to 3 minutes in `src/main/java/com/deskit/deskit/livehost/repository/BroadcastRepositoryImpl.java`.
- Prevent scheduled-end processing from auto-transitioning `STOPPED` broadcasts to `VOD` by changing the condition to only transition when status is `ENDED` in `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java`.
- Preserve existing snapshot saving and SSE notification behavior after scheduled-end handling.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964854a937c832493337227f02b9291)