### PR TITLE
Include STOPPED broadcasts in live stats group

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -1745,7 +1745,10 @@ public class BroadcastService {
     }
 
     private boolean isLiveGroup(BroadcastStatus status) {
-        return status == BroadcastStatus.ON_AIR || status == BroadcastStatus.READY || status == BroadcastStatus.ENDED;
+        return status == BroadcastStatus.ON_AIR
+                || status == BroadcastStatus.READY
+                || status == BroadcastStatus.ENDED
+                || status == BroadcastStatus.STOPPED;
     }
 
     private boolean isJoinableGroup(BroadcastStatus status) {


### PR DESCRIPTION
### Motivation
- Stopped broadcasts were being treated as non-live, which could leave stale accumulated viewer totals visible after an admin force-stop and prevent realtime viewer count from dropping.
- Make STOPPED broadcasts use realtime stats so list/detail views reflect current viewer sets after a `BROADCAST_STOPPED` event.
- Ensure existing broadcast lifecycle/transition logic is not changed by this adjustment.

### Description
- Modify `isLiveGroup` in `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java` to include `BroadcastStatus.STOPPED`.
- This change causes code paths that call `isLiveGroup` (for example `getBroadcastStats`, `createBroadcastResponse`, and stats injection) to use Redis realtime counters for stopped broadcasts.
- No other status transitions or permission checks were altered.

### Testing
- No automated tests were executed for this change.
- The patch was committed to the repository (`git commit`) after the source modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964858ee0c08324a9704c6e6d66e7b9)