### PR TITLE
Move READY countdown to header and only show placeholder messages when waiting image is absent

### DIFF
--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -295,9 +295,16 @@ const streamPlaceholderMessage = computed(() => {
     return '방송이 종료되었습니다.'
   }
   if (lifecycleStatus.value === 'READY') {
-    return readyCountdownLabel.value || '방송 시작 대기 중'
+    return '방송 시작 대기 중'
   }
   return '송출 화면 (WebRTC Stream)'
+})
+const showPlaceholderMessage = computed(() => {
+  if (lifecycleStatus.value === 'STOPPED') return true
+  if (['READY', 'ENDED', 'ON_AIR'].includes(lifecycleStatus.value)) {
+    return !waitingScreenUrl.value
+  }
+  return true
 })
 
 const resolveMediaSelection = (value: string, fallback: string) => {
@@ -1491,7 +1498,10 @@ const toggleFullscreen = async () => {
     <header class="stream-header">
       <div>
         <h2 class="section-title">{{ displayTitle }}</h2>
-        <p class="ds-section-sub">{{ displayDatetime }}</p>
+        <p class="ds-section-sub">
+          {{ displayDatetime }}
+          <span v-if="readyCountdownLabel" class="stream-countdown">{{ readyCountdownLabel }}</span>
+        </p>
       </div>
       <div class="stream-actions">
         <button type="button" class="stream-btn" :disabled="!stream || isStopped" @click="showBasicInfo = true">기본정보 수정</button>
@@ -1655,7 +1665,7 @@ const toggleFullscreen = async () => {
                 :src="waitingScreenUrl"
                 alt="대기 화면"
               />
-              <p class="stream-title">{{ streamPlaceholderMessage }}</p>
+              <p v-if="showPlaceholderMessage" class="stream-title">{{ streamPlaceholderMessage }}</p>
               <p v-if="lifecycleStatus === 'ON_AIR'" class="stream-sub">현재 송출 중인 화면이 표시됩니다.</p>
               <p v-else-if="!waitingScreenUrl && lifecycleStatus !== 'STOPPED'" class="stream-sub">대기 화면 이미지가 없습니다.</p>
             </div>
@@ -2299,6 +2309,19 @@ const toggleFullscreen = async () => {
 .stream-btn.primary {
   border-color: var(--primary-color);
   color: var(--primary-color);
+}
+
+.stream-countdown {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 10px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #2563eb;
+  font-weight: 800;
+  font-size: 0.85rem;
 }
 
 


### PR DESCRIPTION
### Motivation
- Avoid duplicate READY-state countdown shown in both the stream placeholder and the header by relocating the countdown to the header.  
- Only display status placeholder messages for `READY`, `ENDED`, and `ON_AIR` when there is no waiting screen image.  
- Ensure `STOPPED` state messages remain visible regardless of waiting screen presence.  

### Description
- Stop returning the countdown text from `streamPlaceholderMessage` for the `READY` state and return a neutral waiting string instead.  
- Add a new computed `showPlaceholderMessage` that hides placeholder messages for `READY`, `ENDED`, and `ON_AIR` when `waitingScreenUrl` is present while always showing `STOPPED`.  
- Render the countdown in the header with `<span v-if="readyCountdownLabel" class="stream-countdown">{{ readyCountdownLabel }}</span>` placed next to `displayDatetime`.  
- Add styling for the new `.stream-countdown` pill in the component CSS.  

### Testing
- Started the dev server with `npm run dev` and Vite reported ready (succeeded).  
- Ran a Playwright script that opened `/seller/live/1` and captured `artifacts/seller-live-placeholder-message.png` to verify placeholder behavior (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696489d752388324bc4170516a703dfe)