### PR TITLE
Remove OpenVidu recordings after successful VOD upload

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -937,6 +937,12 @@ public class BroadcastService {
                         long contentLength = conn.getContentLengthLong();
                         String s3Url = s3Service.uploadVodStream(inputStream, s3Key, contentLength);
                         log.info("VOD Upload Success: {}", s3Url);
+                        try {
+                            openViduService.deleteRecording(recordingId);
+                        } catch (OpenViduJavaClientException | OpenViduHttpException e) {
+                            log.warn("Failed to delete OpenVidu recording after upload: recordingId={}, reason={}",
+                                    recordingId, e.getMessage());
+                        }
                         return s3Url;
                     }
                 } else {

--- a/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
@@ -138,6 +138,14 @@ public class OpenViduService {
                 .findFirst();
     }
 
+    public void deleteRecording(String recordingId) throws OpenViduJavaClientException, OpenViduHttpException {
+        if (recordingId == null || recordingId.isBlank()) {
+            return;
+        }
+        openVidu.deleteRecording(recordingId);
+        log.info("OpenVidu recording deleted: recordingId={}", recordingId);
+    }
+
     public void forceDisconnect(Long broadcastId, String connectionId) {
         String sessionId = sessionMap.get(broadcastId);
         if (sessionId == null) {


### PR DESCRIPTION
### Motivation

- Prevent recording files from lingering on the OpenVidu server after they have been successfully uploaded to NCP/S3 to free storage and reduce server load.
- Ensure that once a VOD is persisted to S3, the corresponding OpenVidu recording is cleaned up.

### Description

- Added `deleteRecording(String recordingId)` to `OpenViduService` which calls `openVidu.deleteRecording(recordingId)` and logs the deletion.
- Updated `BroadcastService.uploadVodWithRetry` to call `openViduService.deleteRecording(recordingId)` after a successful `s3Service.uploadVodStream` and log a warning if cleanup fails.
- `deleteRecording` is a no-op for `null` or blank `recordingId` to avoid unnecessary API calls.

### Testing

- No automated tests were run for this change.
- Code changes were committed and compiled as part of the build process (manual verification during rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69649d7daa1c83249720916e1fd806d5)