### PR TITLE
Gate live stats polling by lifecycle status (include ENDED/STOPPED)

### DIFF
--- a/front/src/pages/Live.vue
+++ b/front/src/pages/Live.vue
@@ -474,7 +474,7 @@ const connectSse = () => {
 
 const isStatsTarget = (item: LiveItem) => {
   const status = normalizeBroadcastStatus(item.status)
-  if (status === 'ON_AIR' || status === 'READY') return true
+  if (status === 'ON_AIR' || status === 'READY' || status === 'ENDED' || status === 'STOPPED') return true
   const startAtMs = parseLiveDate(item.startAt).getTime()
   if (Number.isNaN(startAtMs)) return false
   const endAtMs = parseLiveDate(item.endAt).getTime()

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -746,6 +746,9 @@ const startStatsPolling = () => {
     if (document.visibilityState !== 'visible') {
       return
     }
+    if (!['READY', 'ON_AIR', 'ENDED', 'STOPPED'].includes(lifecycleStatus.value)) {
+      return
+    }
     void loadStats()
     if (!sseConnected.value) {
       void loadProducts()

--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -467,7 +467,7 @@ const startStatsPolling = () => {
 
 const isStatsTarget = (item: LiveItem) => {
   const status = normalizeBroadcastStatus(item.status)
-  if (status === 'ON_AIR' || status === 'READY') return true
+  if (status === 'ON_AIR' || status === 'READY' || status === 'ENDED' || status === 'STOPPED') return true
   const startAtMs = item.startAtMs
   const endAtMs = item.endAtMs ?? getScheduledEndMs(startAtMs)
   if (!startAtMs || !endAtMs) return false

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -632,6 +632,9 @@ const startStatsPolling = (broadcastId: number) => {
     if (document.visibilityState !== 'visible') {
       return
     }
+    if (!['READY', 'ON_AIR', 'ENDED', 'STOPPED'].includes(lifecycleStatus.value)) {
+      return
+    }
     void refreshStats(broadcastId)
     if (!sseConnected.value) {
       void refreshProducts(broadcastId)

--- a/front/src/pages/seller/Live.vue
+++ b/front/src/pages/seller/Live.vue
@@ -448,7 +448,7 @@ const scheduleRefresh = () => {
 
 const isStatsTarget = (item: LiveItem) => {
   const status = normalizeBroadcastStatus(item.status)
-  if (status === 'ON_AIR' || status === 'READY') return true
+  if (status === 'ON_AIR' || status === 'READY' || status === 'ENDED' || status === 'STOPPED') return true
   const startAtMs = item.startAtMs
   const endAtMs = item.endAtMs ?? getScheduledEndMs(startAtMs)
   if (!startAtMs || !endAtMs) return false

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -1098,6 +1098,9 @@ const startStatsPolling = (broadcastId: number) => {
     if (document.visibilityState !== 'visible') {
       return
     }
+    if (!['READY', 'ON_AIR', 'ENDED', 'STOPPED'].includes(lifecycleStatus.value)) {
+      return
+    }
     void refreshStats(broadcastId)
     if (!sseConnected.value) {
       void refreshProducts(broadcastId)


### PR DESCRIPTION
### Motivation
- Live lists need realtime viewer/like/report metrics for broadcasts that are `ENDED` or `STOPPED` in addition to active broadcasts.  
- Live detail screens (`live` player/admin/seller) were still polling unconditionally or only for `READY`/`ON_AIR`, causing inconsistent behavior with lists.  
- Keep polling behavior consistent between list views and detail screens to ensure metrics remain available where needed.  

### Description
- Updated `isStatsTarget` in `front/src/pages/Live.vue`, `front/src/pages/admin/AdminLive.vue`, and `front/src/pages/seller/Live.vue` to treat `ENDED` and `STOPPED` as stats targets alongside `READY` and `ON_AIR`.  
- Added lifecycle gating to `startStatsPolling` in `front/src/pages/LiveDetail.vue`, `front/src/pages/admin/live/LiveDetail.vue`, and `front/src/pages/seller/LiveStream.vue` so polling returns early unless `lifecycleStatus` is one of `['READY', 'ON_AIR', 'ENDED', 'STOPPED']`.  
- Left existing polling cadence and stats fetch functions (`startStatsPolling`, `loadStats`, `refreshStats`, `refreshProducts`) unchanged except for the added early-return guard.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a8d3e01083248d54691375ccb86b)