### PR TITLE
Enforce 16:9 aspect ratio for live and VOD players across roles

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -1683,7 +1683,6 @@ onBeforeUnmount(() => {
   place-items: center;
   color: #fff;
   font-weight: 700;
-  min-height: clamp(160px, auto, 560px);
   max-width: min(100%, calc((100vh - 180px) * (16 / 9)));
   overflow: hidden;
 }

--- a/front/src/pages/Vod.vue
+++ b/front/src/pages/Vod.vue
@@ -735,7 +735,6 @@ watch(isLoggedIn, (next) => {
   place-items: center;
   color: #fff;
   font-weight: 700;
-  min-height: clamp(160px, auto, 560px);
   max-width: min(100%, calc((100vh - 180px) * (16 / 9)));
   overflow: hidden;
 }

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -1291,7 +1291,6 @@ watch(
   width: min(100%, calc((100vh - 120px) * (16 / 9)));
   height: auto;
   max-height: calc(100vh - 120px);
-  min-height: clamp(360px, auto, 760px);
   aspect-ratio: 16 / 9;
   background: #0b0f1a;
   border-radius: 18px;

--- a/front/src/pages/admin/live/VodDetail.vue
+++ b/front/src/pages/admin/live/VodDetail.vue
@@ -672,20 +672,24 @@ watch(vodId, () => {
 
 .player-frame {
   position: relative;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
   border-radius: 14px;
   overflow: hidden;
   background: #000;
-  min-height: 320px;
+  display: grid;
+  place-items: center;
 }
 
 .player-frame video {
   width: 100%;
   height: 100%;
   display: block;
+  object-fit: contain;
 }
 
 .vod-placeholder {
-  min-height: 320px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -2151,7 +2151,6 @@ const toggleFullscreen = async () => {
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  min-height: 320px;
   max-width: 100%;
 }
 


### PR DESCRIPTION
### Motivation
- Ensure player containers on viewer, admin, and seller screens consistently maintain a 16:9 layout to avoid stretching or visual distortion.
- Remove fixed `min-height` overrides that conflicted with responsive aspect-based sizing and caused inconsistent player dimensions across viewports.
- Make video elements scale cleanly inside their frames using `object-fit` so content is not cropped or distorted.

### Description
- Removed `min-height` constraints from `LiveDetail.vue`, `Vod.vue`, `admin/live/LiveDetail.vue`, `admin/live/VodDetail.vue`, and `seller/LiveStream.vue` so sizing is driven by `aspect-ratio` instead of fixed minima.
- Added or ensured `width: 100%`, `height: auto`, and `aspect-ratio: 16 / 9` on player containers where appropriate to standardize sizing across views.
- Set player frames to center content with `display: grid`/`place-items: center` and applied `object-fit: contain` to video elements so media scales without cropping.
- Preserved existing fullscreen and max-dimension rules so full-screen behavior and viewport constraints remain unchanged.

### Testing
- No automated tests were executed because this is a CSS/UI-only change.
- Linting/build were not run in this rollout environment.
- Manual runtime verification was not performed in this environment (visual change only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ac19eb008324957db209f1400dc6)