### PR TITLE
Fix seller on-air status detection

### DIFF
--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -307,6 +307,14 @@ const showPlaceholderMessage = computed(() => {
   return true
 })
 
+const resolveDetailStatus = (detail: BroadcastDetailResponse) => {
+  const normalized = normalizeBroadcastStatus(detail.status)
+  if (detail.startedAt && ['READY', 'RESERVED'].includes(normalized)) {
+    return 'ON_AIR'
+  }
+  return normalized
+}
+
 const resolveMediaSelection = (value: string, fallback: string) => {
   const trimmed = value?.trim()
   if (!trimmed || trimmed === 'default') return fallback
@@ -795,7 +803,7 @@ const hydrateStream = async () => {
     const startAtMs = baseTime ? parseLiveDate(baseTime).getTime() : NaN
     scheduleStartAtMs.value = Number.isNaN(startAtMs) ? null : startAtMs
     scheduleEndAtMs.value = scheduleStartAtMs.value ? getScheduledEndMs(scheduleStartAtMs.value) ?? null : null
-    streamStatus.value = normalizeBroadcastStatus(detail.status)
+    streamStatus.value = resolveDetailStatus(detail)
 
     const products = (detail.products ?? []).map((product) => ({
       id: String(product.bpId ?? product.productId),
@@ -911,7 +919,7 @@ const refreshInfo = async (broadcastId: number) => {
     const startAtMs = baseTime ? parseLiveDate(baseTime).getTime() : NaN
     scheduleStartAtMs.value = Number.isNaN(startAtMs) ? null : startAtMs
     scheduleEndAtMs.value = scheduleStartAtMs.value ? getScheduledEndMs(scheduleStartAtMs.value) ?? null : null
-    streamStatus.value = normalizeBroadcastStatus(detail.status)
+    streamStatus.value = resolveDetailStatus(detail)
     if (stream.value) {
       stream.value = {
         ...stream.value,


### PR DESCRIPTION
### Motivation
- Seller broadcast page remained blocked from connecting to the publisher when backend returned `READY`/`RESERVED` even though `startedAt` was present. 
- The intent is to treat broadcasts with a `startedAt` timestamp as actively on-air so the seller UI enables WebRTC publishing. 

### Description
- Add `resolveDetailStatus` helper to normalize backend status and coerce `READY`/`RESERVED` to `ON_AIR` when `detail.startedAt` exists. 
- Use `resolveDetailStatus` when setting `streamStatus.value` during initial hydrate (`hydrateStream`) and refresh (`refreshInfo`) flows. 
- Change affects `streamStatus.value` assignment locations in `front/src/pages/seller/LiveStream.vue` so lifecycle computation sees `ON_AIR`. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ac5c6f44832497351cb4c131343a)