### PR TITLE
Enhance live product panels and SSE updates

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -570,6 +570,38 @@ const parseSseData = (event: MessageEvent) => {
   }
 }
 
+const resolveProductId = (data: unknown) => {
+  if (typeof data === 'number') return String(data)
+  if (typeof data === 'string') return data
+  if (data && typeof data === 'object') {
+    const record = data as { productId?: number | string; bpId?: number | string; id?: number | string }
+    if (record.productId !== undefined) return String(record.productId)
+    if (record.bpId !== undefined) return String(record.bpId)
+    if (record.id !== undefined) return String(record.id)
+  }
+  return null
+}
+
+const applyPinnedProduct = (productId: string | null) => {
+  products.value = products.value.map((product) => ({
+    ...product,
+    isPinned: productId ? product.id === productId : false,
+  }))
+}
+
+const markProductSoldOut = (productId: string | null) => {
+  if (!productId) return
+  products.value = products.value.map((product) =>
+    product.id === productId
+      ? {
+        ...product,
+        isSoldOut: true,
+        stockQty: 0,
+      }
+      : product,
+  )
+}
+
 const buildStopConfirmMessage = () => {
   return '방송 운영 정책 위반으로 방송이 중지되었습니다.\n방송에서 나가시겠습니까?'
 }
@@ -633,8 +665,15 @@ const handleSseEvent = (event: MessageEvent) => {
       scheduleRefresh()
       break
     case 'PRODUCT_PINNED':
+      applyPinnedProduct(resolveProductId(data))
+      scheduleRefresh()
+      break
     case 'PRODUCT_UNPINNED':
+      applyPinnedProduct(null)
+      scheduleRefresh()
+      break
     case 'PRODUCT_SOLD_OUT':
+      markProductSoldOut(resolveProductId(data))
       scheduleRefresh()
       break
     case 'SANCTION_ALERT':


### PR DESCRIPTION
### Motivation
- Keep product lists in live pages up-to-date in real time by polling and applying SSE events for product pin and sold-out changes.  
- Make SSE-driven pin/unpin and sold-out events immediately affect UI (card color/disabled state and ordering).  
- Make the seller-side product panel as informative as the admin product panel by showing image, pricing, sold/stock info.  

### Description
- Added product helpers and SSE handlers in `front/src/pages/admin/live/LiveDetail.vue` to resolve product IDs, apply pin/unpin (`applyPinnedProduct`) and mark sold-out (`markProductSoldOut`), and now poll products on the regular stats interval by calling `refreshProducts`.  
- Updated viewer live page `front/src/pages/LiveDetail.vue` to apply SSE `PRODUCT_PINNED`, `PRODUCT_UNPINNED` and `PRODUCT_SOLD_OUT` events immediately via `resolveProductId`, `applyPinnedProduct`, and `markProductSoldOut`.  
- Expanded seller stream page `front/src/pages/seller/LiveStream.vue` with richer product model fields, `mapStreamProduct`, `formatPrice`, `handleImageError`, image thumbnails, price/sale display, sold/stock counts, and updated template + styles for detailed product cards.  

### Testing
- Attempted an automated Playwright screenshot of the running dev site to exercise the new seller product UI, but the page load failed with `net::ERR_EMPTY_RESPONSE` because no dev server responded, so the screenshot run failed.  
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a1b123f88324a5ca0a7bf95f879d)