### PR TITLE
Use broadcast allocation for product stock and sold-out SSE

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
@@ -14,7 +14,7 @@ public class BroadcastProductResponse {
     private String name;          // 상품명 (Product API 연동 필요)
     private String imageUrl;      // 상품 이미지 (Product API 연동 필요)
     private int originalPrice;    // 원가
-    private int stockQty;         // 판매 가능한 재고 수량
+    private int stockQty;         // 방송 판매 수량 기준 재고
     private int safetyStock;      // 안전 재고
 
     private int bpPrice;        // 라이브 특가 (bp_price)
@@ -24,7 +24,12 @@ public class BroadcastProductResponse {
     private BroadcastProductStatus status;        // 상품 상태 (SELLING, SOLDOUT, DELETED)
 
     public static BroadcastProductResponse fromEntity(BroadcastProduct bp) {
+        return fromEntity(bp, bp.getBpQuantity());
+    }
+
+    public static BroadcastProductResponse fromEntity(BroadcastProduct bp, Integer remainingQuantity) {
         Product p = bp.getProduct();
+        int remaining = remainingQuantity != null ? remainingQuantity : bp.getBpQuantity();
 
         return BroadcastProductResponse.builder()
                 .bpId(bp.getBpId())
@@ -32,7 +37,7 @@ public class BroadcastProductResponse {
                 .name(p.getProductName())
 //                .imageUrl(p.getProductThumbUrl())   // 추후 ProductImage 구현되면 추가 예정
                 .originalPrice(p.getPrice())
-                .stockQty(p.getStockQty())
+                .stockQty(remaining)
                 .safetyStock(p.getSafetyStock())
                 .bpPrice(bp.getBpPrice())
                 .bpQuantity(bp.getBpQuantity())


### PR DESCRIPTION
### Motivation
- The live/product panels should show remaining stock based on the broadcast's allocated sale quantity, not the product's global warehouse stock.  
- Sold-out events should be triggered when the broadcast allocation is fully consumed during the broadcast, not when global stock is exhausted.  
- Sales counting for depletion must consider only orders paid during the broadcast window and at the broadcast price (when set).  
- Dashboard and API responses must return remaining allocation to callers so UI and SSE reflect broadcast-level availability.

### Description
- Changed `BroadcastProductResponse` to expose broadcast-based remaining quantity (`stockQty`) and added `fromEntity(..., remainingQuantity)` to allow passing remaining allocation.  
- Updated `getBroadcastProducts`, `getProductListResponse`, and `injectLiveDetails` in `BroadcastService` to compute remaining quantities via a new helper `calculateRemainingQuantities` and use those values for responses and sold-out checks.  
- Implemented `calculateRemainingQuantities` which subtracts paid order quantities (during the broadcast window) from the `bpQuantity`, using `fetchBroadcastSalesSummary` metrics.  
- Adjusted `fetchBroadcastSalesSummary` to derive the broadcast time window (use `startedAt` and `endedAt` or `now`) and added a `priceMatchCondition` so only orders that match the broadcast price (or when `bp_price` is null) are counted toward broadcast sales.

### Testing
- No automated tests were run as part of this change.
- Manual compilation and basic static checks were not reported here (no test output available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964d742b4d8832490b88d6c91561b59)