### PR TITLE
Record viewer enter/exit history and close active sessions for accurate average watch time

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/entity/ViewHistory.java
+++ b/src/main/java/com/deskit/deskit/livehost/entity/ViewHistory.java
@@ -34,6 +34,15 @@ public class ViewHistory {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
+    private ViewHistory(Broadcast broadcast, String viewerId) {
+        this.broadcast = broadcast;
+        this.viewerId = viewerId;
+    }
+
+    public static ViewHistory enter(Broadcast broadcast, String viewerId) {
+        return new ViewHistory(broadcast, viewerId);
+    }
+
     // 입장 시 createdAt과 동일하게 초기화
     @PrePersist
     public void prePersist() {
@@ -47,4 +56,3 @@ public class ViewHistory {
         this.updatedAt = LocalDateTime.now();
     }
 }
-

--- a/src/main/java/com/deskit/deskit/livehost/repository/ViewHistoryRepository.java
+++ b/src/main/java/com/deskit/deskit/livehost/repository/ViewHistoryRepository.java
@@ -12,8 +12,11 @@ import java.util.Optional;
 
 public interface ViewHistoryRepository extends JpaRepository<ViewHistory, Long> {
 
-    @Query("SELECT v FROM ViewHistory v WHERE v.broadcast = :broadcast AND v.viewerId = :viewerId AND v.updatedAt = v.createdAt ORDER BY v.createdAt DESC LIMIT 1")
-    Optional<ViewHistory> findActiveHistory(@Param("broadcast") Broadcast broadcast, @Param("viewerId") String viewerId);
+    @Query(value = "SELECT * FROM view_history v " +
+            "WHERE v.broadcast_id = :broadcastId AND v.viewer_id = :viewerId AND v.updated_at = v.created_at " +
+            "ORDER BY v.created_at DESC LIMIT 1",
+            nativeQuery = true)
+    Optional<ViewHistory> findActiveHistory(@Param("broadcastId") Long broadcastId, @Param("viewerId") String viewerId);
 
     @Query(value = "SELECT COALESCE(AVG(TIMESTAMPDIFF(SECOND, v.created_at, v.updated_at)), 0) " +
             "FROM view_history v " +
@@ -24,4 +27,9 @@ public interface ViewHistoryRepository extends JpaRepository<ViewHistory, Long> 
     @Modifying
     @Query("DELETE FROM ViewHistory v WHERE v.createdAt < :cutoff")
     void deleteByCreatedAtBefore(@Param("cutoff") LocalDateTime cutoff);
+
+    @Modifying
+    @Query("UPDATE ViewHistory v SET v.updatedAt = :exitAt " +
+            "WHERE v.broadcast = :broadcast AND v.updatedAt = v.createdAt")
+    int closeActiveHistories(@Param("broadcast") Broadcast broadcast, @Param("exitAt") LocalDateTime exitAt);
 }


### PR DESCRIPTION
### Motivation
- Ensure viewer enter and exit times are recorded so average watch time can be calculated from actual session durations when creating `BroadcastResult` snapshots.
- Close any remaining active view sessions when a broadcast ends so snapshot statistics reflect final watch durations.

### Description
- Add a private constructor and factory `ViewHistory.enter` to `ViewHistory` to create new enter records and keep `createdAt`/`updatedAt` behavior intact.
- Replace `findActiveHistory` with a native-query variant taking `broadcastId`/`viewerId`, add `closeActiveHistories` repository update to set `updatedAt` for active records, and keep `getAverageWatchTime` SQL intact in `ViewHistoryRepository`.
- In `BroadcastService` import `ViewHistory`, make `joinBroadcast`/`leaveBroadcast` transactional and record sessions via new helpers `recordViewEnter`, `recordViewExit`, and `closeActiveViewHistories`.
- Call `closeActiveViewHistories` on `endBroadcast` and in the scheduled end flow, and record enter/exit also in WebSocket connect/disconnect handling so snapshots use accurate watch-time data.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ddaf2f008324a39c93880223d2b5)