### PR TITLE
Broadcast stats: top-5 ranking and include PAID/COMPLETED orders in sales calculations

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -1190,8 +1190,8 @@ public class BroadcastService {
             topView = broadcastResultRepository.getRanking(sellerId, period, "VIEWS", true, 5);
             worstView = broadcastResultRepository.getRanking(sellerId, period, "VIEWS", false, 5);
         } else {
-            best = broadcastResultRepository.getRanking(null, period, "SALES", true, 10);
-            worst = broadcastResultRepository.getRanking(null, period, "SALES", false, 10);
+            best = broadcastResultRepository.getRanking(null, period, "SALES", true, 5);
+            worst = broadcastResultRepository.getRanking(null, period, "SALES", false, 5);
             topView = List.of();
             worstView = List.of();
             bestProducts = getProductSalesRanking(period, true, 5);
@@ -1252,7 +1252,7 @@ public class BroadcastService {
                 .join(broadcastTable).on(bpBroadcastIdField.eq(broadcastIdField))
                 .join(productTable).on(bpProductIdField.eq(productIdField))
                 .where(
-                        orderStatusField.eq(OrderStatus.COMPLETED.name()),
+                        orderStatusField.in(OrderStatus.PAID.name(), OrderStatus.COMPLETED.name()),
                         orderPaidAtField.isNotNull(),
                         orderPaidAtField.ge(startDate),
                         orderPaidAtField.between(broadcastStartedAtField, broadcastEndedAtField),
@@ -1321,7 +1321,7 @@ public class BroadcastService {
                 .join(bpTable).on(bpProductIdField.eq(orderItemProductIdField)
                         .and(bpBroadcastIdField.eq(broadcast.getBroadcastId())))
                 .where(
-                        orderStatusField.eq(OrderStatus.PAID.name()),
+                        orderStatusField.in(OrderStatus.PAID.name(), OrderStatus.COMPLETED.name()),
                         orderPaidAtField.isNotNull(),
                         orderPaidAtField.between(startedAt, endedAt),
                         priceMatchCondition,


### PR DESCRIPTION
### Motivation
- Ensure admin broadcast rankings match UI expectation by returning top 5 entries instead of top 10 for sales rankings. 
- Make product-level sales and broadcast total revenue include both completed and paid orders so report numbers reflect actual sales. 
- Correct discrepancies where result reports showed missing or incomplete sales totals for products. 
- Keep existing ranking and chart behavior unchanged for seller-scoped queries.

### Description
- Updated `BroadcastService.getStatistics` to request top 5 broadcasts for the admin (global) sales `getRanking` calls instead of top 10. 
- Changed product sales queries in `getProductSalesRanking` to count orders with status `OrderStatus.PAID` and `OrderStatus.COMPLETED` by replacing `eq(...)` with `in(...)`. 
- Updated broadcast sales summary query in `fetchBroadcastSalesSummary` to include both `OrderStatus.PAID` and `OrderStatus.COMPLETED` when aggregating product metrics and total sales. 
- No UI changes; server-side logic now aggregates a broader set of order states and limits admin broadcast ranking to 5.

### Testing
- No automated tests were executed as part of this change. 
- The code was compiled and changes committed locally (manual verification steps not included). 
- Recommend running existing integration tests for statistics and report endpoints to validate numeric changes. 
- Recommend manual verification of admin and seller stats pages to confirm ranking count and report totals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f731664c83249995f0de1bac4159)