### PR TITLE
Fix live carousel layout for two items

### DIFF
--- a/front/src/components/LiveCarousel.vue
+++ b/front/src/components/LiveCarousel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, ref } from 'vue'
+import { computed, nextTick, ref, toRefs, watch } from 'vue'
 import { Swiper, SwiperSlide } from 'swiper/vue'
 import type { Swiper as SwiperClass } from 'swiper'
 import type { NavigationOptions } from 'swiper/types'
@@ -8,15 +8,30 @@ import { Autoplay, Pagination, Navigation } from 'swiper/modules'
 import LiveCard from './LiveCard.vue'
 import type { LiveItem } from '../lib/live/types'
 
-defineProps<{
+const props = defineProps<{
   items: LiveItem[]
 }>()
 
+const { items } = toRefs(props)
 const modules = [Autoplay, Pagination, Navigation]
 const prevEl = ref<HTMLButtonElement | null>(null)
 const nextEl = ref<HTMLButtonElement | null>(null)
+const swiperRef = ref<SwiperClass | null>(null)
+const shouldLoop = computed(() => items.value.length > 2)
+
+const refreshSwiper = async () => {
+  await nextTick()
+  if (!swiperRef.value || !items.value.length) return
+  swiperRef.value.update()
+  if (shouldLoop.value) {
+    swiperRef.value.slideToLoop(0, 0)
+  } else {
+    swiperRef.value.slideTo(0, 0)
+  }
+}
 
 const handleSwiper = (swiper: SwiperClass) => {
+  swiperRef.value = swiper
   nextTick(() => {
     if (!prevEl.value || !nextEl.value) {
       return
@@ -34,7 +49,12 @@ const handleSwiper = (swiper: SwiperClass) => {
     swiper.navigation?.init()
     swiper.navigation?.update()
   })
+  void refreshSwiper()
 }
+
+watch(() => items.value.length, () => {
+  void refreshSwiper()
+}, { immediate: true })
 </script>
 
 <template>
@@ -55,22 +75,22 @@ const handleSwiper = (swiper: SwiperClass) => {
     </button>
 
     <Swiper
-        v-if="items.length"
-        class="live-swiper"
-        :modules="modules"
-        :centered-slides="true"
-        :slides-per-view="'auto'"
-        :space-between="28"
-        :loop="items.length > 1"
-        :speed="880"
-        :navigation="true"
-        :autoplay="{
-          delay: 3000,
-          disableOnInteraction: false,
-          pauseOnMouseEnter: true,
-        }"
-        :pagination="{ clickable: true }"
-        @swiper="handleSwiper"
+      v-if="items.length"
+      class="live-swiper"
+      :modules="modules"
+      :centered-slides="true"
+      :slides-per-view="'auto'"
+      :space-between="28"
+      :loop="shouldLoop"
+      :speed="880"
+      :navigation="true"
+      :autoplay="{
+        delay: 3000,
+        disableOnInteraction: false,
+        pauseOnMouseEnter: true,
+      }"
+      :pagination="{ clickable: true }"
+      @swiper="handleSwiper"
     >
       <SwiperSlide v-for="item in items" :key="item.id" class="live-slide">
         <LiveCard :item="item" />


### PR DESCRIPTION
### Motivation
- The live carousel on the home page rendered incorrectly when there were exactly two live cards and required a manual navigation click to correct the layout.
- This was caused by Swiper loop behavior and stale swiper state when the number of items changed.

### Description
- Updated `front/src/components/LiveCarousel.vue` to use a `props` ref and `toRefs` for `items` and added a `swiperRef` to keep the swiper instance.
- Added `shouldLoop` computed that enables looping only when there are more than two items and replaced the previous `:loop` condition with `shouldLoop`.
- Implemented `refreshSwiper()` to call `swiper.update()` and reset slide position via `slideToLoop` or `slideTo` depending on `shouldLoop`.
- Called `refreshSwiper()` after swiper initialization and on `items.length` changes with a `watch(..., { immediate: true })` to keep the UI in sync.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite started successfully (local server served at `http://localhost:5173/`).
- Captured a screenshot of the home page using Playwright to verify the carousel visuals, and the script completed successfully.
- Verified that changes were staged and committed (`git commit`) without errors.
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f8b1ecc48324a081fb25fb731630)