### PR TITLE
Fix seller live preview autoplay

### DIFF
--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -458,8 +458,11 @@ const applyPublisherVolume = () => {
   if (!publisherContainerRef.value) return
   const video = publisherContainerRef.value.querySelector('video') as HTMLVideoElement | null
   if (!video) return
-  video.muted = false
+  video.muted = true
+  video.autoplay = true
+  video.playsInline = true
   video.volume = Math.min(1, Math.max(0, volume.value / 100))
+  void video.play().catch(() => {})
 }
 
 const waitForPublisherContainer = async () => {


### PR DESCRIPTION
### Motivation
- Seller broadcast publisher preview was not appearing for sellers due to browser autoplay restrictions for unmuted video, while admin/viewer pages (subscriber) worked fine.
- The publisher video element was not explicitly configured for muted/inline autoplay, which can cause the local preview to be blocked by the browser.

### Description
- Updated `applyPublisherVolume` in `front/src/pages/seller/LiveStream.vue` to keep the preview muted by setting `video.muted = true`.
- Also set `video.autoplay = true` and `video.playsInline = true`, and call `video.play().catch(() => {})` to proactively attempt playback.
- Changes ensure the OpenVidu publisher video can start silently and avoid autoplay blocking on seller pages.

### Testing
- No automated tests were run for this change.
- The change was committed to `front/src/pages/seller/LiveStream.vue`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964fc878b6c83248ae8b188464d611e)