### PR TITLE
Mirror preview, SSE home updates, auto-unpin sold-out products, fix product sales ranking

### DIFF
--- a/front/src/components/LiveCard.vue
+++ b/front/src/components/LiveCard.vue
@@ -118,6 +118,14 @@ const totalDurationLabel = computed(() => {
   return formatDuration(end.getTime() - start.getTime())
 })
 
+const endedDurationLabel = computed(() => {
+  const start = parseLiveDate(props.item.startAt)
+  if (Number.isNaN(start.getTime())) return ''
+  const end = parseLiveDate(props.item.endAt)
+  const endMs = Number.isNaN(end.getTime()) ? now.value.getTime() : end.getTime()
+  return formatDuration(endMs - start.getTime())
+})
+
 const timeLabel = computed(() => {
   if (status.value === 'LIVE') {
     return `방송 시간 ${elapsed.value}`
@@ -134,7 +142,7 @@ const timeLabel = computed(() => {
   if (status.value === 'VOD') {
     return totalDurationLabel.value ? `총 재생 ${totalDurationLabel.value}` : 'VOD'
   }
-  return totalDurationLabel.value ? `경과 ${totalDurationLabel.value}` : '방송 종료'
+  return endedDurationLabel.value ? `경과 ${endedDurationLabel.value}` : '방송 종료'
 })
 
 const viewerLabel = computed(() => {

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -2257,6 +2257,7 @@ const toggleFullscreen = async () => {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transform: scaleX(-1);
 }
 
 .stream-player--fullscreen {


### PR DESCRIPTION
### Motivation
- Seller preview video was displayed flipped for hosts and needs to be mirrored for correct orientation.
- Ended broadcasts should show a dynamically updating elapsed time on viewer cards instead of a static total duration.
- Viewer home should react to broadcast/product state changes (pin/unpin, sold out, broadcast state) via SSE and refresh counts/listings.
- Product sales ranking logic must aggregate sales correctly across broadcasts (previously only counted per single broadcast window).

### Description
- Mirror publisher video by adding `transform: scaleX(-1)` to the publisher video selector in `front/src/pages/seller/LiveStream.vue`.
- Keep ended card durations live by adding `endedDurationLabel` and switching `LiveCard.vue` to use it for post-end elapsed display so the UI updates with `useNow` ticks.
- Add an SSE subscriber to the viewer home in `front/src/pages/Home.vue` that connects to `GET /api/broadcasts/subscribe/all`, listens for broadcast/product events, schedules small debounced refreshes, and implements reconnect/backoff logic.
- Update `BroadcastService.getBroadcastProducts` to mark products sold out, automatically clear `isPinned` for pinned sold-out items and emit `PRODUCT_SOLD_OUT` / `PRODUCT_UNPINNED` SSE events, and fix `getProductSalesRanking` to compute product sales across broadcasts by adjusting the jOOQ query (use `order_item` prices and an `exists` check against `broadcast_product`).

### Testing
- No automated tests were executed for these changes.
- Manual runtime verification is recommended for SSE connectivity, publisher preview mirroring, pin release on sold-out, and the admin stats product ranking.
- Static type checks / compilation were not reported as part of this change.
- Further unit/integration tests should be added for `getProductSalesRanking` and SSE notification flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965109f85908324863ec52e2ec5741c)