### PR TITLE
Fix admin live stats typing

### DIFF
--- a/front/src/pages/admin/AdminLive.vue
+++ b/front/src/pages/admin/AdminLive.vue
@@ -497,8 +497,8 @@ const updateLiveViewerCounts = async () => {
     }
   })
   if (!statsMap.size) return
-  const applyStats = (items: LiveItem[]) =>
-    items.map((item) => {
+  const applyStats = <T extends LiveItem>(items: T[]): T[] =>
+    items.map((item): T => {
       const stats = statsMap.get(item.id)
       if (!stats) return item
       const viewers = stats.viewerCount ?? item.viewers ?? 0
@@ -508,7 +508,7 @@ const updateLiveViewerCounts = async () => {
         viewerBadge: `${viewers}명 시청 중`,
         likes: stats.likeCount ?? item.likes ?? 0,
         reports: stats.reportCount ?? item.reports ?? 0,
-      }
+      } as T
     })
   liveItems.value = applyStats(liveItems.value)
   scheduledItems.value = applyStats(scheduledItems.value)


### PR DESCRIPTION
### Motivation
- Updating live stats was losing concrete item subtypes and caused a TypeScript mismatch when assigning `LiveItem[]` to `ReservationItem[]` in the admin live page.
- The change aims to preserve the original item subtype while applying broadcast stats so downstream code still sees `ReservationItem` or other specialized types.

### Description
- Made the stats applicator generic as `const applyStats = <T extends LiveItem>(items: T[]): T[] => ...` in `front/src/pages/admin/AdminLive.vue`.
- Ensured the mapped return value is typed as the same subtype with a cast `} as T` so properties and types are preserved.
- Continued to call `applyStats` for both `liveItems.value` and `scheduledItems.value` to update viewer/like/report counts without losing subtype information.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696518c3fb7483248d26c49b843643fa)