### PR TITLE
Fix product sales ranking join

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -1259,7 +1259,7 @@ public class BroadcastService {
         return dsl.select(productIdField, productNameField, salesExpr)
                 .from(orderItemTable)
                 .join(orderTable).on(orderItemOrderIdField.eq(orderIdField))
-                .join(productTable).on(bpProductIdField.eq(productIdField))
+                .join(productTable).on(orderItemProductIdField.eq(productIdField))
                 .where(
                         orderStatusField.in(OrderStatus.PAID.name(), OrderStatus.COMPLETED.name()),
                         orderPaidAtField.isNotNull(),


### PR DESCRIPTION
### Motivation
- Error logs showed a SQL syntax error `Unknown column 'bp.product_id' in 'on clause'` when computing product sales rankings. 
- The join used the `broadcast_product` alias (`bp`) in the `ON` clause where that alias was not part of the join path, producing invalid SQL. 
- The intent is to compute product sales by matching `order_item.product_id` to `product.product_id`. 
- Fixing the join ensures the ranking query references the correct column source.

### Description
- Updated the join in `getProductSalesRanking` to use `orderItemProductIdField.eq(productIdField)` instead of `bpProductIdField.eq(productIdField)`.
- Change is located in `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java` inside the `getProductSalesRanking` method.
- Kept the `EXISTS` check against `broadcast_product` (`bpExists`) unchanged so only products participating in broadcasts are considered.
- This is a single-line fix to correct the jOOQ-generated SQL join condition.

### Testing
- No automated tests were executed for this change.
- The change was committed and is ready for review/CI to run the project test suite.
- Manual verification is recommended by running the code path that previously produced the `BadSqlGrammarException` to confirm the SQL error is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651ceb80b08324a47e62a78853fae6)