### PR TITLE
Widen sanction rank cards; add independent rank controls; wrap chart labels; fix product sales join

### DIFF
--- a/front/src/components/stats/StatsBarChart.vue
+++ b/front/src/components/stats/StatsBarChart.vue
@@ -232,10 +232,11 @@ const barLayoutStyle = computed(() => ({
   font-size: 0.8rem;
   color: var(--text-muted, #666);
   font-weight: 600;
-  /* 긴 라벨 말줄임 처리 */
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  line-height: 1.2;
+  min-height: 2.4em;
+  white-space: normal;
+  word-break: break-word;
+  overflow-wrap: anywhere;
   width: 100%;
 }
 

--- a/front/src/pages/admin/live/SanctionStats.vue
+++ b/front/src/pages/admin/live/SanctionStats.vue
@@ -11,6 +11,7 @@ type RankItem = { rank: number; title: string; value: number }
 
 const stopMetric = ref<Metric>('daily')
 const viewerMetric = ref<Metric>('daily')
+const rankMetric = ref<Metric>('daily')
 
 const periodMap: Record<Metric, string> = {
   daily: 'DAILY',
@@ -59,12 +60,8 @@ const loadStopStats = async () => {
   try {
     const payload = await fetchSanctionStatistics(periodMap[stopMetric.value])
     stopChart.value = mapChart(payload.forceStopChart ?? [])
-    topSellerStops.value = mapSellerRanks(payload.worstSellers ?? [])
-    topViewerSanctions.value = mapViewerRanks(payload.worstViewers ?? [])
   } catch {
     stopChart.value = []
-    topSellerStops.value = []
-    topViewerSanctions.value = []
   }
 }
 
@@ -77,12 +74,27 @@ const loadViewerStats = async () => {
   }
 }
 
+const loadRankStats = async () => {
+  try {
+    const payload = await fetchSanctionStatistics(periodMap[rankMetric.value])
+    topSellerStops.value = mapSellerRanks(payload.worstSellers ?? [])
+    topViewerSanctions.value = mapViewerRanks(payload.worstViewers ?? [])
+  } catch {
+    topSellerStops.value = []
+    topViewerSanctions.value = []
+  }
+}
+
 watch(stopMetric, () => {
   loadStopStats()
 }, { immediate: true })
 
 watch(viewerMetric, () => {
   loadViewerStats()
+}, { immediate: true })
+
+watch(rankMetric, () => {
+  loadRankStats()
 }, { immediate: true })
 </script>
 
@@ -142,6 +154,35 @@ watch(viewerMetric, () => {
     </section>
 
     <section class="ranks-grid">
+      <div class="ranks-grid__head">
+        <h3 class="ranks-grid__title">순위 리스트</h3>
+        <div class="toggle-group" role="tablist" aria-label="순위 기간">
+          <button
+            type="button"
+            class="toggle-btn"
+            :class="{ 'toggle-btn--active': rankMetric === 'daily' }"
+            @click="rankMetric = 'daily'"
+          >
+            일별
+          </button>
+          <button
+            type="button"
+            class="toggle-btn"
+            :class="{ 'toggle-btn--active': rankMetric === 'monthly' }"
+            @click="rankMetric = 'monthly'"
+          >
+            월별
+          </button>
+          <button
+            type="button"
+            class="toggle-btn"
+            :class="{ 'toggle-btn--active': rankMetric === 'yearly' }"
+            @click="rankMetric = 'yearly'"
+          >
+            연도별
+          </button>
+        </div>
+      </div>
       <article class="ds-surface panel">
         <h3 class="panel__title">송출 중지 횟수 많은 판매자 TOP 5</h3>
         <StatsRankList :items="topSellerStops" />
@@ -188,9 +229,25 @@ watch(viewerMetric, () => {
 
 .ranks-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
   gap: 14px;
   margin-top: 14px;
+}
+
+.ranks-grid__head {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.ranks-grid__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 900;
+  color: var(--text-strong);
 }
 
 .panel {
@@ -234,5 +291,17 @@ watch(viewerMetric, () => {
   border-color: var(--primary-color);
   color: var(--primary-color);
   background: rgba(var(--primary-rgb), 0.08);
+}
+
+@media (max-width: 640px) {
+  .ranks-grid__head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .toggle-group {
+    width: 100%;
+    flex-wrap: wrap;
+  }
 }
 </style>

--- a/front/src/pages/admin/live/Stats.vue
+++ b/front/src/pages/admin/live/Stats.vue
@@ -13,6 +13,7 @@ type RankGroup = { best: RankItem[]; worst: RankItem[] }
 
 const revenueRange = ref<StatsRange>('monthly')
 const perViewerRange = ref<StatsRange>('monthly')
+const rankRange = ref<StatsRange>('monthly')
 const broadcastRankView = ref<RankView>('best')
 const productRankView = ref<RankView>('best')
 
@@ -64,12 +65,8 @@ const loadRevenueStats = async () => {
   try {
     const payload = await fetchAdminStatistics(periodMap[revenueRange.value])
     revenueChart.value = mapChart(payload.salesChart ?? [])
-    broadcastRanks.value = mapRankGroup(payload.bestBroadcasts ?? [], payload.worstBroadcasts ?? [])
-    productRanks.value = mapProductRanks(payload.bestProducts ?? [], payload.worstProducts ?? [])
   } catch {
     revenueChart.value = []
-    broadcastRanks.value = { best: [], worst: [] }
-    productRanks.value = { best: [], worst: [] }
   }
 }
 
@@ -82,12 +79,27 @@ const loadViewerStats = async () => {
   }
 }
 
+const loadRankStats = async () => {
+  try {
+    const payload = await fetchAdminStatistics(periodMap[rankRange.value])
+    broadcastRanks.value = mapRankGroup(payload.bestBroadcasts ?? [], payload.worstBroadcasts ?? [])
+    productRanks.value = mapProductRanks(payload.bestProducts ?? [], payload.worstProducts ?? [])
+  } catch {
+    broadcastRanks.value = { best: [], worst: [] }
+    productRanks.value = { best: [], worst: [] }
+  }
+}
+
 watch(revenueRange, () => {
   loadRevenueStats()
 }, { immediate: true })
 
 watch(perViewerRange, () => {
   loadViewerStats()
+}, { immediate: true })
+
+watch(rankRange, () => {
+  loadRankStats()
 }, { immediate: true })
 </script>
 
@@ -164,6 +176,35 @@ watch(perViewerRange, () => {
     </section>
 
     <section class="stats-section stats-section--ranks">
+      <div class="stats-section__head">
+        <h3 class="stats-section__title">순위 리스트</h3>
+        <div class="toggle-group" role="tablist" aria-label="순위 기간">
+          <button
+            type="button"
+            class="toggle-btn"
+            :class="{ 'toggle-btn--active': rankRange === 'daily' }"
+            @click="rankRange = 'daily'"
+          >
+            일별
+          </button>
+          <button
+            type="button"
+            class="toggle-btn"
+            :class="{ 'toggle-btn--active': rankRange === 'monthly' }"
+            @click="rankRange = 'monthly'"
+          >
+            월별
+          </button>
+          <button
+            type="button"
+            class="toggle-btn"
+            :class="{ 'toggle-btn--active': rankRange === 'yearly' }"
+            @click="rankRange = 'yearly'"
+          >
+            연도별
+          </button>
+        </div>
+      </div>
       <article class="ds-surface stats-card">
         <header class="stats-card__head">
           <h3 class="stats-card__title">방송 매출 순위 TOP 5</h3>
@@ -234,6 +275,21 @@ watch(perViewerRange, () => {
   grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
 }
 
+.stats-section__head {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.stats-section__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
 .stats-card {
   padding: 18px;
   border-radius: 16px;
@@ -281,6 +337,11 @@ watch(perViewerRange, () => {
 
 @media (max-width: 640px) {
   .stats-card__head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .stats-section__head {
     flex-direction: column;
     align-items: flex-start;
   }

--- a/front/src/pages/seller/LiveStats.vue
+++ b/front/src/pages/seller/LiveStats.vue
@@ -13,6 +13,7 @@ type RankGroup = { best: RankItem[]; worst: RankItem[] }
 
 const revenueRange = ref<StatsRange>('monthly')
 const perViewerRange = ref<StatsRange>('monthly')
+const rankRange = ref<StatsRange>('monthly')
 const revenueRankView = ref<RankView>('best')
 const viewerRankView = ref<RankView>('best')
 
@@ -65,12 +66,8 @@ const loadRevenueStats = async () => {
   try {
     const payload = await fetchSellerStatistics(periodMap[revenueRange.value])
     revenueChart.value = mapChart(payload.salesChart ?? [])
-    revenueRanks.value = mapRankGroup(payload.bestBroadcasts ?? [], payload.worstBroadcasts ?? [])
-    viewerRanks.value = mapViewerRankGroup(payload.topViewerBroadcasts ?? [], payload.worstViewerBroadcasts ?? [])
   } catch {
     revenueChart.value = []
-    revenueRanks.value = { best: [], worst: [] }
-    viewerRanks.value = { best: [], worst: [] }
   }
 }
 
@@ -83,12 +80,27 @@ const loadViewerStats = async () => {
   }
 }
 
+const loadRankStats = async () => {
+  try {
+    const payload = await fetchSellerStatistics(periodMap[rankRange.value])
+    revenueRanks.value = mapRankGroup(payload.bestBroadcasts ?? [], payload.worstBroadcasts ?? [])
+    viewerRanks.value = mapViewerRankGroup(payload.topViewerBroadcasts ?? [], payload.worstViewerBroadcasts ?? [])
+  } catch {
+    revenueRanks.value = { best: [], worst: [] }
+    viewerRanks.value = { best: [], worst: [] }
+  }
+}
+
 watch(revenueRange, () => {
   loadRevenueStats()
 }, { immediate: true })
 
 watch(perViewerRange, () => {
   loadViewerStats()
+}, { immediate: true })
+
+watch(rankRange, () => {
+  loadRankStats()
 }, { immediate: true })
 </script>
 
@@ -165,6 +177,35 @@ watch(perViewerRange, () => {
     </section>
 
     <section class="stats-section stats-section--ranks">
+      <div class="stats-section__head">
+        <h3 class="stats-section__title">순위 리스트</h3>
+        <div class="toggle-group" role="tablist" aria-label="순위 기간">
+          <button
+            type="button"
+            class="toggle-btn"
+            :class="{ 'toggle-btn--active': rankRange === 'daily' }"
+            @click="rankRange = 'daily'"
+          >
+            일별
+          </button>
+          <button
+            type="button"
+            class="toggle-btn"
+            :class="{ 'toggle-btn--active': rankRange === 'monthly' }"
+            @click="rankRange = 'monthly'"
+          >
+            월별
+          </button>
+          <button
+            type="button"
+            class="toggle-btn"
+            :class="{ 'toggle-btn--active': rankRange === 'yearly' }"
+            @click="rankRange = 'yearly'"
+          >
+            연도별
+          </button>
+        </div>
+      </div>
       <article class="ds-surface stats-card">
         <header class="stats-card__head">
           <h3 class="stats-card__title">매출 베스트/워스트 방송 5순위</h3>
@@ -235,6 +276,21 @@ watch(perViewerRange, () => {
   grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
 }
 
+.stats-section__head {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.stats-section__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
 .stats-card {
   padding: 18px;
   border-radius: 16px;
@@ -282,6 +338,11 @@ watch(perViewerRange, () => {
 
 @media (max-width: 640px) {
   .stats-card__head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .stats-section__head {
     flex-direction: column;
     align-items: flex-start;
   }

--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -1259,7 +1259,7 @@ public class BroadcastService {
         return dsl.select(productIdField, productNameField, salesExpr)
                 .from(orderItemTable)
                 .join(orderTable).on(orderItemOrderIdField.eq(orderIdField))
-                .join(productTable).on(bpProductIdField.eq(productIdField))
+                .join(productTable).on(orderItemProductIdField.eq(productIdField))
                 .where(
                         orderStatusField.in(OrderStatus.PAID.name(), OrderStatus.COMPLETED.name()),
                         orderPaidAtField.isNotNull(),


### PR DESCRIPTION
### Motivation
- Make rank lists independent from chart period selectors so rank data can be fetched and filtered separately.
- Prevent long bar chart labels from being truncated so timeline labels remain readable.
- Match the sanction page rank card widths to the chart grid for a consistent layout.
- Ensure product sales ranking uses the correct join column so sales are computed for the actual `order_item.product_id`.

### Description
- Update bar chart label styling in `front/src/components/stats/StatsBarChart.vue` to allow wrapping by changing `white-space`, adding `word-break`, `min-height`, and `overflow-wrap` rules.
- Add independent rank period state, loader and `watch` hooks plus a section header and toggle group in `front/src/pages/admin/live/SanctionStats.vue`, `front/src/pages/admin/live/Stats.vue`, and `front/src/pages/seller/LiveStats.vue` via `rankMetric`/`rankRange`, `loadRankStats`, and UI controls so rank lists have their own daily/monthly/yearly selectors.
- Widen the sanction page rank list columns by changing the grid min width from `minmax(320px, 1fr)` to `minmax(380px, 1fr)` and add responsive header styling in `front/src/pages/admin/live/SanctionStats.vue`.
- Fix the SQL join in `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java` to join `productTable` on `orderItemProductIdField.eq(productIdField)` so product ranks use `order_item.product_id`.

### Testing
- Started the front-end dev server with `npm run dev` and Vite reported ready, indicating the dev server started successfully — success.
- Ran a Playwright script that navigated to `/admin/live/sanctions` and saved a screenshot to `artifacts/admin-sanction-stats-wide.png` to verify the wider sanction rank cards — success.
- No automated unit or integration test suites were executed as part of this change. 
- The sanction grid width change was committed as `Widen sanction rank cards` and included the screenshot artifact for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651ceb80b08324a47e62a78853fae6)