### PR TITLE
Fix reservation detail stock display

### DIFF
--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -149,6 +149,7 @@ export type BroadcastDetailResponse = {
     originalPrice: number
     stockQty?: number
     safetyStock?: number
+    productStockQty?: number
     bpPrice: number
     bpQuantity: number
     displayOrder: number

--- a/front/src/pages/admin/live/ReservationDetail.vue
+++ b/front/src/pages/admin/live/ReservationDetail.vue
@@ -64,7 +64,7 @@ const mapDetail = (payload: BroadcastDetailResponse): AdminReservationDetail => 
     price: formatCurrency(item.originalPrice ?? 0),
     salePrice: formatCurrency(item.bpPrice ?? item.originalPrice ?? 0),
     qty: item.bpQuantity ?? 0,
-    stock: item.stockQty ?? item.bpQuantity ?? 0,
+    stock: item.productStockQty ?? item.stockQty ?? item.bpQuantity ?? 0,
   })),
   cueQuestions: (payload.qcards ?? []).map((card) => card.question),
   cancelReason: payload.stoppedReason ?? undefined,

--- a/front/src/pages/seller/broadcasts/ReservationDetail.vue
+++ b/front/src/pages/seller/broadcasts/ReservationDetail.vue
@@ -102,7 +102,7 @@ const mapDetail = (payload: BroadcastDetailResponse): SellerReservationDetail =>
     name: item.name,
     price: formatCurrency(item.originalPrice ?? 0),
     salePrice: formatCurrency(item.bpPrice ?? item.originalPrice ?? 0),
-    stock: item.stockQty ?? item.bpQuantity ?? 0,
+    stock: item.productStockQty ?? item.stockQty ?? item.bpQuantity ?? 0,
     qty: item.bpQuantity ?? 0,
   })),
   cueQuestions: (payload.qcards ?? []).map((card) => card.question),

--- a/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
@@ -16,6 +16,7 @@ public class BroadcastProductResponse {
     private int originalPrice;    // 원가
     private int stockQty;         // 방송 판매 수량 기준 재고
     private int safetyStock;      // 안전 재고
+    private int productStockQty;  // 상품 원본 재고 수량
 
     private int bpPrice;        // 라이브 특가 (bp_price)
     private int bpQuantity;     // 판매 수량 (bp_quantity)
@@ -39,6 +40,7 @@ public class BroadcastProductResponse {
                 .originalPrice(p.getPrice())
                 .stockQty(remaining)
                 .safetyStock(p.getSafetyStock())
+                .productStockQty(p.getStockQty())
                 .bpPrice(bp.getBpPrice())
                 .bpQuantity(bp.getBpQuantity())
                 .displayOrder(bp.getDisplayOrder())


### PR DESCRIPTION
### Motivation
- Reservation detail screens showed `재고` equal to broadcast allocation instead of the product's actual inventory, causing confusion.
- The UI used `stockQty` (broadcast-level) or `bpQuantity` instead of the product's original stock value.
- We need to display the true product inventory where available in admin and seller reservation views.

### Description
- Added `productStockQty` to `BroadcastProductResponse` and populated it from `Product.getStockQty()` in `fromEntity`.
- Exposed `productStockQty` in the front-end API type `BroadcastDetailResponse` (`front/src/lib/live/api.ts`).
- Updated seller reservation detail mapping (`front/src/pages/seller/broadcasts/ReservationDetail.vue`) to prefer `productStockQty` when rendering `stock`.
- Updated admin reservation detail mapping (`front/src/pages/admin/live/ReservationDetail.vue`) to prefer `productStockQty` when rendering `stock`.

### Testing
- No automated tests were executed for this change.
- All changes are limited to DTOs and view mappings to avoid runtime side effects.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696526035958832ea687a457060b63dc)