### PR TITLE
Fix remaining stock calc for duplicate broadcast products

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -1967,11 +1967,16 @@ public class BroadcastService {
         }
         SalesSummary salesSummary = fetchBroadcastSalesSummary(broadcast);
         Map<Long, SalesMetric> metrics = salesSummary.productMetrics();
-        return products.stream()
-                .collect(Collectors.toMap(
+        Map<Long, Integer> totalQuantities = products.stream()
+                .collect(Collectors.groupingBy(
                         bp -> bp.getProduct().getId(),
-                        bp -> Math.max(0, bp.getBpQuantity()
-                                - Optional.ofNullable(metrics.get(bp.getProduct().getId()))
+                        Collectors.summingInt(BroadcastProduct::getBpQuantity)
+                ));
+        return totalQuantities.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> Math.max(0, entry.getValue()
+                                - Optional.ofNullable(metrics.get(entry.getKey()))
                                 .map(SalesMetric::salesQuantity)
                                 .orElse(0))
                 ));


### PR DESCRIPTION
### Motivation
- Avoid `IllegalStateException: Duplicate key` when multiple `BroadcastProduct` entries reference the same product ID.
- Ensure remaining stock reflects the sum of broadcast quantities when duplicate product entries exist.
- Correctly subtract sales metrics from aggregated broadcast quantities to compute remaining stock.

### Description
- Replace the direct `toMap` on `products` with `Collectors.groupingBy` and `Collectors.summingInt` to aggregate `bp.getBpQuantity()` per product ID in `calculateRemainingQuantities`.
- Compute remaining per-product stock by subtracting the corresponding `SalesMetric::salesQuantity` from the aggregated total and clamp to zero with `Math.max(0, ...)`.
- Preserve existing null/empty checks for `broadcast` and `products` and keep caller behavior unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69652aa86ca4832e819f9b0794389c96)