### PR TITLE
Mirror seller broadcast view in admin

### DIFF
--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -1540,6 +1540,7 @@ watch(
   width: 100%;
   height: 100%;
   object-fit: contain;
+  transform: scaleX(-1);
 }
 
 .player-frame--fullscreen {


### PR DESCRIPTION
### Motivation
- Make the admin live detail player display the seller's broadcast mirrored so the view matches the publisher preview.
- Ensure visual consistency between the seller-side `LiveStream` preview and the admin `LiveDetail` viewer.

### Description
- Added a horizontal flip to the admin player video by applying `transform: scaleX(-1)` to `.player-frame__viewer :deep(video)` in `front/src/pages/admin/live/LiveDetail.vue`.
- The change only updates CSS for the admin live detail player and does not touch JavaScript logic or server code.

### Testing
- No automated tests were run for this change.
- Visual verification was intended (manual), but no automated UI tests or CI runs were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965320c8a00832eb5eed397db85ddbd)