### PR TITLE
Fix OpenVidu subscriber typing and SSE payload handling

### DIFF
--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { OpenVidu, type Session, type Subscriber } from 'openvidu-browser'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Client, type StompSubscription } from '@stomp/stompjs'
 import SockJS from 'sockjs-client/dist/sockjs'
@@ -140,7 +140,7 @@ const leaveRequested = ref(false)
 const viewerContainerRef = ref<HTMLDivElement | null>(null)
 const openviduInstance = ref<OpenVidu | null>(null)
 const openviduSession = ref<Session | null>(null)
-const openviduSubscriber = ref<Subscriber | null>(null)
+const openviduSubscriber = shallowRef<Subscriber | null>(null)
 const openviduConnected = ref(false)
 const FALLBACK_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
 
@@ -763,6 +763,7 @@ const scheduleRefresh = (broadcastId: number) => {
 const handleSseEvent = (event: MessageEvent) => {
   const idValue = Number(liveId.value)
   if (Number.isNaN(idValue)) return
+  const data = parseSseData(event)
   switch (event.type) {
     case 'BROADCAST_READY':
     case 'BROADCAST_UPDATED':


### PR DESCRIPTION
### Motivation
- Fix TypeScript errors where the `Subscriber` instance lost class typing when stored in a normal `ref`, causing missing method/property complaints when passed to OpenVidu APIs.
- Resolve runtime/compile issues caused by `parseSseData` being declared but unused and `data` being referenced without definition in SSE event handling.
- Ensure SSE events that carry payloads (e.g. product pin/sold notifications) use the parsed payload when updating UI state.

### Description
- Import `shallowRef` from `vue` and replace `openviduSubscriber` declaration with `const openviduSubscriber = shallowRef<Subscriber | null>(null)` to preserve the original class instance typing.
- Call `parseSseData(event)` at the start of `handleSseEvent` and store the result in a local `data` variable, then pass `data` into `resolveProductId` and related handlers.
- Minor import update to include `shallowRef` in the top-level imports.

### Testing
- No automated tests were run as part of this change.
- Type-check/build was not executed within this rollout (no test failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696538935b3c832e96418ffbeab96a38)