### PR TITLE
Allow sanctions by loginId without modifying chat UI flows

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -684,6 +684,12 @@ const refreshChatPermission = async () => {
   }
 }
 
+watch(hasChatPermission, (next) => {
+  if (!next) {
+    input.value = ''
+  }
+})
+
 const handleSseEvent = (event: MessageEvent) => {
   const data = parseSseData(event)
   switch (event.type) {

--- a/src/main/java/com/deskit/deskit/livehost/dto/request/SanctionRequest.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/request/SanctionRequest.java
@@ -10,8 +10,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SanctionRequest {
 
-    @NotNull(message = "대상 회원 ID는 필수입니다.")
     private Long memberId;
+
+    private String memberLoginId;
 
     @NotNull
     private ActorType actorType;


### PR DESCRIPTION
### Motivation
- Allow sanctions to target a user even when `memberId` is not provided by resolving the target using `memberLoginId` so enforcement reaches the correct account.  
- Ensure enforcement effects continue to be delivered via SSE to the resolved member without changing the chat broadcast/notice flow.  
- Preserve existing chat UI behavior and avoid touching chat-rendering code, only applying the minimal client-side change needed when chat permission is revoked.  

### Description
- Added `memberLoginId` to `SanctionRequest` to accept a login identifier when `memberId` is absent.  
- Added `resolveMember(SanctionRequest)` in `SanctionService` to load the `Member` by `memberId` or `memberLoginId` and used the resolved `member.getMemberId()` for subsequent logic.  
- Updated seller/admin sanction flows in `SanctionService` to call `resolveMember(...)` and to use the resolved member id for `sseService.notifyTargetUser(...)` and `sseService.notifyBroadcastUpdate(...)`.  
- Small frontend UX tweak in `LiveDetail.vue` to clear the chat input when `hasChatPermission` becomes `false` while leaving chat UI flows otherwise unchanged.  

### Testing
- No automated tests were executed for these changes.  
- No CI/build verification was run as part of this rollout.  
- Frontend type checks and linters were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965311832e0832eaed1d39c76090c2b)