### PR TITLE
Resolve sanctions by loginId and alert blocked viewers on rejoin

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -684,6 +684,12 @@ const refreshChatPermission = async () => {
   }
 }
 
+watch(hasChatPermission, (next) => {
+  if (!next) {
+    input.value = ''
+  }
+})
+
 const handleSseEvent = (event: MessageEvent) => {
   const data = parseSseData(event)
   switch (event.type) {
@@ -832,7 +838,12 @@ const requestJoinToken = async () => {
   try {
     streamToken.value = await joinBroadcast(broadcastId.value, viewerId.value)
     joinedBroadcastId.value = broadcastId.value
-  } catch {
+  } catch (error) {
+    const code = (error as { code?: string } | null)?.code
+    if (code === 'B007') {
+      alert('관리자(판매자)에 의해 퇴장 처리되어 방송에 입장할 수 없습니다.')
+      router.push({ name: 'live' }).catch(() => {})
+    }
     return
   } finally {
     joinInFlight.value = false

--- a/src/main/java/com/deskit/deskit/livehost/dto/request/SanctionRequest.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/request/SanctionRequest.java
@@ -10,8 +10,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SanctionRequest {
 
-    @NotNull(message = "대상 회원 ID는 필수입니다.")
     private Long memberId;
+
+    private String memberLoginId;
 
     @NotNull
     private ActorType actorType;


### PR DESCRIPTION
### Motivation
- Allow sanctions to target a user when `memberId` is not provided by resolving the target using `memberLoginId`.
- Ensure SSE notifications are delivered to the correct member after resolution so enforcement reaches the intended account.
- Inform viewers who are blocked from rejoining a broadcast with a clear alert and redirect when re-entry is denied (`B007`).
- Minimize UI changes by only clearing the chat input when chat permission is revoked via `hasChatPermission`.

### Description
- Added `memberLoginId` to `SanctionRequest` to accept a login identifier when `memberId` is absent.
- Implemented `resolveMember(SanctionRequest)` in `SanctionService` and replaced direct `memberId` lookups with the resolved `Member`.
- Updated SSE notifications in `SanctionService` to use `member.getMemberId()` for `sseService.notifyTargetUser(...)` and `sseService.notifyBroadcastUpdate(...)`.
- Updated `front/src/pages/LiveDetail.vue` to clear the chat input when `hasChatPermission` becomes `false` and added error handling in `requestJoinToken` to detect `B007`, show an alert, and redirect to `live`.

### Testing
- No automated tests were executed for these changes.
- No CI or build verification was run.
- Frontend type checks and linters were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965311832e0832eaed1d39c76090c2b)