### PR TITLE
Show dynamic elapsed time for ENDED live cards

### DIFF
--- a/front/src/components/LiveCard.vue
+++ b/front/src/components/LiveCard.vue
@@ -121,9 +121,7 @@ const totalDurationLabel = computed(() => {
 const endedDurationLabel = computed(() => {
   const start = parseLiveDate(props.item.startAt)
   if (Number.isNaN(start.getTime())) return ''
-  const end = parseLiveDate(props.item.endAt)
-  const endMs = Number.isNaN(end.getTime()) ? now.value.getTime() : end.getTime()
-  return formatDuration(endMs - start.getTime())
+  return formatDuration(now.value.getTime() - start.getTime())
 })
 
 const timeLabel = computed(() => {


### PR DESCRIPTION
### Motivation
- The live card displayed an `ENDED` badge showing the total scheduled duration instead of the time elapsed since the broadcast started. 
- The intent is to show how long ago / how long the broadcast lasted dynamically using the current time. 

### Description
- Update `front/src/components/LiveCard.vue` to compute `endedDurationLabel` as `now.value.getTime() - start.getTime()` instead of using the parsed `endAt` fallback. 
- This change ensures the `ENDED` time badge calls `formatDuration` with a dynamic difference based on `now` so the badge updates over time. 

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, which succeeded. 
- Ran a Playwright script to load the homepage and capture a screenshot (`artifacts/home.png`), which completed successfully. 
- No unit tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69653ebd8d98832eba2a636de6092b96)