### PR TITLE
Resolve sanction targets by loginId, add sanction API calls, and handle MUTE/OUT + rejoin block in frontend

### DIFF
--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -499,6 +499,28 @@ export const fetchSanctionStatistics = async (period: string): Promise<SanctionS
   return ensureSuccess(data)
 }
 
+export const sanctionSellerViewer = async (
+  broadcastId: number,
+  payload: { memberLoginId: string; status: 'MUTE' | 'OUT'; reason?: string; connectionId?: string },
+): Promise<void> => {
+  const { data } = await http.post<ApiResult<void>>(`/api/seller/broadcasts/${broadcastId}/sanctions`, {
+    ...payload,
+    actorType: 'SELLER',
+  })
+  return ensureSuccess(data)
+}
+
+export const sanctionAdminViewer = async (
+  broadcastId: number,
+  payload: { memberLoginId: string; status: 'MUTE' | 'OUT'; reason?: string; connectionId?: string },
+): Promise<void> => {
+  const { data } = await http.post<ApiResult<void>>(`/api/admin/broadcasts/${broadcastId}/sanctions`, {
+    ...payload,
+    actorType: 'ADMIN',
+  })
+  return ensureSuccess(data)
+}
+
 export const fetchRecentLiveChats = async (broadcastId: number, seconds = 60): Promise<LiveChatMessage[]> => {
   const { data } = await http.get<ApiResult<LiveChatMessage[]>>(`/livechats/${broadcastId}/recent`, { params: { seconds } })
   return ensureSuccess(data)

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -684,6 +684,12 @@ const refreshChatPermission = async () => {
   }
 }
 
+watch(hasChatPermission, (next) => {
+  if (!next) {
+    input.value = ''
+  }
+})
+
 const handleSseEvent = (event: MessageEvent) => {
   const data = parseSseData(event)
   switch (event.type) {
@@ -832,7 +838,12 @@ const requestJoinToken = async () => {
   try {
     streamToken.value = await joinBroadcast(broadcastId.value, viewerId.value)
     joinedBroadcastId.value = broadcastId.value
-  } catch {
+  } catch (error) {
+    const code = (error as { code?: string } | null)?.code
+    if (code === 'B007') {
+      alert('관리자(판매자)에 의해 퇴장 처리되어 방송에 입장할 수 없습니다.')
+      router.push({ name: 'live' }).catch(() => {})
+    }
     return
   } finally {
     joinInFlight.value = false

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -17,6 +17,7 @@ import {
   fetchSellerBroadcastDetail,
   joinBroadcast,
   leaveBroadcast,
+  sanctionSellerViewer,
   startSellerBroadcast,
   startSellerRecording,
   endSellerBroadcast,
@@ -1497,6 +1498,13 @@ const openSanction = (username: string) => {
 
 const applySanction = (payload: { type: string; reason: string }) => {
   if (!sanctionTarget.value) return
+  if (!broadcastId.value) return
+  const sanctionType = payload.type === '채팅 금지' ? 'MUTE' : 'OUT'
+  void sanctionSellerViewer(broadcastId.value, {
+    memberLoginId: sanctionTarget.value,
+    status: sanctionType,
+    reason: payload.reason,
+  })
   sanctionedUsers.value = {
     ...sanctionedUsers.value,
     [sanctionTarget.value]: { type: payload.type, reason: payload.reason },

--- a/src/main/java/com/deskit/deskit/livehost/dto/request/SanctionRequest.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/request/SanctionRequest.java
@@ -10,8 +10,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SanctionRequest {
 
-    @NotNull(message = "대상 회원 ID는 필수입니다.")
     private Long memberId;
+
+    private String memberLoginId;
 
     @NotNull
     private ActorType actorType;


### PR DESCRIPTION
### Motivation
- Allow applying sanctions when `memberId` is not provided by resolving the target via `memberLoginId` so enforcement reaches the intended account.
- Ensure SSE notifications target the resolved member id so clients receive the correct `SANCTION_ALERT`/`SANCTION_UPDATED` events.
- Let admin and seller UIs trigger backend sanction endpoints so moderation actions take effect server-side as well as locally.
- Improve viewer UX for moderation by clearing chat input on `MUTE` and showing an explicit alert/redirect when re-entry is blocked (`B007`).

### Description
- Backend: added `memberLoginId` to `SanctionRequest` and implemented `resolveMember(SanctionRequest)` in `SanctionService`, replacing direct `memberId` lookups and using `member.getMemberId()` for SSE notifications and broadcast updates.
- Frontend API: added `sanctionSellerViewer` and `sanctionAdminViewer` helpers in `front/src/lib/live/api.ts` to call `/sanctions` endpoints with `actorType` set.
- Admin UI: made `saveModeration` async in `front/src/pages/admin/live/LiveDetail.vue`, call `sanctionAdminViewer(...)` (reason is optional), handle errors with an alert, and continue updating local moderated state and system message on success.
- Seller UI & viewer UX: wired `applySanction` in `front/src/pages/seller/LiveStream.vue` to call `sanctionSellerViewer(...)`, added a `watch` on `hasChatPermission` in `front/src/pages/LiveDetail.vue` to clear the chat input when chat is revoked, and added handling in `requestJoinToken` to detect `B007` and show an alert + redirect to `live`.

### Testing
- No automated tests were executed for these changes.
- CI/build verification was not executed.
- Frontend type checks and linters were not run.
- No automated integration tests were run against SSE/OpenVidu behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965311832e0832eaed1d39c76090c2b)