### PR TITLE
Remove admin and seller video mirroring

### DIFF
--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -1551,7 +1551,6 @@ watch(
   width: 100%;
   height: 100%;
   object-fit: contain;
-  transform: scaleX(-1);
 }
 
 .player-frame--fullscreen {

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -2466,7 +2466,6 @@ const toggleFullscreen = async () => {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transform: scaleX(-1);
 }
 
 .stream-player--fullscreen {


### PR DESCRIPTION
### Motivation
- Make admin and seller views show the same unflipped live stream by removing per-role CSS mirroring.
- Eliminate inconsistency where publisher or viewer video was mirrored using `transform: scaleX(-1)`.
- Simplify video presentation so previews and viewers match the actual camera orientation.

### Description
- Removed the `transform: scaleX(-1)` rule from the video styles in `front/src/pages/seller/LiveStream.vue`.
- Removed the `transform: scaleX(-1)` rule from the video styles in `front/src/pages/admin/live/LiveDetail.vue`.
- Kept existing `width`, `height`, and `object-fit` settings intact to preserve layout and scaling behavior.

### Testing
- No automated tests were run for this change.
- Changes were committed locally with the message `Remove admin and seller video mirroring`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696545eadecc832e89ae19bea39b16c9)