### PR TITLE
Mirror seller broadcast preview (flip publisher video horizontally)

### DIFF
--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -2473,6 +2473,7 @@ const toggleFullscreen = async () => {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transform: scaleX(-1);
 }
 
 .stream-player--fullscreen {


### PR DESCRIPTION
### Motivation
- The seller live broadcast preview should be shown mirrored (left-right flipped) so the on-screen preview matches the seller's expectation.
- This change implements the visual flip only for the publisher preview, leaving viewer streams unchanged.
- Keep the change minimal and scoped to the seller live streaming page UI.

### Description
- Added `transform: scaleX(-1);` to the `.stream-player__publisher :deep(video)` rule in `front/src/pages/seller/LiveStream.vue` to horizontally mirror the publisher video.
- Change is purely CSS inside the scoped style block and does not modify any JavaScript or runtime broadcast logic.
- File updated: `front/src/pages/seller/LiveStream.vue` and committed as "Mirror seller broadcast preview".

### Testing
- No automated tests were executed for this change.
- The change is a single-line CSS tweak intended to affect only the publisher preview element and has no backend impact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654dcccf2c832ea6a175e0e0b97f49)