### PR TITLE
Fix SSE delivery for viewer sanctions

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/SanctionService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/SanctionService.java
@@ -70,6 +70,16 @@ public class SanctionService {
                         "actorType", request.getActorType()
                 )
         );
+        sseService.notifyTargetUser(
+                broadcastId,
+                member.getLoginId(),
+                "SANCTION_ALERT",
+                Map.of(
+                        "type", request.getStatus(),
+                        "reason", request.getReason(),
+                        "actorType", request.getActorType()
+                )
+        );
 
         sseService.notifyBroadcastUpdate(
                 broadcastId,
@@ -109,6 +119,16 @@ public class SanctionService {
         sseService.notifyTargetUser(
                 broadcastId,
                 member.getMemberId(),
+                "SANCTION_ALERT",
+                Map.of(
+                        "type", request.getStatus(),
+                        "reason", request.getReason(),
+                        "actorType", request.getActorType()
+                )
+        );
+        sseService.notifyTargetUser(
+                broadcastId,
+                member.getLoginId(),
                 "SANCTION_ALERT",
                 Map.of(
                         "type", request.getStatus(),

--- a/src/main/java/com/deskit/deskit/livehost/service/SseService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/SseService.java
@@ -92,6 +92,22 @@ public class SseService {
         }
     }
 
+    public void notifyTargetUser(Long broadcastId, String userId, String eventName, Object data) {
+        String resolvedUserId = resolveUserId(userId);
+        String prefix = broadcastId + ":" + resolvedUserId + ":";
+        boolean delivered = false;
+        for (Map.Entry<String, SseEmitter> entry : emitters.entrySet()) {
+            String key = entry.getKey();
+            if (key.startsWith(prefix)) {
+                sendToClient(entry.getValue(), key, eventName, data);
+                delivered = true;
+            }
+        }
+        if (!delivered) {
+            log.warn("Target user not found or disconnected: keyPrefix={}", prefix);
+        }
+    }
+
     private void notifyGlobalUpdate(Long broadcastId, String eventName, Object data) {
         Map<String, Object> payload = Map.of(
                 "broadcastId", broadcastId,


### PR DESCRIPTION
### Motivation
- SSE notifications could be missed when viewers subscribe using a string-based `viewerId` (login ID) while the server targeted only numeric member IDs.
- The goal is to reliably deliver `SANCTION_ALERT` to viewers regardless of whether their SSE subscription key uses a numeric member ID or a string login ID.

### Description
- Add an overloaded `notifyTargetUser(Long, String, String, Object)` in `SseService` that resolves and matches string-based user IDs when sending SSE events.
- Send `SANCTION_ALERT` to both `member.getMemberId()` and `member.getLoginId()` in `SanctionService` for seller and admin sanctions to improve delivery reliability.
- No other behavioral changes to existing broadcast/global SSE flows were made.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696552cfe414832e84e9b98d7eb35090)