### PR TITLE
Align viewer SSE identity and improve SANCTION_ALERT delivery

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/SanctionService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/SanctionService.java
@@ -70,6 +70,16 @@ public class SanctionService {
                         "actorType", request.getActorType()
                 )
         );
+        sseService.notifyTargetUser(
+                broadcastId,
+                member.getLoginId(),
+                "SANCTION_ALERT",
+                Map.of(
+                        "type", request.getStatus(),
+                        "reason", request.getReason(),
+                        "actorType", request.getActorType()
+                )
+        );
 
         sseService.notifyBroadcastUpdate(
                 broadcastId,
@@ -109,6 +119,16 @@ public class SanctionService {
         sseService.notifyTargetUser(
                 broadcastId,
                 member.getMemberId(),
+                "SANCTION_ALERT",
+                Map.of(
+                        "type", request.getStatus(),
+                        "reason", request.getReason(),
+                        "actorType", request.getActorType()
+                )
+        );
+        sseService.notifyTargetUser(
+                broadcastId,
+                member.getLoginId(),
                 "SANCTION_ALERT",
                 Map.of(
                         "type", request.getStatus(),

--- a/src/main/java/com/deskit/deskit/livehost/service/SseService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/SseService.java
@@ -92,6 +92,22 @@ public class SseService {
         }
     }
 
+    public void notifyTargetUser(Long broadcastId, String userId, String eventName, Object data) {
+        String resolvedUserId = resolveUserId(userId);
+        String prefix = broadcastId + ":" + resolvedUserId + ":";
+        boolean delivered = false;
+        for (Map.Entry<String, SseEmitter> entry : emitters.entrySet()) {
+            String key = entry.getKey();
+            if (key.startsWith(prefix)) {
+                sendToClient(entry.getValue(), key, eventName, data);
+                delivered = true;
+            }
+        }
+        if (!delivered) {
+            log.warn("Target user not found or disconnected: keyPrefix={}", prefix);
+        }
+    }
+
     private void notifyGlobalUpdate(Long broadcastId, String eventName, Object data) {
         Map<String, Object> payload = Map.of(
                 "broadcastId", broadcastId,


### PR DESCRIPTION
### Motivation
- Viewer SSE connections were established before session data was hydrated, causing `viewerId` to be a transient/random value and leading to missed `SANCTION_ALERT` deliveries.  
- The server-side targeting assumed numeric member IDs while clients sometimes subscribe with string `loginId` keys, further causing delivery mismatches.  
- The goal is to ensure SSE subscriptions use the hydrated/stable viewer identity and that sanctions reach viewers regardless of whether they subscribed by numeric `memberId` or string `loginId`.

### Description
- Update `front/src/pages/LiveDetail.vue` to call `hydrateSessionUser`, derive a stable `viewerId`, and reconnect SSE when the resolved viewer identity changes, and reuse the resolved viewer id when building the SSE subscription URL.  
- Add `SseService.notifyTargetUser(Long, String, String, Object)` to resolve string user IDs and match emitters keyed by string `loginId`.  
- Modify `SanctionService` to send `SANCTION_ALERT` to both `member.getMemberId()` and `member.getLoginId()` so viewers subscribed by either identifier receive the alert.  
- Keep existing broadcast/global SSE flows unchanged while adding the reconnection and dual-target notifications to improve delivery reliability.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696552cfe414832e84e9b98d7eb35090)