### PR TITLE
[FEAT] 판매자 상품 등록 2단계 플로우 정합성 개선 (초안 생성 → 등록 완료)

### DIFF
--- a/front/src/composables/useSellerProducts.ts
+++ b/front/src/composables/useSellerProducts.ts
@@ -1,6 +1,6 @@
 export type SellerProduct = {
   id: string
-  sellerId: number
+  sellerId?: number
   name: string
   shortDesc: string
   costPrice: number
@@ -40,7 +40,7 @@ const isSellerProduct = (value: any): value is SellerProduct => {
   return (
     value &&
     typeof value.id === 'string' &&
-    typeof value.sellerId === 'number' &&
+    (value.sellerId == null || typeof value.sellerId === 'number') &&
     typeof value.name === 'string' &&
     typeof value.shortDesc === 'string' &&
     typeof value.costPrice === 'number' &&
@@ -62,8 +62,8 @@ const writeAll = (items: SellerProduct[]) => {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(items))
 }
 
-export const getSellerProducts = (sellerId: number): SellerProduct[] => {
-  return readAll().filter((item) => item.sellerId === sellerId)
+export const getSellerProducts = (): SellerProduct[] => {
+  return readAll()
 }
 
 export const getProductById = (id: string): SellerProduct | null => {

--- a/front/src/lib/checkout/checkout-storage.ts
+++ b/front/src/lib/checkout/checkout-storage.ts
@@ -74,7 +74,7 @@ const normalizeShipping = (raw: any): ShippingInfo => ({
 const normalizeDraft = (raw: any): CheckoutDraft | null => {
   if (!raw || typeof raw !== 'object') return null
   const items = Array.isArray(raw.items)
-    ? raw.items.map(normalizeItem).filter((v): v is CheckoutItem => Boolean(v))
+    ? raw.items.map(normalizeItem).filter((v: CheckoutItem | null): v is CheckoutItem => Boolean(v))
     : []
   if (items.length === 0) return null
   const source = raw.source === 'BUY_NOW' ? 'BUY_NOW' : 'CART'

--- a/front/src/pages/seller/ProductCreateInfo.vue
+++ b/front/src/pages/seller/ProductCreateInfo.vue
@@ -3,7 +3,6 @@ import {onMounted, ref} from 'vue'
 import {useRoute, useRouter} from 'vue-router'
 import PageContainer from '../../components/PageContainer.vue'
 import PageHeader from '../../components/PageHeader.vue'
-import {getAuthUser} from '../../lib/auth'
 import {clearProductDraft, loadProductDraft, saveProductDraft} from '../../composables/useSellerProducts'
 
 const route = useRoute()
@@ -18,25 +17,10 @@ const stock = ref(0)
 const images = ref<string[]>(['', '', '', '', ''])
 const error = ref('')
 
-const sellerId = ref<number | null>(null)
-
 const buildAuthHeaders = (): Record<string, string> => {
   const access = localStorage.getItem('access') || sessionStorage.getItem('access')
   if (!access) return {}
   return {Authorization: `Bearer ${access}`}
-}
-
-const deriveSellerId = () => {
-  const user = getAuthUser() as any
-  const candidates = [user?.seller_id, user?.sellerId, user?.id, user?.user_id, user?.userId]
-  for (const value of candidates) {
-    if (typeof value === 'number' && Number.isFinite(value)) return value
-    if (typeof value === 'string') {
-      const parsed = Number.parseInt(value, 10)
-      if (!Number.isNaN(parsed)) return parsed
-    }
-  }
-  return null
 }
 
 const loadDraft = () => {
@@ -58,7 +42,6 @@ const loadDraft = () => {
 const saveDraft = (productId?: number) => {
   saveProductDraft({
     id: productId ? String(productId) : undefined,
-    sellerId: sellerId.value ?? undefined,
     name: name.value.trim(),
     shortDesc: shortDesc.value.trim(),
     costPrice: costPrice.value,
@@ -142,7 +125,6 @@ const cancel = () => {
 }
 
 onMounted(() => {
-  sellerId.value = deriveSellerId()
   const resume = route.query.resume
   const shouldResume = resume === '1' || (Array.isArray(resume) && resume[0] === '1')
   if (shouldResume) {

--- a/src/main/java/com/deskit/deskit/product/controller/SellerProductController.java
+++ b/src/main/java/com/deskit/deskit/product/controller/SellerProductController.java
@@ -6,6 +6,7 @@ import com.deskit.deskit.account.oauth.CustomOAuth2User;
 import com.deskit.deskit.account.repository.SellerRepository;
 import com.deskit.deskit.product.dto.ProductCreateRequest;
 import com.deskit.deskit.product.dto.ProductCreateResponse;
+import com.deskit.deskit.product.dto.ProductDetailUpdateRequest;
 import com.deskit.deskit.product.dto.ProductImageResponse;
 import com.deskit.deskit.product.dto.SellerProductListResponse;
 import com.deskit.deskit.product.dto.SellerProductStatusUpdateRequest;
@@ -76,6 +77,27 @@ public class SellerProductController {
   ) {
     Long sellerId = resolveSellerId(user);
     return ResponseEntity.ok(productService.updateProductStatus(sellerId, productId, request));
+  }
+
+  @PatchMapping("/{productId}/detail")
+  public ResponseEntity<Void> updateProductDetail(
+          @AuthenticationPrincipal CustomOAuth2User user,
+          @PathVariable("productId") Long productId,
+          @Valid @RequestBody ProductDetailUpdateRequest request
+  ) {
+    Long sellerId = resolveSellerId(user);
+    productService.updateProductDetailHtml(sellerId, productId, request);
+    return ResponseEntity.ok().build();
+  }
+
+  @PatchMapping("/{productId}/complete")
+  public ResponseEntity<Void> completeProductRegistration(
+          @AuthenticationPrincipal CustomOAuth2User user,
+          @PathVariable("productId") Long productId
+  ) {
+    Long sellerId = resolveSellerId(user);
+    productService.completeProductRegistration(sellerId, productId);
+    return ResponseEntity.ok().build();
   }
 
   @PostMapping("/{productId}/images")

--- a/src/main/java/com/deskit/deskit/product/dto/ProductCreateRequest.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductCreateRequest.java
@@ -15,7 +15,6 @@ public record ProductCreateRequest(
   String shortDesc,
 
   @JsonProperty("detail_html")
-  @NotBlank
   String detailHtml,
 
   @JsonProperty("price")

--- a/src/main/java/com/deskit/deskit/product/dto/ProductDetailUpdateRequest.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductDetailUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.deskit.deskit.product.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+public record ProductDetailUpdateRequest(
+  @JsonProperty("detail_html")
+  @NotNull
+  String detailHtml
+) {}

--- a/src/main/java/com/deskit/deskit/product/entity/Product.java
+++ b/src/main/java/com/deskit/deskit/product/entity/Product.java
@@ -127,6 +127,13 @@ public class Product extends BaseEntity {
     this.status = next;
   }
 
+  public void changeDetailHtml(String detailHtml) {
+    if (detailHtml == null) {
+      throw new IllegalArgumentException("detail_html required");
+    }
+    this.detailHtml = detailHtml;
+  }
+
   // LIMITED_SALE is derived from ON_SALE + low stock; it is not a persisted transition target.
   public boolean isLimitedSale() {
     if (this.status != Status.ON_SALE) {


### PR DESCRIPTION
## 📌 관련 이슈
- closes #297 

## 📝 작업 내용
- 판매자 상품 등록 2단계 플로우 정책 정리
- 상품 생성(DRAFT)과 등록 완료(READY) 책임 분리
- detail_html 필수 검증 분리 및 전용 업데이트 API 추가
- 상품 등록 완료 API(PATCH /complete) 신설
- 프론트 ProductCreateDetail에서 서버 기준 등록 완료 처리
- draft 기반 임시 sellerId 의존 로직 제거