### PR TITLE
order-live FEAT: update broadcastResult logic added to cancel process

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/entity/BroadcastResult.java
+++ b/src/main/java/com/deskit/deskit/livehost/entity/BroadcastResult.java
@@ -73,6 +73,10 @@ public class BroadcastResult {
         this.totalSales = totalSales;
     }
 
+    public void updateTotalSales(BigDecimal totalSales) {
+        this.totalSales = totalSales;
+    }
+
     public void applyVodStatsDelta(int viewDelta, int likeDelta, int reportDelta) {
         this.totalViews = Math.max(0, this.totalViews + viewDelta);
         this.totalLikes = Math.max(0, this.totalLikes + likeDelta);

--- a/src/main/java/com/deskit/deskit/livehost/repository/BroadcastProductRepository.java
+++ b/src/main/java/com/deskit/deskit/livehost/repository/BroadcastProductRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,6 +23,19 @@ public interface BroadcastProductRepository extends JpaRepository<BroadcastProdu
 
     @Query("SELECT bp.bpQuantity FROM BroadcastProduct bp WHERE bp.broadcast.broadcastId = :bid AND bp.product.id = :pid")
     Integer findStock(@Param("bid") Long bid, @Param("pid") Long pid);
+
+    @Query("""
+            SELECT DISTINCT bp.broadcast.broadcastId
+            FROM BroadcastProduct bp
+            WHERE bp.product.id IN :productIds
+              AND bp.broadcast.startedAt IS NOT NULL
+              AND :paidAt >= bp.broadcast.startedAt
+              AND (bp.broadcast.endedAt IS NULL OR :paidAt <= bp.broadcast.endedAt)
+            """)
+    List<Long> findBroadcastIdsByProductIdsAndPaidAt(
+            @Param("productIds") List<Long> productIds,
+            @Param("paidAt") LocalDateTime paidAt
+    );
 
     @Query("SELECT bp FROM BroadcastProduct bp " +
             "JOIN FETCH bp.product p " +

--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -1355,6 +1355,26 @@ public class BroadcastService {
         return new SalesSummary(totalSales, metrics);
     }
 
+    @Transactional
+    public void refreshBroadcastTotalSales(Long broadcastId) {
+        if (broadcastId == null) {
+            return;
+        }
+        Broadcast broadcast = broadcastRepository.findById(broadcastId)
+                .orElse(null);
+        if (broadcast == null) {
+            return;
+        }
+        BroadcastResult result = broadcastResultRepository.findById(broadcastId).orElse(null);
+        if (result == null) {
+            return;
+        }
+        SalesSummary salesSummary = fetchBroadcastSalesSummary(broadcast);
+        BigDecimal totalSales = salesSummary.totalSales() != null ? salesSummary.totalSales() : BigDecimal.ZERO;
+        result.updateTotalSales(totalSales);
+        broadcastResultRepository.save(result);
+    }
+
     private int countBroadcastChats(Long broadcastId) {
         return (int) liveChatRepository.countByBroadcastIdAndMsgTypeIn(
                 broadcastId,

--- a/src/main/java/com/deskit/deskit/order/service/OrderService.java
+++ b/src/main/java/com/deskit/deskit/order/service/OrderService.java
@@ -1,6 +1,8 @@
 package com.deskit.deskit.order.service;
 
 import com.deskit.deskit.account.repository.MemberRepository;
+import com.deskit.deskit.livehost.repository.BroadcastProductRepository;
+import com.deskit.deskit.livehost.service.BroadcastService;
 import com.deskit.deskit.order.dto.OrderCancelRequest;
 import com.deskit.deskit.order.dto.OrderCancelResponse;
 import com.deskit.deskit.order.dto.CreateOrderItemRequest;
@@ -17,6 +19,8 @@ import com.deskit.deskit.order.repository.OrderItemRepository;
 import com.deskit.deskit.order.repository.OrderRepository;
 import com.deskit.deskit.product.entity.Product;
 import com.deskit.deskit.product.repository.ProductRepository;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,6 +45,8 @@ public class OrderService {
   private final ProductRepository productRepository;
   private final MemberRepository memberRepository;
   private final TossPaymentService tossPaymentService;
+  private final BroadcastProductRepository broadcastProductRepository;
+  private final BroadcastService broadcastService;
 
   public CreateOrderResponse createOrder(Long memberId, CreateOrderRequest request) {
     if (memberId == null) {
@@ -206,10 +212,36 @@ public class OrderService {
     if (order.getStatus() == OrderStatus.REFUND_REQUESTED) {
       tossPaymentService.cancelPayment(order, request.reason());
       order.approveRefund();
+      updateBroadcastSalesAfterRefund(order);
     }
 
     orderRepository.save(order);
     return new OrderCancelResponse(order.getId(), order.getStatus());
+  }
+
+  private void updateBroadcastSalesAfterRefund(Order order) {
+    if (order == null) {
+      return;
+    }
+    LocalDateTime paidAt = order.getPaidAt();
+    if (paidAt == null) {
+      return;
+    }
+    List<OrderItem> items = orderItemRepository.findByOrder_Id(order.getId());
+    if (items.isEmpty()) {
+      return;
+    }
+    List<Long> productIds = items.stream()
+            .map(OrderItem::getProductId)
+            .distinct()
+            .toList();
+    if (productIds.isEmpty()) {
+      return;
+    }
+    List<Long> broadcastIds = broadcastProductRepository.findBroadcastIdsByProductIdsAndPaidAt(productIds, paidAt);
+    for (Long broadcastId : broadcastIds) {
+      broadcastService.refreshBroadcastTotalSales(broadcastId);
+    }
   }
 
   private int safeQuantity(Integer quantity) {


### PR DESCRIPTION
## 📌 관련 이슈

- closes #334 

## 📝 작업 내용

- 주문 환불 뒤에 방송 결과 총매출 업데이트 로직 추가
- 관련 메서드 구현

## 🧐 리뷰 포인트

- OrderService에서 총매출 업데이트 로직이 적절한지 봐주세요.

## ✅ 체크리스트

- [ ] 빌드가 오류 없이 실행되는지 확인했나요?
- [ ] 환불 절차에서 메서드의 위치가 올바른지 확인해주세요.
