### PR TITLE
feat: 배송지 관련 기능을 구현한다

### DIFF
--- a/front/src/api/endpoints.ts
+++ b/front/src/api/endpoints.ts
@@ -8,6 +8,8 @@ export const endpoints = {
   homePopularSetups: '/api/home/popular-setups',
   cart: '/api/cart',
   cartItems: '/api/cart/items',
+  addresses: '/api/addresses',
+  addressDetail: (id: string | number) => `/api/addresses/${id}`,
   orders: '/api/orders',
   orderDetail: (id: string | number) => `/api/orders/${id}`,
   orderStatus: (id: string | number) => `/api/orders/${id}/status`,

--- a/front/src/api/types/orders.ts
+++ b/front/src/api/types/orders.ts
@@ -7,6 +7,10 @@ export interface CreateOrderItemRequest {
 
 export interface CreateOrderRequest {
   items: CreateOrderItemRequest[]
+  receiver: string
+  postcode: string
+  addr_detail: string
+  is_default?: boolean
 }
 
 export interface CreateOrderResponse {

--- a/front/src/lib/checkout/checkout-storage.ts
+++ b/front/src/lib/checkout/checkout-storage.ts
@@ -18,6 +18,7 @@ export type ShippingInfo = {
   zipcode: string
   address1: string
   address2: string
+  isDefault?: boolean
 }
 
 export type PaymentMethod = 'CARD' | 'EASY_PAY' | 'TRANSFER'
@@ -69,6 +70,7 @@ const normalizeShipping = (raw: any): ShippingInfo => ({
   zipcode: typeof raw?.zipcode === 'string' ? raw.zipcode : '',
   address1: typeof raw?.address1 === 'string' ? raw.address1 : '',
   address2: typeof raw?.address2 === 'string' ? raw.address2 : '',
+  isDefault: typeof raw?.isDefault === 'boolean' ? raw.isDefault : undefined,
 })
 
 const normalizeDraft = (raw: any): CheckoutDraft | null => {
@@ -126,6 +128,9 @@ export const updateShipping = (patch: Partial<ShippingInfo>): CheckoutDraft | nu
   }
   if ('address2' in patch) {
     nextPatch.address2 = (patch.address2 ?? '').trim()
+  }
+  if ('isDefault' in patch) {
+    nextPatch.isDefault = Boolean(patch.isDefault)
   }
 
   current.shipping = {

--- a/front/src/pages/MyAddress.vue
+++ b/front/src/pages/MyAddress.vue
@@ -1,0 +1,648 @@
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import PageContainer from '../components/PageContainer.vue'
+import PageHeader from '../components/PageHeader.vue'
+import { createAddress, deleteAddress, getMyAddresses, updateAddress } from '../api/addresses'
+import type { AddressResponse } from '../api/types/addresses'
+
+const router = useRouter()
+const MAX_ADDRESS_COUNT = 3
+
+const addresses = ref<AddressResponse[]>([])
+const isLoading = ref(false)
+const errorMessage = ref('')
+const isFormOpen = ref(false)
+const editingId = ref<number | null>(null)
+
+const form = reactive({
+  receiver: '',
+  postcode: '',
+  address1: '',
+  address2: '',
+  isDefault: false,
+})
+
+const errors = reactive({
+  receiver: '',
+  postcode: '',
+  address1: '',
+})
+
+let postcodeScriptPromise: Promise<void> | null = null
+
+const canAdd = computed(() => addresses.value.length < MAX_ADDRESS_COUNT)
+const isEditing = computed(() => editingId.value !== null)
+
+const loadAddresses = async () => {
+  isLoading.value = true
+  errorMessage.value = ''
+  try {
+    const response = await getMyAddresses()
+    addresses.value = Array.isArray(response) ? response : []
+  } catch (error: any) {
+    const status = error?.response?.status
+    if (status === 401 || status === 403) {
+      router.push('/login').catch(() => {})
+      return
+    }
+    errorMessage.value = '배송지 정보를 불러오지 못했습니다.'
+    addresses.value = []
+  } finally {
+    isLoading.value = false
+  }
+}
+
+const openCreateForm = () => {
+  if (!canAdd.value) {
+    window.alert('배송지는 최대 3개까지 입력 가능해요.')
+    return
+  }
+  editingId.value = null
+  resetForm()
+  isFormOpen.value = true
+}
+
+const openEditForm = (address: AddressResponse) => {
+  editingId.value = address.address_id
+  form.receiver = address.receiver
+  form.postcode = address.postcode
+  form.address1 = address.addr_detail
+  form.address2 = ''
+  form.isDefault = Boolean(address.is_default)
+  errors.receiver = ''
+  errors.postcode = ''
+  errors.address1 = ''
+  errorMessage.value = ''
+  isFormOpen.value = true
+}
+
+const closeForm = () => {
+  isFormOpen.value = false
+  editingId.value = null
+  resetForm()
+}
+
+const resetForm = () => {
+  form.receiver = ''
+  form.postcode = ''
+  form.address1 = ''
+  form.address2 = ''
+  form.isDefault = false
+  errors.receiver = ''
+  errors.postcode = ''
+  errors.address1 = ''
+  errorMessage.value = ''
+}
+
+const validate = () => {
+  errors.receiver = ''
+  errors.postcode = ''
+  errors.address1 = ''
+
+  const receiver = form.receiver.trim()
+  const postcode = form.postcode.trim()
+  const address1 = form.address1.trim()
+
+  if (!receiver) {
+    errors.receiver = '수령인을 입력해주세요.'
+  } else if (!/^[a-zA-Z가-힣]{1,20}$/.test(receiver)) {
+    errors.receiver = '이름은 영문/한글 20글자 이내로 입력해주세요.'
+  }
+
+  if (!postcode) {
+    errors.postcode = '우편번호를 입력해주세요.'
+  } else if (!/^[0-9]{5}$/.test(postcode)) {
+    errors.postcode = '우편번호는 5자리 숫자입니다.'
+  }
+
+  if (!address1) {
+    errors.address1 = '주소를 입력해주세요.'
+  }
+
+  form.receiver = receiver
+  form.postcode = postcode
+  form.address1 = address1
+  form.address2 = form.address2.trim()
+
+  return !errors.receiver && !errors.postcode && !errors.address1
+}
+
+const loadPostcodeScript = () => {
+  if (typeof window === 'undefined') return Promise.reject(new Error('window missing'))
+  if ((window as any).daum?.Postcode) return Promise.resolve()
+  if (!postcodeScriptPromise) {
+    postcodeScriptPromise = new Promise<void>((resolve, reject) => {
+      const script = document.createElement('script')
+      script.src = '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js'
+      script.async = true
+      script.onload = () => resolve()
+      script.onerror = () => reject(new Error('postcode script load failed'))
+      document.head.appendChild(script)
+    })
+  }
+  return postcodeScriptPromise
+}
+
+const openPostcode = async () => {
+  await loadPostcodeScript()
+  const daumPostcode = (window as any).daum?.Postcode
+  if (!daumPostcode) return
+
+  new daumPostcode({
+    oncomplete: (data: any) => {
+      const roadAddr = data.roadAddress || ''
+      const jibunAddr = data.jibunAddress || ''
+      let extraRoadAddr = ''
+
+      if (data.bname && /[가-힣]/.test(data.bname)) {
+        extraRoadAddr += data.bname
+      }
+      if (data.buildingName && data.apartment === 'Y') {
+        extraRoadAddr += extraRoadAddr ? `, ${data.buildingName}` : data.buildingName
+      }
+      if (extraRoadAddr) {
+        extraRoadAddr = ` (${extraRoadAddr})`
+      }
+
+      const address1 = roadAddr ? `${roadAddr}${extraRoadAddr}` : jibunAddr
+      form.postcode = data.zonecode
+      form.address1 = address1
+    },
+  }).open()
+}
+
+const handleSubmit = async () => {
+  if (!isEditing.value && !canAdd.value) {
+    errorMessage.value = '배송지는 최대 3개까지 등록할 수 있습니다.'
+    return
+  }
+  if (!validate()) return
+
+  const addrDetail = [form.address1, form.address2]
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+    .join(' ')
+
+  try {
+    if (isEditing.value && editingId.value !== null) {
+      await updateAddress(editingId.value, {
+        receiver: form.receiver,
+        postcode: form.postcode,
+        addr_detail: addrDetail,
+        is_default: form.isDefault,
+      })
+    } else {
+      await createAddress({
+        receiver: form.receiver,
+        postcode: form.postcode,
+        addr_detail: addrDetail,
+        is_default: form.isDefault,
+      })
+    }
+    await loadAddresses()
+    closeForm()
+  } catch (error: any) {
+    const status = error?.response?.status
+    const serverMessage = String(error?.response?.data?.message ?? '').trim()
+    if (status === 400 && serverMessage) {
+      if (serverMessage.includes('address limit exceeded')) {
+        errorMessage.value = '배송지는 최대 3개까지 등록할 수 있습니다.'
+      } else if (serverMessage.includes('receiver required')) {
+        errorMessage.value = '수령인을 입력해주세요.'
+      } else if (serverMessage.includes('postcode invalid')) {
+        errorMessage.value = '우편번호를 확인해주세요.'
+      } else if (serverMessage.includes('addr_detail required')) {
+        errorMessage.value = '주소를 입력해주세요.'
+      } else {
+        errorMessage.value = '배송지 등록에 실패했습니다.'
+      }
+      return
+    }
+    if (status === 400) {
+      errorMessage.value = '배송지 등록에 실패했습니다.'
+      return
+    }
+    if (status === 401 || status === 403) {
+      router.push('/login').catch(() => {})
+      return
+    }
+    errorMessage.value = '배송지 등록에 실패했습니다.'
+  }
+}
+
+const handleDelete = async (address: AddressResponse) => {
+  if (!window.confirm('배송지를 삭제하시겠습니까?')) {
+    return
+  }
+  try {
+    await deleteAddress(address.address_id)
+    await loadAddresses()
+    if (editingId.value === address.address_id) {
+      closeForm()
+    }
+  } catch (error: any) {
+    const status = error?.response?.status
+    if (status === 401 || status === 403) {
+      router.push('/login').catch(() => {})
+      return
+    }
+    errorMessage.value = '배송지 삭제에 실패했습니다.'
+  }
+}
+
+onMounted(() => {
+  loadAddresses()
+})
+</script>
+
+<template>
+  <PageContainer>
+    <PageHeader eyebrow="DESKIT" title="배송지 관리" />
+
+    <div class="address-wrap">
+      <section class="address-panel">
+        <div class="panel-head">
+          <div>
+            <h3 class="panel-title">등록된 배송지</h3>
+            <p class="panel-sub">총 {{ addresses.length }}개 / 최대 {{ MAX_ADDRESS_COUNT }}개</p>
+          </div>
+          <button type="button" class="btn ghost" @click="openCreateForm">배송지 등록</button>
+        </div>
+
+        <div v-if="isLoading" class="empty-card">
+          <p>배송지 정보를 불러오는 중입니다.</p>
+        </div>
+        <div v-else-if="!addresses.length" class="empty-card">
+          <p>등록된 배송지가 없습니다.</p>
+          <p class="muted">배송지를 등록해 빠르게 주문해보세요.</p>
+        </div>
+        <div v-else class="address-grid">
+          <article v-for="address in addresses" :key="address.address_id" class="address-card">
+            <div class="card-head">
+              <div>
+                <p class="receiver">{{ address.receiver }}</p>
+                <p class="postcode">{{ address.postcode }}</p>
+              </div>
+              <div class="card-actions">
+                <span v-if="address.is_default" class="badge">기본</span>
+                <button type="button" class="icon-btn" @click="handleDelete(address)">X</button>
+              </div>
+            </div>
+            <p class="addr-detail">{{ address.addr_detail }}</p>
+            <div class="card-footer">
+              <button type="button" class="btn ghost" @click="openEditForm(address)">수정</button>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section v-if="isFormOpen" class="address-panel">
+        <div class="panel-head">
+          <div>
+            <h3 class="panel-title">{{ isEditing ? '배송지 수정' : '새 배송지 등록' }}</h3>
+            <p class="panel-sub">기본 배송지는 주문 시 자동으로 선택됩니다.</p>
+          </div>
+          <span v-if="!canAdd" class="limit-pill">최대 등록 완료</span>
+        </div>
+
+        <div class="form">
+          <div class="field">
+            <label for="receiver">수령인</label>
+            <input
+              id="receiver"
+              v-model="form.receiver"
+              type="text"
+              placeholder="이름을 입력해주세요"
+              maxlength="20"
+              @blur="validate"
+            />
+            <p v-if="errors.receiver" class="error">{{ errors.receiver }}</p>
+          </div>
+
+          <div class="field">
+            <label for="postcode">우편번호</label>
+            <div class="field-row">
+              <input
+                id="postcode"
+                v-model="form.postcode"
+                type="text"
+                placeholder="12345"
+                maxlength="5"
+                inputmode="numeric"
+                pattern="\\d{5}"
+                readonly
+                @blur="validate"
+              />
+              <button type="button" class="btn ghost btn-inline" @click="openPostcode">
+                우편번호 찾기
+              </button>
+            </div>
+            <p v-if="errors.postcode" class="error">{{ errors.postcode }}</p>
+          </div>
+
+          <div class="field">
+            <label for="address1">주소</label>
+            <input
+              id="address1"
+              v-model="form.address1"
+              type="text"
+              placeholder="주소를 입력해주세요"
+              readonly
+              @blur="validate"
+            />
+            <p v-if="errors.address1" class="error">{{ errors.address1 }}</p>
+          </div>
+
+          <div class="field">
+            <label for="address2">상세주소</label>
+            <input
+              id="address2"
+              v-model="form.address2"
+              type="text"
+              placeholder="예) 101동 101호"
+            />
+          </div>
+
+          <div class="field field--checkbox">
+            <label class="checkbox">
+              <input v-model="form.isDefault" type="checkbox" />
+              <span>기본 배송지로 설정</span>
+            </label>
+          </div>
+
+          <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
+
+          <div class="actions">
+            <button type="button" class="btn ghost" @click="closeForm">닫기</button>
+            <button
+              type="button"
+              class="btn primary"
+              :disabled="!isEditing && !canAdd"
+              @click="handleSubmit"
+            >
+              {{ isEditing ? '수정 완료' : '배송지 등록' }}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  </PageContainer>
+</template>
+
+<style scoped>
+.address-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.address-panel {
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.panel-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 900;
+  color: var(--text-strong);
+}
+
+.panel-sub {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.limit-pill {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-weak);
+  font-size: 12px;
+  font-weight: 800;
+  color: var(--text-muted);
+}
+
+.empty-card {
+  border: 1px dashed var(--border-color);
+  border-radius: 12px;
+  padding: 14px;
+  color: var(--text-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.muted {
+  margin: 0;
+  font-weight: 700;
+}
+
+.address-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.address-card {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--surface-weak);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.card-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.receiver {
+  margin: 0;
+  font-weight: 900;
+  color: var(--text-strong);
+}
+
+.postcode {
+  margin: 2px 0 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  font-weight: 700;
+}
+
+.badge {
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(34, 197, 94, 0.4);
+  color: #16a34a;
+  background: rgba(34, 197, 94, 0.1);
+  font-weight: 800;
+  font-size: 12px;
+}
+
+.addr-detail {
+  margin: 0;
+  color: var(--text-strong);
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.card-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.field label {
+  display: block;
+  margin-bottom: 6px;
+  font-weight: 800;
+  color: var(--text-strong);
+}
+
+.field input {
+  width: 100%;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: var(--surface-weak);
+  color: var(--text-strong);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.field-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.field-row input {
+  flex: 1;
+}
+
+.btn-inline {
+  white-space: nowrap;
+}
+
+.field input:focus {
+  border-color: var(--primary-color);
+  background: var(--surface);
+}
+
+.field--checkbox {
+  margin-top: 4px;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 800;
+  color: var(--text-strong);
+}
+
+.checkbox input {
+  width: 16px;
+  height: 16px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn {
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.btn.ghost {
+  color: var(--text-strong);
+}
+
+.btn.primary {
+  background: var(--primary-color);
+  border-color: var(--primary-color);
+  color: #fff;
+}
+
+.icon-btn {
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  font-weight: 900;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-btn:hover,
+.icon-btn:focus-visible {
+  color: var(--text-strong);
+  border-color: var(--primary-color);
+  outline: none;
+}
+
+.btn.primary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.error {
+  margin: 6px 0 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--danger-color, #dc2626);
+}
+
+@media (max-width: 720px) {
+  .panel-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .actions {
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/front/src/router/index.ts
+++ b/front/src/router/index.ts
@@ -93,6 +93,11 @@ const routes: RouteRecordRaw[] = [
     component: () => import('../pages/MyPage.vue'),
   },
   {
+    path: '/my/address',
+    name: 'my-address',
+    component: () => import('../pages/MyAddress.vue'),
+  },
+  {
     path: '/my/orders',
     name: 'order-history',
     component: () => import('../pages/OrderHistory.vue'),

--- a/src/main/java/com/deskit/deskit/account/address/controller/AddressController.java
+++ b/src/main/java/com/deskit/deskit/account/address/controller/AddressController.java
@@ -1,0 +1,130 @@
+package com.deskit.deskit.account.address.controller;
+
+import com.deskit.deskit.account.entity.Member;
+import com.deskit.deskit.account.oauth.CustomOAuth2User;
+import com.deskit.deskit.account.repository.MemberRepository;
+import com.deskit.deskit.account.address.dto.AddressCreateRequest;
+import com.deskit.deskit.account.address.dto.AddressResponse;
+import com.deskit.deskit.account.address.dto.AddressUpdateRequest;
+import com.deskit.deskit.account.address.service.AddressService;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/addresses")
+public class AddressController {
+
+  private final AddressService addressService;
+  private final MemberRepository memberRepository;
+
+  public AddressController(AddressService addressService, MemberRepository memberRepository) {
+    this.addressService = addressService;
+    this.memberRepository = memberRepository;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<AddressResponse>> getMyAddresses(
+      @AuthenticationPrincipal CustomOAuth2User user
+  ) {
+    Long memberId = resolveMemberId(user);
+    return ResponseEntity.ok(addressService.getMyAddresses(memberId));
+  }
+
+  @PostMapping
+  public ResponseEntity<AddressResponse> createAddress(
+      @AuthenticationPrincipal CustomOAuth2User user,
+      @Valid @RequestBody AddressCreateRequest request
+  ) {
+    Long memberId = resolveMemberId(user);
+    return ResponseEntity.ok(addressService.createAddress(memberId, request));
+  }
+
+  @PatchMapping("/{addressId}")
+  public ResponseEntity<AddressResponse> updateAddress(
+      @AuthenticationPrincipal CustomOAuth2User user,
+      @PathVariable("addressId") Long addressId,
+      @Valid @RequestBody AddressUpdateRequest request
+  ) {
+    Long memberId = resolveMemberId(user);
+    return ResponseEntity.ok(addressService.updateAddress(memberId, addressId, request));
+  }
+
+  @DeleteMapping("/{addressId}")
+  public ResponseEntity<Void> deleteAddress(
+      @AuthenticationPrincipal CustomOAuth2User user,
+      @PathVariable("addressId") Long addressId
+  ) {
+    Long memberId = resolveMemberId(user);
+    addressService.deleteAddress(memberId, addressId);
+    return ResponseEntity.noContent().build();
+  }
+
+  private Long resolveMemberId(CustomOAuth2User user) {
+    if (user == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "unauthorized");
+    }
+
+    Long memberId = tryExtractMemberId(user);
+    if (memberId != null) {
+      return memberId;
+    }
+
+    String loginId = user.getUsername();
+    if (loginId == null || loginId.isBlank()) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found");
+    }
+
+    Member member = memberRepository.findByLoginId(loginId);
+    if (member == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found");
+    }
+
+    return member.getMemberId();
+  }
+
+  private Long tryExtractMemberId(CustomOAuth2User user) {
+    Map<String, Object> attributes = user.getAttributes();
+    if (attributes == null || attributes.isEmpty()) {
+      return null;
+    }
+
+    Object value = attributes.get("memberId");
+    if (value == null) {
+      value = attributes.get("member_id");
+    }
+    if (value == null) {
+      value = attributes.get("id");
+    }
+
+    if (value instanceof Number) {
+      return ((Number) value).longValue();
+    }
+
+    if (value instanceof String) {
+      String text = ((String) value).trim();
+      if (text.isEmpty()) {
+        return null;
+      }
+      try {
+        return Long.parseLong(text);
+      } catch (NumberFormatException ex) {
+        return null;
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/deskit/deskit/account/address/dto/AddressCreateRequest.java
+++ b/src/main/java/com/deskit/deskit/account/address/dto/AddressCreateRequest.java
@@ -1,18 +1,11 @@
-package com.deskit.deskit.order.dto;
+package com.deskit.deskit.account.address.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import java.util.List;
 
-public record CreateOrderRequest(
-  @JsonProperty("items")
-  @NotNull
-  @Size(min = 1)
-  List<CreateOrderItemRequest> items,
-
+public record AddressCreateRequest(
   @JsonProperty("receiver")
   @NotBlank
   @Size(max = 20)

--- a/src/main/java/com/deskit/deskit/account/address/dto/AddressResponse.java
+++ b/src/main/java/com/deskit/deskit/account/address/dto/AddressResponse.java
@@ -1,0 +1,34 @@
+package com.deskit.deskit.account.address.dto;
+
+import com.deskit.deskit.account.address.entity.Address;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AddressResponse(
+  @JsonProperty("address_id")
+  Long addressId,
+
+  @JsonProperty("receiver")
+  String receiver,
+
+  @JsonProperty("postcode")
+  String postcode,
+
+  @JsonProperty("addr_detail")
+  String addrDetail,
+
+  @JsonProperty("is_default")
+  Boolean isDefault
+) {
+  public static AddressResponse from(Address address) {
+    if (address == null) {
+      return new AddressResponse(null, null, null, null, null);
+    }
+    return new AddressResponse(
+      address.getId(),
+      address.getReceiver(),
+      address.getPostcode(),
+      address.getAddrDetail(),
+      Boolean.TRUE.equals(address.getIsDefault())
+    );
+  }
+}

--- a/src/main/java/com/deskit/deskit/account/address/dto/AddressUpdateRequest.java
+++ b/src/main/java/com/deskit/deskit/account/address/dto/AddressUpdateRequest.java
@@ -1,18 +1,11 @@
-package com.deskit.deskit.order.dto;
+package com.deskit.deskit.account.address.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import java.util.List;
 
-public record CreateOrderRequest(
-  @JsonProperty("items")
-  @NotNull
-  @Size(min = 1)
-  List<CreateOrderItemRequest> items,
-
+public record AddressUpdateRequest(
   @JsonProperty("receiver")
   @NotBlank
   @Size(max = 20)

--- a/src/main/java/com/deskit/deskit/account/address/entity/Address.java
+++ b/src/main/java/com/deskit/deskit/account/address/entity/Address.java
@@ -1,0 +1,69 @@
+package com.deskit.deskit.account.address.entity;
+
+import com.deskit.deskit.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "address")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "address_id", nullable = false)
+  private Long id;
+
+  @Column(name = "member_id", nullable = false)
+  private Long memberId;
+
+  @Column(name = "receiver", nullable = false, length = 20)
+  private String receiver;
+
+  @Column(name = "postcode", nullable = false, length = 10)
+  private String postcode;
+
+  @Column(name = "addr_detail", nullable = false, length = 255)
+  private String addrDetail;
+
+  @Column(name = "is_default", nullable = false)
+  private Boolean isDefault;
+
+  public static Address create(
+      Long memberId,
+      String receiver,
+      String postcode,
+      String addrDetail,
+      boolean isDefault
+  ) {
+    Address address = new Address();
+    address.memberId = memberId;
+    address.receiver = receiver;
+    address.postcode = postcode;
+    address.addrDetail = addrDetail;
+    address.isDefault = isDefault;
+    return address;
+  }
+
+  public void markDefault(boolean value) {
+    this.isDefault = value;
+  }
+
+  public void update(String receiver, String postcode, String addrDetail) {
+    this.receiver = receiver;
+    this.postcode = postcode;
+    this.addrDetail = addrDetail;
+  }
+
+  public Boolean getIsDefault() {
+    return isDefault;
+  }
+}

--- a/src/main/java/com/deskit/deskit/account/address/repository/AddressRepository.java
+++ b/src/main/java/com/deskit/deskit/account/address/repository/AddressRepository.java
@@ -1,0 +1,26 @@
+package com.deskit.deskit.account.address.repository;
+
+import com.deskit.deskit.account.address.entity.Address;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+
+  long countByMemberId(Long memberId);
+
+  List<Address> findByMemberIdOrderByIsDefaultDescIdDesc(Long memberId);
+
+  boolean existsByMemberIdAndIsDefaultTrue(Long memberId);
+
+  Optional<Address> findByIdAndMemberId(Long id, Long memberId);
+
+  Optional<Address> findByMemberIdAndIsDefaultTrue(Long memberId);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("update Address a set a.isDefault = false where a.memberId = :memberId and a.isDefault = true")
+  int clearDefaultByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/deskit/deskit/account/address/service/AddressService.java
+++ b/src/main/java/com/deskit/deskit/account/address/service/AddressService.java
@@ -1,0 +1,171 @@
+package com.deskit.deskit.account.address.service;
+
+import com.deskit.deskit.account.repository.MemberRepository;
+import com.deskit.deskit.account.address.dto.AddressCreateRequest;
+import com.deskit.deskit.account.address.dto.AddressResponse;
+import com.deskit.deskit.account.address.dto.AddressUpdateRequest;
+import com.deskit.deskit.account.address.entity.Address;
+import com.deskit.deskit.account.address.repository.AddressRepository;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AddressService {
+
+  private static final int MAX_ADDRESS_COUNT = 3;
+  private static final Pattern POSTCODE_PATTERN = Pattern.compile("\\d{5}");
+
+  private final AddressRepository addressRepository;
+  private final MemberRepository memberRepository;
+
+  @Transactional(readOnly = true)
+  public List<AddressResponse> getMyAddresses(Long memberId) {
+    ensureMemberExists(memberId);
+    return addressRepository.findByMemberIdOrderByIsDefaultDescIdDesc(memberId)
+      .stream()
+      .map(AddressResponse::from)
+      .collect(Collectors.toList());
+  }
+
+  public AddressResponse createAddress(Long memberId, AddressCreateRequest request) {
+    ensureMemberExists(memberId);
+    if (request == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "request required");
+    }
+
+    String receiver = normalizeReceiver(request.receiver());
+    String postcode = normalizePostcode(request.postcode());
+    String addrDetail = normalizeAddrDetail(request.addrDetail());
+
+    long count = addressRepository.countByMemberId(memberId);
+    if (count >= MAX_ADDRESS_COUNT) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "address limit exceeded");
+    }
+
+    boolean requestedDefault = Boolean.TRUE.equals(request.isDefault());
+    boolean isDefault = requestedDefault || count == 0;
+    if (isDefault) {
+      addressRepository.clearDefaultByMemberId(memberId);
+    }
+
+    Address address = Address.create(memberId, receiver, postcode, addrDetail, isDefault);
+    return AddressResponse.from(addressRepository.save(address));
+  }
+
+  public AddressResponse updateAddress(Long memberId, Long addressId, AddressUpdateRequest request) {
+    ensureMemberExists(memberId);
+    if (addressId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "address_id required");
+    }
+    if (request == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "request required");
+    }
+
+    Address address = addressRepository.findByIdAndMemberId(addressId, memberId)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "address not found"));
+
+    String receiver = normalizeReceiver(request.receiver());
+    String postcode = normalizePostcode(request.postcode());
+    String addrDetail = normalizeAddrDetail(request.addrDetail());
+
+    boolean requestedDefault = Boolean.TRUE.equals(request.isDefault());
+    if (requestedDefault) {
+      addressRepository.clearDefaultByMemberId(memberId);
+    }
+
+    address.markDefault(requestedDefault);
+    address.update(receiver, postcode, addrDetail);
+    return AddressResponse.from(addressRepository.save(address));
+  }
+
+  public void deleteAddress(Long memberId, Long addressId) {
+    ensureMemberExists(memberId);
+    if (addressId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "address_id required");
+    }
+    Address address = addressRepository.findByIdAndMemberId(addressId, memberId)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "address not found"));
+    addressRepository.delete(address);
+  }
+
+  public void saveAddressFromOrder(
+    Long memberId,
+    String receiver,
+    String postcode,
+    String addrDetail,
+    Boolean saveAsDefault
+  ) {
+    if (memberId == null) {
+      return;
+    }
+
+    String normalizedReceiver = normalizeReceiver(receiver);
+    String normalizedPostcode = normalizePostcode(postcode);
+    String normalizedAddrDetail = normalizeAddrDetail(addrDetail);
+
+    long count = addressRepository.countByMemberId(memberId);
+    boolean shouldSave = Boolean.TRUE.equals(saveAsDefault) || count == 0;
+    if (!shouldSave) {
+      return;
+    }
+    if (count >= MAX_ADDRESS_COUNT) {
+      return;
+    }
+
+    boolean requestedDefault = Boolean.TRUE.equals(saveAsDefault);
+    boolean isDefault = requestedDefault || count == 0;
+    if (isDefault) {
+      addressRepository.clearDefaultByMemberId(memberId);
+    }
+
+    Address address = Address.create(
+      memberId,
+      normalizedReceiver,
+      normalizedPostcode,
+      normalizedAddrDetail,
+      isDefault
+    );
+    addressRepository.save(address);
+  }
+
+  private void ensureMemberExists(Long memberId) {
+    if (memberId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "member_id required");
+    }
+    if (!memberRepository.existsById(memberId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "member not found");
+    }
+  }
+
+  private String normalizeReceiver(String receiver) {
+    String normalized = receiver == null ? "" : receiver.trim();
+    if (normalized.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "receiver required");
+    }
+    return normalized.length() > 20 ? normalized.substring(0, 20) : normalized;
+  }
+
+  private String normalizePostcode(String postcode) {
+    String normalized = postcode == null ? "" : postcode.trim();
+    if (!POSTCODE_PATTERN.matcher(normalized).matches()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "postcode invalid");
+    }
+    return normalized;
+  }
+
+  private String normalizeAddrDetail(String addrDetail) {
+    String normalized = addrDetail == null ? "" : addrDetail.trim();
+    if (normalized.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "addr_detail required");
+    }
+    return normalized.length() > 255 ? normalized.substring(0, 255) : normalized;
+  }
+}

--- a/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
+++ b/src/main/java/com/deskit/deskit/common/config/SecurityConfig.java
@@ -119,6 +119,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(HttpMethod.PATCH, "/api/orders/**").hasAuthority("ROLE_MEMBER")
+                        .requestMatchers("/api/addresses/**").hasAuthority("ROLE_MEMBER")
                         .requestMatchers(HttpMethod.PATCH, "/api/seller/products/**")
                         .hasAnyAuthority("ROLE_SELLER", "ROLE_SELLER_OWNER", "ROLE_SELLER_MANAGER")
                         .requestMatchers(HttpMethod.GET,

--- a/src/main/java/com/deskit/deskit/order/entity/Order.java
+++ b/src/main/java/com/deskit/deskit/order/entity/Order.java
@@ -47,6 +47,13 @@ public class Order extends BaseEntity {
   private Long memberId;
 
   /**
+   * Shipping address detail snapshot.
+   * - addr_detail (nullable)
+   */
+  @Column(name = "addr_detail", length = 255)
+  private String addrDetail;
+
+  /**
    * 주문번호(외부 노출용 식별자)
    * - order_number (VARCHAR(50))
    * - 보통 "ORD-YYYYMMDD-XXXX" 같은 규칙으로 생성
@@ -128,6 +135,7 @@ public class Order extends BaseEntity {
    */
   public static Order create(
           Long memberId,
+          String addrDetail,
           String orderNumber,
           Integer totalProductAmount,
           Integer shippingFee,
@@ -137,6 +145,7 @@ public class Order extends BaseEntity {
   ) {
     Order order = new Order();
     order.memberId = memberId;
+    order.addrDetail = addrDetail;
     order.orderNumber = orderNumber;
     order.totalProductAmount = totalProductAmount;
     order.shippingFee = shippingFee;

--- a/src/main/resources/sql/livecommerce_create_table.sql
+++ b/src/main/resources/sql/livecommerce_create_table.sql
@@ -1,7 +1,8 @@
 -- =========================================================
 -- DESKIT & LIVE COMMERCE INTEGRATED DB SCHEMA
--- 최근작성일: 2026-01-06
+-- 최근작성일: 2026-01-13
 -- 수정사항:
+-- order 테이블 컬럼 추가, address 테이블 추가 (26.01.13)
 -- chat_info, chat_handoff 테이블 updated_at 컬럼 추가 (26.01.06)
 -- broadcast_result, view_history 테이블 컬럼 수정 (26.01.05)
 -- seller_grade 테이블 컬럼(grade) 수정 : enum 요소 추가 (26.01.04)
@@ -60,6 +61,7 @@ DROP TABLE IF EXISTS company_registered;
 DROP TABLE IF EXISTS seller_register;
 DROP TABLE IF EXISTS seller;
 DROP TABLE IF EXISTS admin;
+DROP TABLE IF EXISTS address;
 DROP TABLE IF EXISTS member;
 
 -- [Payment & CS]
@@ -98,6 +100,21 @@ CREATE TABLE member
     PRIMARY KEY (member_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='회원';
+
+CREATE TABLE address
+(
+    address_id  BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '배송지 ID',
+    member_id   BIGINT UNSIGNED NOT NULL COMMENT '회원 ID(논리 FK: member)',
+    receiver    VARCHAR(20)     NOT NULL COMMENT '수령인',
+    postcode    VARCHAR(10)     NOT NULL COMMENT '우편번호',
+    addr_detail VARCHAR(255)    NOT NULL COMMENT '주소',
+    is_default  TINYINT         NOT NULL DEFAULT 0 COMMENT '기본 배송지 여부',
+    created_at  DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 시각',
+    updated_at  DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시각',
+    PRIMARY KEY (address_id),
+    KEY idx_address_member (member_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='배송지';
 
 CREATE TABLE seller
 (
@@ -289,6 +306,7 @@ CREATE TABLE `order`
 (
     order_id             BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '주문 ID',
     member_id            BIGINT UNSIGNED NOT NULL COMMENT '회원 ID(논리 FK: member)',
+    addr_detail          VARCHAR(255)    NULL COMMENT '배송지 주소',
     order_number         VARCHAR(50)     NOT NULL COMMENT '구매자 노출 주문번호(유니크)',
     total_product_amount INT UNSIGNED    NOT NULL COMMENT '상품 총액(상품가 합)',
     shipping_fee         INT UNSIGNED    NOT NULL DEFAULT 0 COMMENT '배송비(추후 확장)',
@@ -704,6 +722,10 @@ ALTER TABLE cart_item
     ADD CONSTRAINT FK_cart_item_cart FOREIGN KEY (cart_id) REFERENCES cart (cart_id);
 ALTER TABLE cart_item
     ADD CONSTRAINT FK_cart_item_product FOREIGN KEY (product_id) REFERENCES product (product_id);
+
+-- [Address Relations]
+ALTER TABLE address
+    ADD CONSTRAINT FK_address_member FOREIGN KEY (member_id) REFERENCES member (member_id);
 
 -- [Order Relations] (테이블명 `order`에 백틱 사용)
 ALTER TABLE `order`


### PR DESCRIPTION
## 📌 관련 이슈

- closes #271 

## 📝 작업 내용

- 마이페이지에 배송지 관리 페이지를 구현하였습니다.
- order 테이블에 배송 주소 컬럼을 추가했고, address 테이블을 새로 만들어서 배송지 정보를 저장할 수 있습니다.
- 기본 배송지는 1개 등록할 수 있고 주문 결제 화면에서 우선적으로 선택됩니다.
- 배송지를 등록/수정/삭제 가능하며, 최대 3개까지 등록 가능합니다.
- 배송지를 등록하지 않은 경우에는 주문 결제 화면에서 배송지를 등록할 수 있습니다.

## 🧐 리뷰 포인트

- 마이페이지 > 배송지 관리
- 상품 > 결제 > 주문 결제 페이지
