### PR TITLE
Use product `price` for live listings, restore original cost on sellout, and add frontend price refresh

### DIFF
--- a/front/src/lib/cart/cart-storage.ts
+++ b/front/src/lib/cart/cart-storage.ts
@@ -144,6 +144,34 @@ export const setAllSelected = (selected: boolean): StoredCartItem[] => {
   return updated
 }
 
+export const updateCartItemsPricing = (
+  patches: Array<{
+    productId: string
+    price: number
+    originalPrice: number
+    discountRate: number
+    stock: number
+  }>,
+): StoredCartItem[] => {
+  if (!Array.isArray(patches) || patches.length === 0) return loadCart()
+  const patchMap = new Map(patches.map((patch) => [String(patch.productId), patch]))
+  const updated = loadCart().map((item) => {
+    const patch = patchMap.get(item.productId)
+    if (!patch) return item
+    const stock = Math.max(1, Number(patch.stock ?? item.stock) || item.stock)
+    return {
+      ...item,
+      price: patch.price,
+      originalPrice: patch.originalPrice,
+      discountRate: patch.discountRate,
+      stock,
+      quantity: clamp(item.quantity, 1, stock),
+    }
+  })
+  saveCart(updated)
+  return updated
+}
+
 export const removeCartItemsByProductIds = (productIds: string[]): StoredCartItem[] => {
   if (!Array.isArray(productIds) || productIds.length === 0) return loadCart()
   const set = new Set(productIds.map((id) => String(id)))

--- a/front/src/lib/live/api.ts
+++ b/front/src/lib/live/api.ts
@@ -67,6 +67,7 @@ export type BroadcastProductItem = {
   name: string
   imageUrl: string
   price: number
+  originalPrice?: number
   totalQty?: number
   isPinned?: boolean
   isSoldOut: boolean
@@ -346,7 +347,9 @@ export const fetchBroadcastProducts = async (broadcastId: number): Promise<Broad
         productId: number
         name: string
         imageUrl?: string
+        originalPrice?: number
         bpPrice: number
+        originalCostPrice?: number
         bpQuantity: number
         stockQty?: number
         status: string
@@ -361,6 +364,7 @@ export const fetchBroadcastProducts = async (broadcastId: number): Promise<Broad
     name: item.name,
     imageUrl: item.imageUrl ?? '',
     price: item.bpPrice,
+    originalPrice: item.originalPrice ?? item.bpPrice,
     totalQty: item.bpQuantity,
     isPinned: item.isPinned ?? item.pinned ?? false,
     isSoldOut: item.status === 'SOLDOUT' || item.bpQuantity <= 0,

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -1566,7 +1566,15 @@ onBeforeUnmount(() => {
             <img class="product-card__thumb" :src="product.imageUrl" :alt="product.name" @error="handleImageError" />
             <div class="product-card__info">
               <p class="product-card__name">{{ product.name }}</p>
-              <p class="product-card__price">{{ formatPrice(product.price) }}</p>
+              <p class="product-card__price">
+                <span
+                  v-if="product.originalPrice && product.originalPrice > product.price"
+                  class="product-card__price--original"
+                >
+                  {{ formatPrice(product.originalPrice) }}
+                </span>
+                <span class="product-card__price--sale">{{ formatPrice(product.price) }}</span>
+              </p>
               <span v-if="product.isSoldOut" class="product-card__badge">품절</span>
             </div>
           </button>
@@ -1712,6 +1720,21 @@ onBeforeUnmount(() => {
   margin: 0;
   color: var(--text-muted);
   font-size: 0.95rem;
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+
+.product-card__price--original {
+  color: var(--text-soft);
+  font-weight: 600;
+  text-decoration: line-through;
+  font-size: 0.85rem;
+}
+
+.product-card__price--sale {
+  color: var(--text-strong);
+  font-weight: 700;
 }
 
 .product-card__badge {

--- a/front/src/pages/ProductDetail.vue
+++ b/front/src/pages/ProductDetail.vue
@@ -13,26 +13,44 @@ const productId = computed(() => (Array.isArray(route.params.id) ? route.params.
 
 const rawProduct = ref<DbProduct | null>(null)
 const isLoading = ref(false)
+const priceNotice = ref('')
+const pricePollTimer = ref<number | null>(null)
 
-const loadProduct = async () => {
+const loadProduct = async (options: { silent?: boolean; notifyOnChange?: boolean } = {}) => {
   const id = productId.value ? String(productId.value) : ''
   if (!id) {
     rawProduct.value = null
     return
   }
-  isLoading.value = true
+  if (!options.silent) {
+    isLoading.value = true
+  }
+  const previous = rawProduct.value as any
   try {
-    rawProduct.value = await getProductDetail(id)
+    const next = await getProductDetail(id)
+    if (options.notifyOnChange && previous && next) {
+      const prevPrice = Number(previous.price ?? 0) || 0
+      const prevCost = Number(previous.cost_price ?? previous.costPrice ?? prevPrice) || prevPrice
+      const nextPrice = Number((next as any).price ?? 0) || 0
+      const nextCost = Number((next as any).cost_price ?? (next as any).costPrice ?? nextPrice) || nextPrice
+      if (prevPrice !== nextPrice || prevCost !== nextCost) {
+        priceNotice.value = '가격이 변경되어 최신 정보로 업데이트했습니다.'
+      }
+    }
+    rawProduct.value = next
   } catch (error) {
     console.error('Failed to load product.', error)
     rawProduct.value = null
   } finally {
-    isLoading.value = false
+    if (!options.silent) {
+      isLoading.value = false
+    }
   }
 }
 
 watch(productId, () => {
-  loadProduct()
+  priceNotice.value = ''
+  loadProduct({ notifyOnChange: false })
 }, { immediate: true })
 
 const product = computed(() => {
@@ -217,12 +235,18 @@ watch(
 onMounted(() => {
   window.addEventListener('keydown', handleEsc)
   window.addEventListener('keydown', handleTrapFocus)
+  pricePollTimer.value = window.setInterval(() => {
+    loadProduct({ silent: true, notifyOnChange: true })
+  }, 15000)
 })
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', handleEsc)
   window.removeEventListener('keydown', handleTrapFocus)
   document.body.style.overflow = ''
+  if (pricePollTimer.value) {
+    window.clearInterval(pricePollTimer.value)
+  }
 })
 </script>
 
@@ -232,6 +256,10 @@ onBeforeUnmount(() => {
 
     <div v-if="isLoading" class="empty">상품 정보를 불러오는 중...</div>
     <div v-else-if="product" class="card">
+      <div v-if="priceNotice" class="price-notice">
+        <span>{{ priceNotice }}</span>
+        <button type="button" class="price-notice__close" @click="priceNotice = ''">닫기</button>
+      </div>
       <div class="media">
         <div class="thumbs" v-if="imageList.length">
           <button
@@ -343,6 +371,27 @@ onBeforeUnmount(() => {
   border-radius: 16px;
   overflow: hidden;
   box-shadow: var(--shadow-card);
+}
+
+.price-notice {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--surface-weak);
+  border-bottom: 1px solid var(--border-color);
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.price-notice__close {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-weight: 700;
+  cursor: pointer;
 }
 
 .media {

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -235,6 +235,7 @@ const mapLiveProduct = (item: {
   id: string
   name: string
   price: number
+  originalPrice?: number
   isSoldOut: boolean
   isPinned?: boolean
   imageUrl?: string
@@ -244,11 +245,12 @@ const mapLiveProduct = (item: {
   const totalQty = item.totalQty ?? item.stockQty ?? 0
   const stockQty = item.stockQty ?? totalQty
   const sold = Math.max(0, totalQty - stockQty)
+  const originalPrice = item.originalPrice && item.originalPrice > item.price ? item.originalPrice : item.price
   return {
     id: item.id,
     name: item.name,
     option: item.name,
-    price: `₩${item.price.toLocaleString('ko-KR')}`,
+    price: `₩${originalPrice.toLocaleString('ko-KR')}`,
     sale: `₩${item.price.toLocaleString('ko-KR')}`,
     status: item.isSoldOut ? '품절' : '판매중',
     thumb: item.imageUrl ?? '',

--- a/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
@@ -14,6 +14,7 @@ public class BroadcastProductResponse {
     private String name;          // 상품명 (Product API 연동 필요)
     private String imageUrl;      // 상품 이미지 (Product API 연동 필요)
     private int originalPrice;    // 원가
+    private Integer originalCostPrice; // 방송 시작 전 판매 원가
     private int stockQty;         // 방송 판매 수량 기준 재고
     private int safetyStock;      // 안전 재고
     private int productStockQty;  // 상품 원본 재고 수량
@@ -25,10 +26,14 @@ public class BroadcastProductResponse {
     private BroadcastProductStatus status;        // 상품 상태 (SELLING, SOLDOUT, DELETED)
 
     public static BroadcastProductResponse fromEntity(BroadcastProduct bp) {
-        return fromEntity(bp, bp.getBpQuantity());
+        return fromEntity(bp, bp.getBpQuantity(), null);
     }
 
     public static BroadcastProductResponse fromEntity(BroadcastProduct bp, Integer remainingQuantity) {
+        return fromEntity(bp, remainingQuantity, null);
+    }
+
+    public static BroadcastProductResponse fromEntity(BroadcastProduct bp, Integer remainingQuantity, Integer originalCostPrice) {
         Product p = bp.getProduct();
         int remaining = remainingQuantity != null ? remainingQuantity : bp.getBpQuantity();
 
@@ -38,6 +43,7 @@ public class BroadcastProductResponse {
                 .name(p.getProductName())
 //                .imageUrl(p.getProductThumbUrl())   // 추후 ProductImage 구현되면 추가 예정
                 .originalPrice(p.getPrice())
+                .originalCostPrice(originalCostPrice)
                 .stockQty(remaining)
                 .safetyStock(p.getSafetyStock())
                 .productStockQty(p.getStockQty())

--- a/src/main/java/com/deskit/deskit/livehost/service/RedisService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/RedisService.java
@@ -206,6 +206,10 @@ public class RedisService {
         return value != null ? Integer.valueOf(value.toString()) : null;
     }
 
+    public void removeOriginalCostPrice(Long broadcastId, Long productId) {
+        redisTemplate.opsForHash().delete(getOriginalCostPriceKey(broadcastId), productId.toString());
+    }
+
     public void clearOriginalCostPrices(Long broadcastId) {
         redisTemplate.delete(getOriginalCostPriceKey(broadcastId));
     }


### PR DESCRIPTION
### Motivation
- Ensure live product cards and seller broadcast product selection show the product `price` as the original/list price rather than the store `costPrice` value. 
- Restore any overridden original cost price back onto the product entity when a broadcast product sells out during an on-air session. 
- Make product pricing in product detail, cart and checkout react to server-side price changes while users are active on those pages. 

### Description
- Frontend: map and expose the API `originalPrice` field and render original vs sale price in `LiveDetail.vue`, `admin/live/LiveDetail.vue`, and use `originalPrice` in `front/src/lib/live/api.ts` when building `BroadcastProductItem` objects. 
- Frontend: add polling + update helpers to refresh pricing and notify users in `ProductDetail.vue`, `Cart.vue`, and `Checkout.vue`, and add storage helpers `updateCartItemsPricing` and `updateCheckoutItemsPricing` in `front/src/lib/cart/cart-storage.ts` and `front/src/lib/checkout/checkout-storage.ts` respectively. 
- Backend: return `price` (product list price) instead of `cost_price` for seller broadcast product selection in `BroadcastService.getSellerProducts` by querying the `price` column and mapping it into `ProductSelectResponse`. 
- Backend: add `originalCostPrice` to `BroadcastProductResponse`, implement `resolveOriginalCostPrice` and `restoreOriginalCostPriceIfNeeded` to read from Redis and restore product cost when sold out, and add `RedisService.removeOriginalCostPrice` to clear stored values. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965c147120c832e89c3495a6b8d0bdf)