### PR TITLE
Use `price` field instead of undefined `costPrice` in BroadcastService

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -339,7 +339,7 @@ public class BroadcastService {
         return dsl.select(
                         productId,
                         productName,
-                        costPrice,
+                        price,
                         stockQty,
                         safetyStock,
                         org.jooq.impl.DSL.coalesce(reservedQty, 0).as("reserved_qty"),
@@ -352,7 +352,7 @@ public class BroadcastService {
                 .orderBy(productId.asc())
                 .fetch(record -> {
                     Long currentBroadcastId = record.get(liveBroadcastId);
-                    Integer resolvedCostPrice = record.get(costPrice);
+                    Integer resolvedCostPrice = record.get(price);
                     if (currentBroadcastId != null) {
                         Integer originalCostPrice = redisService.getOriginalCostPrice(currentBroadcastId, record.get(productId));
                         if (originalCostPrice != null) {


### PR DESCRIPTION
### Motivation
- Fix a compile-time error caused by an undefined `costPrice` symbol in the broadcast product selection code.
- Ensure the product's actual price is selected from the `product` table when building broadcast product responses.
- Preserve existing logic that may override the displayed price with an original broadcast price stored in Redis.

### Description
- Replaced the selected column `costPrice` with `price` in `BroadcastService` when querying product data.
- Updated the record extraction to use `record.get(price)` for resolving the displayed price.
- Kept the Redis-based override intact by still calling `redisService.getOriginalCostPrice(...)` and applying it when present.
- Modified file: `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965fbaedb1c832ea98f8e35d42ad84f)