### PR TITLE
[FEAT] 판매자 상품 수정 페이지 삭제(soft delete) 기능 추가

### DIFF
--- a/src/main/java/com/deskit/deskit/product/controller/SellerProductController.java
+++ b/src/main/java/com/deskit/deskit/product/controller/SellerProductController.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -145,6 +146,16 @@ public class SellerProductController {
     Long sellerId = resolveSellerId(user);
     productTagService.updateProductTags(sellerId, productId, request);
     return ResponseEntity.ok().build();
+  }
+
+  @DeleteMapping("/{productId}")
+  public ResponseEntity<Void> deleteProduct(
+          @AuthenticationPrincipal CustomOAuth2User user,
+          @PathVariable("productId") Long productId
+  ) {
+    Long sellerId = resolveSellerId(user);
+    productService.softDeleteProduct(sellerId, productId);
+    return ResponseEntity.noContent().build();
   }
 
   private Long resolveSellerId(CustomOAuth2User user) {

--- a/src/main/java/com/deskit/deskit/product/service/ProductService.java
+++ b/src/main/java/com/deskit/deskit/product/service/ProductService.java
@@ -15,6 +15,7 @@ import com.deskit.deskit.product.repository.ProductRepository;
 import com.deskit.deskit.product.repository.ProductTagRepository;
 import com.deskit.deskit.product.repository.ProductTagRepository.ProductTagRow;
 import com.deskit.deskit.tag.entity.TagCategory.TagCode;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -337,6 +338,28 @@ public class ProductService {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 
+    productRepository.save(product);
+  }
+
+  public void softDeleteProduct(Long sellerId, Long productId) {
+    if (sellerId == null) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "seller_id required");
+    }
+    if (productId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "product_id required");
+    }
+
+    Product product = productRepository.findById(productId)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "product not found"));
+
+    if (!Objects.equals(product.getSellerId(), sellerId)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+    }
+    if (product.getDeletedAt() != null) {
+      return;
+    }
+
+    product.setDeletedAt(LocalDateTime.now());
     productRepository.save(product);
   }
 


### PR DESCRIPTION
## 📌 관련 이슈
- closes #354 

## 📝 작업 내용
- 판매자 상품 soft delete 처리 로직 추가(ProductService.softDeleteProduct)
- 판매자 상품 삭제 API 추가(DELETE /api/seller/products/{productId})
- 상품 수정(기본정보) 페이지에 삭제 버튼 추가 및 삭제 플로우(확인/성공 후 목록 이동) 구현
- ProductEditInfo 페이지 라우팅을 named route(seller-products)로 통일