### PR TITLE
Fix live broadcast price handling

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
@@ -13,8 +13,8 @@ public class BroadcastProductResponse {
     private Long productId;       // 원본 상품 ID
     private String name;          // 상품명 (Product API 연동 필요)
     private String imageUrl;      // 상품 이미지 (Product API 연동 필요)
-    private int originalPrice;    // 원가
-    private Integer originalCostPrice; // 방송 시작 전 판매 원가
+    private int originalPrice;    // 정가(원가)
+    private Integer originalCostPrice; // 방송 시작 전 판매가
     private int stockQty;         // 방송 판매 수량 기준 재고
     private int safetyStock;      // 안전 재고
     private int productStockQty;  // 상품 원본 재고 수량
@@ -42,7 +42,7 @@ public class BroadcastProductResponse {
                 .productId(p.getId())
                 .name(p.getProductName())
 //                .imageUrl(p.getProductThumbUrl())   // 추후 ProductImage 구현되면 추가 예정
-                .originalPrice(p.getPrice())
+                .originalPrice(p.getCostPrice())
                 .originalCostPrice(originalCostPrice)
                 .stockQty(remaining)
                 .safetyStock(p.getSafetyStock())

--- a/src/main/java/com/deskit/deskit/livehost/dto/response/ProductSelectResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/ProductSelectResponse.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class ProductSelectResponse {
     private Long productId;
     private String productName;
-    private Integer price;      // 원가
+    private Integer price;      // 판매가
     private Integer stockQty;   // 현재 재고
     private Integer safetyStock;   // 안전 재고
     private Integer reservedBroadcastQty;   // 예약 방송 판매 수량

--- a/src/main/java/com/deskit/deskit/livehost/service/AdminService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/AdminService.java
@@ -48,7 +48,7 @@ public class AdminService {
 
             validateTransition(broadcast.getStatus(), BroadcastStatus.STOPPED);
             broadcast.forceStopByAdmin(reason);
-            broadcastService.restoreOriginalProductCostPrice(broadcast);
+            broadcastService.restoreOriginalProductPrice(broadcast);
 
             broadcastService.saveBroadcastResultSnapshot(broadcast);
             openViduService.closeSession(broadcastId);

--- a/src/main/java/com/deskit/deskit/livehost/service/RedisService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/RedisService.java
@@ -93,8 +93,8 @@ public class RedisService {
         return "broadcast:" + broadcastId + ":notice:" + type;
     }
 
-    public String getOriginalCostPriceKey(Long broadcastId) {
-        return "broadcast:" + broadcastId + ":original_cost_price";
+    public String getOriginalPriceKey(Long broadcastId) {
+        return "broadcast:" + broadcastId + ":original_price";
     }
 
     public String getRecordingRetryQueueKey() {
@@ -189,29 +189,29 @@ public class RedisService {
         redisTemplate.delete(getRecordingStartRetryAttemptKey(broadcastId));
     }
 
-    public void storeOriginalCostPrice(Long broadcastId, Long productId, Integer costPrice) {
-        if (costPrice == null) {
+    public void storeOriginalPrice(Long broadcastId, Long productId, Integer price) {
+        if (price == null) {
             return;
         }
         redisTemplate.opsForHash().putIfAbsent(
-                getOriginalCostPriceKey(broadcastId),
+                getOriginalPriceKey(broadcastId),
                 productId.toString(),
-                costPrice
+                price
         );
     }
 
-    public Integer getOriginalCostPrice(Long broadcastId, Long productId) {
+    public Integer getOriginalPrice(Long broadcastId, Long productId) {
         Object value = redisTemplate.opsForHash()
-                .get(getOriginalCostPriceKey(broadcastId), productId.toString());
+                .get(getOriginalPriceKey(broadcastId), productId.toString());
         return value != null ? Integer.valueOf(value.toString()) : null;
     }
 
-    public void removeOriginalCostPrice(Long broadcastId, Long productId) {
-        redisTemplate.opsForHash().delete(getOriginalCostPriceKey(broadcastId), productId.toString());
+    public void removeOriginalPrice(Long broadcastId, Long productId) {
+        redisTemplate.opsForHash().delete(getOriginalPriceKey(broadcastId), productId.toString());
     }
 
-    public void clearOriginalCostPrices(Long broadcastId) {
-        redisTemplate.delete(getOriginalCostPriceKey(broadcastId));
+    public void clearOriginalPrices(Long broadcastId) {
+        redisTemplate.delete(getOriginalPriceKey(broadcastId));
     }
 
     public void enterLiveRoom(Long broadcastId, String uuid) {

--- a/src/main/java/com/deskit/deskit/product/entity/Product.java
+++ b/src/main/java/com/deskit/deskit/product/entity/Product.java
@@ -141,6 +141,13 @@ public class Product extends BaseEntity {
     this.costPrice = costPrice;
   }
 
+  public void changePrice(Integer price) {
+    if (price == null || price < 0) {
+      throw new IllegalArgumentException("price must be >= 0");
+    }
+    this.price = price;
+  }
+
   // LIMITED_SALE is derived from ON_SALE + low stock; it is not a persisted transition target.
   public boolean isLimitedSale() {
     if (this.status != Status.ON_SALE) {


### PR DESCRIPTION
### Motivation
- The live broadcast flow previously treated `price` and `costPrice` roles incorrectly when applying broadcast discounts, causing live specials to overwrite product `costPrice` instead of the sale `price`.
- Redis keys and stored values referenced original cost values while the system needs to preserve and restore the original sale price when applying `bpPrice` for a broadcast.

### Description
- Added `Product.changePrice(Integer)` and updated broadcast logic to apply `bpPrice` to the product `price` via `applyLiveProductPrice` and to persist/restore original sale prices in Redis using `storeOriginalPrice`/`getOriginalPrice`/`removeOriginalPrice`/`clearOriginalPrices`.
- Renamed and refactored methods in `BroadcastService` from cost-focused names to price-focused names (`applyLiveProductPrice`, `restoreOriginalProductPrice`, `resolveOriginalPrice`, `restoreOriginalPriceIfNeeded`) and updated usages (including admin stop/VOD transitions) to restore original prices.
- Updated `RedisService` keys from `original_cost_price` to `original_price` and corresponding API methods to store and fetch original sale price values.
- Aligned DTO semantics by adjusting `BroadcastProductResponse` to use product `costPrice` as the original list price and changed `ProductSelectResponse` comment to indicate `price` is the sale price.

### Testing
- No automated tests were executed as part of this change.
- The code changes were compiled and staged in the working tree and committed locally (no CI run reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69662624a150832e87e4f9ffe51fb7cc)