### PR TITLE
Adjust live placeholder messaging and VOD time label

### DIFF
--- a/front/src/components/LiveCard.vue
+++ b/front/src/components/LiveCard.vue
@@ -138,7 +138,7 @@ const timeLabel = computed(() => {
     return '송출 중지'
   }
   if (status.value === 'VOD') {
-    return totalDurationLabel.value ? `총 재생 ${totalDurationLabel.value}` : 'VOD'
+    return totalDurationLabel.value ? `재생 시간 ${totalDurationLabel.value}` : '재생 시간'
   }
   return endedDurationLabel.value ? `경과 ${endedDurationLabel.value}` : '방송 종료'
 })

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -1396,7 +1396,9 @@ onBeforeUnmount(() => {
                 alt="대기 화면"
                 @error="handleImageError"
               />
-              <p v-if="playerMessage" class="player-frame__message">{{ playerMessage }}</p>
+              <p v-if="playerMessage && (!waitingScreenUrl || lifecycleStatus === 'STOPPED')" class="player-frame__message">
+                {{ playerMessage }}
+              </p>
             </div>
             <span v-else-if="!hasSubscriberStream" class="player-frame__label">LIVE 플레이어</span>
             <div v-if="!isStopRestricted" class="player-actions">

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -1317,7 +1317,12 @@ watch(
                       alt="대기 화면"
                       @error="handleImageError"
                   />
-                  <p v-if="playerMessage" class="player-placeholder__message">{{ playerMessage }}</p>
+                  <p
+                    v-if="playerMessage && (!waitingScreenUrl || lifecycleStatus === 'STOPPED')"
+                    class="player-placeholder__message"
+                  >
+                    {{ playerMessage }}
+                  </p>
                 </div>
                 <div v-else-if="!hasSubscriberStream" class="player-label">송출 화면</div>
               </div>


### PR DESCRIPTION
### Motivation
- Ensure admin, seller, and viewer live pages display the waiting screen image when available and fall back to a message only when no image exists or when the lifecycle is `STOPPED`.
- Hide placeholder messages on admin and viewer pages while a waiting screen image is present to match expected UX across roles.
- Use the correct VOD meta/time label text `재생 시간` in the card component.
- Leave seller live screen logic unchanged since it already handles waiting screen presence correctly.

### Description
- Update `front/src/pages/admin/live/LiveDetail.vue` to only render the placeholder message when `!waitingScreenUrl || lifecycleStatus === 'STOPPED'`.
- Apply the same placeholder message condition to `front/src/pages/LiveDetail.vue` so viewer pages behave consistently.
- Change the VOD time/meta label in `front/src/components/LiveCard.vue` to return `재생 시간` for `VOD` status.
- Modified files: `front/src/pages/admin/live/LiveDetail.vue`, `front/src/pages/LiveDetail.vue`, and `front/src/components/LiveCard.vue`.

### Testing
- Started the dev server with `npm run dev` and the server reported ready without errors.
- Executed a Playwright script to load `http://127.0.0.1:4173` and successfully captured a screenshot at `artifacts/home.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696627842808832e9e19b062fdd7519e)