### PR TITLE
Fix live create product modal height on short viewports

### DIFF
--- a/front/src/pages/seller/LiveCreateBasic.vue
+++ b/front/src/pages/seller/LiveCreateBasic.vue
@@ -1360,7 +1360,8 @@ input[type='file'] {
 }
 
 .modal__body {
-  max-height: 520px;
+  flex: 1;
+  min-height: 0;
   overflow: auto;
 }
 
@@ -1536,11 +1537,13 @@ input[type='file'] {
   border-radius: 16px;
   padding: 18px;
   max-width: 520px;
+  max-height: calc(100vh - 32px);
   width: 100%;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   gap: 12px;
+  overflow: hidden;
 }
 
 .modal__header {


### PR DESCRIPTION
### Motivation
- The product selection modal in the seller live-create flow could extend beyond short browser viewports and hide the footer actions including the `저장` button. 
- The change aims to make the modal layout use viewport-aware sizing and a scrollable body area so controls remain reachable on small screens.

### Description
- Updated `front/src/pages/seller/LiveCreateBasic.vue` styles to make `.modal__body` flex-grow with `flex: 1` and `min-height: 0` while keeping `overflow: auto` for internal scrolling. 
- Constrained the modal container by adding `max-height: calc(100vh - 32px)` and `overflow: hidden` to `.modal__content` so the modal fits within the viewport and only the body scrolls. 
- Small CSS removal of the fixed `max-height: 520px` to enable dynamic height behavior.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which launched successfully and served the app. 
- Ran a Playwright script that attempted to open the live-create page and click the `상품 선택` button, but the click action timed out (failed). 
- Captured a Playwright full-page screenshot of the `seller/live/create/basic` page which succeeded and produced an artifact at `browser:/tmp/codex_browser_invocations/e7ce1e72063c9237/artifacts/artifacts/live-create-basic.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696632aa6ad4832eb4fcf8ab7425c63b)