### PR TITLE
Restore reserved status when seller edits canceled broadcast

### DIFF
--- a/front/src/pages/seller/LiveCreateBasic.vue
+++ b/front/src/pages/seller/LiveCreateBasic.vue
@@ -1360,7 +1360,8 @@ input[type='file'] {
 }
 
 .modal__body {
-  max-height: 520px;
+  flex: 1;
+  min-height: 0;
   overflow: auto;
 }
 
@@ -1536,11 +1537,13 @@ input[type='file'] {
   border-radius: 16px;
   padding: 18px;
   max-width: 520px;
+  max-height: calc(100vh - 32px);
   width: 100%;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   gap: 12px;
+  overflow: hidden;
 }
 
 .modal__header {

--- a/src/main/java/com/deskit/deskit/livehost/entity/Broadcast.java
+++ b/src/main/java/com/deskit/deskit/livehost/entity/Broadcast.java
@@ -181,6 +181,7 @@ public class Broadcast {
         }
         return switch (from) {
             case RESERVED -> to == BroadcastStatus.READY || to == BroadcastStatus.CANCELED;
+            case CANCELED -> to == BroadcastStatus.RESERVED;
             case READY -> to == BroadcastStatus.ON_AIR || to == BroadcastStatus.CANCELED || to == BroadcastStatus.STOPPED;
             case ON_AIR -> to == BroadcastStatus.ENDED || to == BroadcastStatus.STOPPED;
             case ENDED -> to == BroadcastStatus.VOD || to == BroadcastStatus.STOPPED;

--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -203,6 +203,9 @@ public class BroadcastService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CATEGORY_NOT_FOUND));
 
         if (broadcast.getStatus() == BroadcastStatus.RESERVED || broadcast.getStatus() == BroadcastStatus.CANCELED) {
+            if (broadcast.getStatus() == BroadcastStatus.CANCELED) {
+                broadcast.changeStatus(BroadcastStatus.RESERVED);
+            }
             LocalDateTime nextScheduledAt = request.getScheduledAt();
             LocalDateTime currentScheduledAt = broadcast.getScheduledAt();
             if (nextScheduledAt != null && (currentScheduledAt == null || !currentScheduledAt.equals(nextScheduledAt))) {


### PR DESCRIPTION
### Motivation
- When a seller edits a broadcast that is currently `CANCELED`, the reservation should be revived to `RESERVED` so the seller can modify schedule and metadata. 
- The entity state machine previously disallowed `CANCELED -> RESERVED` transitions which blocked legitimate edit flows. 
- The seller update flow must accept edits to schedule, products and q-cards for revived reservations. 
- The front-end modal sizing fix ensures the product selection modal remains usable on short viewports so controls remain reachable.

### Description
- Permit `CANCELED -> RESERVED` in the broadcast state machine by updating `isTransitionAllowed` in `src/main/java/com/deskit/deskit/livehost/entity/Broadcast.java`. 
- In `updateBroadcast` of `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java`, reset a `CANCELED` broadcast to `RESERVED` via `broadcast.changeStatus(BroadcastStatus.RESERVED)` before applying updates. 
- Keep the front-end modal sizing improvements in `front/src/pages/seller/LiveCreateBasic.vue` so `.modal__content` uses `max-height: calc(100vh - 32px)` and the body scrolls (`flex: 1`, `min-height: 0`, `overflow: auto`). 
- Modified files: `Broadcast.java`, `BroadcastService.java`, and `front/src/pages/seller/LiveCreateBasic.vue`.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which launched successfully. 
- Ran a Playwright script to open the live-create page and click the `상품 선택` button which timed out (the click action failed). 
- Captured a Playwright full-page screenshot of `seller/live/create/basic` which succeeded and produced an artifact. 
- No backend unit or integration tests were executed for the Java changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696632aa6ad4832eb4fcf8ab7425c63b)