### PR TITLE
Fix product list discount display for live pricing

### DIFF
--- a/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
@@ -90,19 +90,30 @@ public class ProductResponse {
     if (product.isLimitedSale()) {
       status = Product.Status.LIMITED_SALE;
     }
-    return fromWithCostPrice(product, tags, tagsFlat, costPriceOverride, status);
+    return fromWithOverrides(product, tags, tagsFlat, null, costPriceOverride, status);
   }
 
-  private static ProductResponse fromWithCostPrice(Product product, ProductTags tags, List<String> tagsFlat,
-                                                   Integer costPriceOverride, Product.Status status) {
+  public static ProductResponse fromWithPrice(Product product, ProductTags tags, List<String> tagsFlat,
+                                              Integer priceOverride) {
+    Product.Status status = product.getStatus();
+    if (product.isLimitedSale()) {
+      status = Product.Status.LIMITED_SALE;
+    }
+    return fromWithOverrides(product, tags, tagsFlat, priceOverride, null, status);
+  }
+
+  private static ProductResponse fromWithOverrides(Product product, ProductTags tags, List<String> tagsFlat,
+                                                   Integer priceOverride, Integer costPriceOverride,
+                                                   Product.Status status) {
     Integer resolvedCostPrice = costPriceOverride != null ? costPriceOverride : product.getCostPrice();
+    Integer resolvedPrice = priceOverride != null ? priceOverride : product.getPrice();
     return new ProductResponse(
             product.getId(),
             product.getSellerId(),
             product.getProductName(), // 엔티티 productName -> 응답 name
             product.getShortDesc(),
             product.getDetailHtml(),
-            product.getPrice(),
+            resolvedPrice,
             resolvedCostPrice,
             status,
             product.getStockQty(),

--- a/src/main/java/com/deskit/deskit/product/service/ProductService.java
+++ b/src/main/java/com/deskit/deskit/product/service/ProductService.java
@@ -56,7 +56,7 @@ public class ProductService {
             .map(Product::getId)
             .collect(Collectors.toList());
 
-    Map<Long, Integer> liveCostPrices = broadcastProductRepository.findLiveBpPrices(productIds).stream()
+    Map<Long, Integer> livePrices = broadcastProductRepository.findLiveBpPrices(productIds).stream()
             .collect(Collectors.toMap(
                     BroadcastProductRepository.LivePriceRow::getProductId,
                     BroadcastProductRepository.LivePriceRow::getBpPrice,
@@ -75,8 +75,8 @@ public class ProductService {
               TagsBundle bundle = tagsByProductId.get(product.getId());
               ProductTags tags = bundle == null ? ProductTags.empty() : bundle.getTags();
               List<String> tagsFlat = bundle == null ? Collections.emptyList() : bundle.getTagsFlat();
-              Integer costPriceOverride = liveCostPrices.get(product.getId());
-              return ProductResponse.fromWithCostPrice(product, tags, tagsFlat, costPriceOverride);
+              Integer priceOverride = livePrices.get(product.getId());
+              return ProductResponse.fromWithPrice(product, tags, tagsFlat, priceOverride);
             })
             .collect(Collectors.toList());
   }
@@ -97,10 +97,10 @@ public class ProductService {
     ProductTags tags = bundle == null ? ProductTags.empty() : bundle.getTags();
     List<String> tagsFlat = bundle == null ? Collections.emptyList() : bundle.getTagsFlat();
 
-    Integer costPriceOverride = broadcastProductRepository.findLiveBpPriceByProductId(id).stream()
+    Integer priceOverride = broadcastProductRepository.findLiveBpPriceByProductId(id).stream()
             .findFirst()
             .orElse(null);
-    return Optional.of(ProductResponse.fromWithCostPrice(product.get(), tags, tagsFlat, costPriceOverride));
+    return Optional.of(ProductResponse.fromWithPrice(product.get(), tags, tagsFlat, priceOverride));
   }
 
   public List<SellerProductListResponse> getSellerProducts(Long sellerId) {


### PR DESCRIPTION
### Motivation
- ON_AIR broadcast prices (`bp_price`) were being applied as a `cost_price` override which broke the `originalPrice > price` condition and caused discount/original-price UI to disappear.
- The intent is to apply live broadcast special prices to the displayed sale `price` while keeping `cost_price` (원가) unchanged so discount calculation and badge rendering remain correct.

### Description
- Added `fromWithPrice` and a shared `fromWithOverrides` helper to `ProductResponse` to support overriding response `price` without changing `cost_price`.
- Adjusted `ProductService.getProducts` and `ProductService.getProduct` to collect live broadcast prices (`findLiveBpPrices` / `findLiveBpPriceByProductId`) and pass them as a `price` override to the new DTO helper.
- Renamed local variables for clarity (`liveCostPrices` -> `livePrices`) and switched calls from `fromWithCostPrice` to `fromWithPrice` for list/detail responses.

### Testing
- No automated tests were executed as part of this change.
- The change was compiled and committed locally (no CI results included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966358b45ac832e98c3af21adbb2802)