### PR TITLE
PR 제목: feat: 판매자 상품 수정 스텝 플로우 및 soft delete 추가

### DIFF
--- a/front/src/pages/seller/ProductEditInfo.vue
+++ b/front/src/pages/seller/ProductEditInfo.vue
@@ -213,7 +213,7 @@ const handleSubmit = async () => {
       error.value = '상품 수정에 실패했습니다.'
       return
     }
-    router.push({ name: 'seller-products' }).catch(() => {})
+    router.push({ name: 'seller-products-edit-detail', params: { id } }).catch(() => {})
   } catch {
     error.value = '상품 수정에 실패했습니다.'
   }
@@ -268,7 +268,7 @@ onMounted(() => {
       <div class="actions">
         <button type="button" class="btn" @click="cancel">취소</button>
         <button type="button" class="btn danger" :disabled="isDeleting" @click="handleDelete">삭제</button>
-        <button type="button" class="btn primary" @click="handleSubmit">저장</button>
+        <button type="button" class="btn primary" @click="handleSubmit">상세 수정</button>
       </div>
     </section>
   </PageContainer>

--- a/src/main/java/com/deskit/deskit/product/dto/ProductBasicUpdateRequest.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductBasicUpdateRequest.java
@@ -2,6 +2,7 @@ package com.deskit.deskit.product.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Min;
+import java.util.List;
 
 public record ProductBasicUpdateRequest(
   @JsonProperty("product_name")
@@ -16,5 +17,11 @@ public record ProductBasicUpdateRequest(
 
   @JsonProperty("stock_qty")
   @Min(0)
-  Integer stockQty
+  Integer stockQty,
+
+  @JsonProperty("detail_html")
+  String detailHtml,
+
+  @JsonProperty("image_urls")
+  List<String> imageUrls
 ) {}

--- a/src/main/java/com/deskit/deskit/product/dto/SellerProductDetailResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/SellerProductDetailResponse.java
@@ -2,6 +2,7 @@ package com.deskit.deskit.product.dto;
 
 import com.deskit.deskit.product.entity.Product;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 
 public record SellerProductDetailResponse(
   @JsonProperty("product_id")
@@ -19,12 +20,18 @@ public record SellerProductDetailResponse(
   @JsonProperty("stock_qty")
   Integer stockQty,
 
+  @JsonProperty("detail_html")
+  String detailHtml,
+
+  @JsonProperty("image_urls")
+  List<String> imageUrls,
+
   @JsonProperty("status")
   Product.Status status
 ) {
-  public static SellerProductDetailResponse from(Product product) {
+  public static SellerProductDetailResponse from(Product product, List<String> imageUrls) {
     if (product == null) {
-      return new SellerProductDetailResponse(null, null, null, null, null, null);
+      return new SellerProductDetailResponse(null, null, null, null, null, null, null, null);
     }
     return new SellerProductDetailResponse(
       product.getId(),
@@ -32,6 +39,8 @@ public record SellerProductDetailResponse(
       product.getShortDesc(),
       product.getPrice(),
       product.getStockQty(),
+      product.getDetailHtml(),
+      imageUrls,
       product.getStatus()
     );
   }

--- a/src/main/java/com/deskit/deskit/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductImageRepository.java
@@ -2,6 +2,7 @@ package com.deskit.deskit.product.repository;
 
 import com.deskit.deskit.product.entity.ProductImage;
 import com.deskit.deskit.product.entity.ProductImage.ImageType;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
@@ -13,4 +14,6 @@ public interface ProductImageRepository extends JpaRepository<ProductImage, Long
     ImageType imageType,
     Integer slotIndex
   );
+
+  List<ProductImage> findAllByProductIdAndDeletedAtIsNullOrderBySlotIndexAsc(Long productId);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closes #355 

## 📝 작업 내용
- 판매자 상품 수정(기본) 화면에 삭제 버튼 추가 및 DELETE 연동(soft delete)
- 태그 조회 LazyInitializationException 해결을 위한 DTO projection 적용
- 상품 태그 매핑 저장 시 복합키(productId, tagId) 세팅 보강 및 입력 검증
- 상품 수정 플로우를 기본 -> 상세 스텝으로 연결(기본 저장 후 상세로 이동, 상세 저장 후 리스트로 이동)
- 상품 상세 조회/수정에 detail_html, image_urls 처리 추가 및 이미지 soft delete 갱신 로직 반영