### PR TITLE
Use persisted stats for STOPPED broadcasts to preserve view/max viewer metrics

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java
@@ -1946,6 +1946,12 @@ public class BroadcastService {
                 || status == BroadcastStatus.STOPPED;
     }
 
+    private boolean shouldUseRealtimeStats(BroadcastStatus status) {
+        return status == BroadcastStatus.ON_AIR
+                || status == BroadcastStatus.READY
+                || status == BroadcastStatus.ENDED;
+    }
+
     private boolean isJoinableGroup(BroadcastStatus status) {
         return status == BroadcastStatus.ON_AIR || status == BroadcastStatus.READY;
     }
@@ -1984,7 +1990,7 @@ public class BroadcastService {
         Integer reports = 0;
         String vodUrl = null;
 
-        if (isLiveGroup(broadcast.getStatus())) {
+        if (shouldUseRealtimeStats(broadcast.getStatus())) {
             views = redisService.getRealtimeViewerCount(broadcast.getBroadcastId());
             likes = redisService.getLikeCount(broadcast.getBroadcastId());
             reports = redisService.getReportCount(broadcast.getBroadcastId());
@@ -2041,7 +2047,7 @@ public class BroadcastService {
 
     private void injectLiveStats(List<BroadcastListResponse> list) {
         list.forEach(item -> {
-            if (isLiveGroup(item.getStatus())) {
+            if (shouldUseRealtimeStats(item.getStatus())) {
                 item.setLiveViewerCount(redisService.getRealtimeViewerCount(item.getBroadcastId()));
                 item.setTotalLikes(redisService.getLikeCount(item.getBroadcastId()));
                 item.setReportCount(redisService.getReportCount(item.getBroadcastId()));
@@ -2065,9 +2071,11 @@ public class BroadcastService {
 
         list.forEach(item -> {
             if (isLiveGroup(item.getStatus())) {
-                item.setLiveViewerCount(redisService.getRealtimeViewerCount(item.getBroadcastId()));
-                item.setTotalLikes(redisService.getLikeCount(item.getBroadcastId()));
-                item.setReportCount(redisService.getReportCount(item.getBroadcastId()));
+                if (shouldUseRealtimeStats(item.getStatus())) {
+                    item.setLiveViewerCount(redisService.getRealtimeViewerCount(item.getBroadcastId()));
+                    item.setTotalLikes(redisService.getLikeCount(item.getBroadcastId()));
+                    item.setReportCount(redisService.getReportCount(item.getBroadcastId()));
+                }
 
                 List<BroadcastProduct> products = productMap.getOrDefault(item.getBroadcastId(), List.of());
                 Broadcast broadcast = broadcastMap.get(item.getBroadcastId());


### PR DESCRIPTION
### Motivation
- When a broadcast is forced to `STOPPED`, runtime Redis keys are cleared which caused cumulative stats like total views and max viewers to disappear from admin/seller result reports. 
- The intent is to hide live realtime counters for stopped broadcasts while retaining persisted result metrics for reporting. 

### Description
- Added `shouldUseRealtimeStats` to decide when to read realtime counters (returns true for `ON_AIR`, `READY`, `ENDED`).
- Switched `BroadcastService` to use `shouldUseRealtimeStats` instead of treating `STOPPED` as a live group, so `STOPPED` broadcasts now use persisted `BroadcastResult` values for `totalViews`, `maxViews`, `maxViewerTime`, and related metrics.
- Updated usage sites in `createBroadcastResponse`, `injectLiveStats`, and `injectLiveDetails` in `src/main/java/com/deskit/deskit/livehost/service/BroadcastService.java` to avoid pulling realtime Redis counters for `STOPPED` broadcasts.

### Testing
- No automated tests were executed for this change.
- Manual verification not included in automated run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663aae3ed0832ea7c3e9ae4a2b11a3)