### PR TITLE
Fix ProductResponse factory status override

### DIFF
--- a/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
@@ -81,7 +81,7 @@ public class ProductResponse {
     if (product.isLimitedSale()) {
       status = Product.Status.LIMITED_SALE;
     }
-    return fromWithCostPrice(product, tags, tagsFlat, product.getCostPrice(), status);
+    return fromWithOverrides(product, tags, tagsFlat, null, product.getCostPrice(), status);
   }
 
   public static ProductResponse fromWithCostPrice(Product product, ProductTags tags, List<String> tagsFlat,


### PR DESCRIPTION
### Motivation
- A compilation error occurred because `ProductResponse.from` invoked `fromWithCostPrice` with an extra `status` argument that doesn't match the method signature. 
- The factory should apply the `LIMITED_SALE` status override where applicable while preserving the intended cost/price resolution. 

### Description
- Replace the incorrect call in `ProductResponse.from` with `fromWithOverrides(product, tags, tagsFlat, null, product.getCostPrice(), status)`. 
- This routes the status-aware creation through the shared `fromWithOverrides` helper and fixes the argument mismatch. 
- Modified file: `src/main/java/com/deskit/deskit/product/dto/ProductResponse.java`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696643c72100832eaff65ffcb3ead02f)