### PR TITLE
Prevent OpenVidu DOM cleanup error on stream teardown

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -1,5 +1,5 @@
 ﻿<script setup lang="ts">
-import { OpenVidu, type Session, type Subscriber } from 'openvidu-browser'
+import { OpenVidu, type Session, type StreamEvent, type Subscriber } from 'openvidu-browser'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Client, type StompSubscription } from '@stomp/stompjs'
@@ -462,7 +462,8 @@ const connectSubscriber = async (token: string) => {
       applySubscriberVolume()
       void applyVideoQuality(selectedQuality.value)
     })
-    openviduSession.value.on('streamDestroyed', () => {
+    openviduSession.value.on('streamDestroyed', (event: StreamEvent) => {
+      event.preventDefault()
       openviduSubscriber.value = null
       clearViewerContainer()
     })

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { OpenVidu, type Session, type Subscriber } from 'openvidu-browser'
+import { OpenVidu, type Session, type StreamEvent, type Subscriber } from 'openvidu-browser'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Client, type StompSubscription } from '@stomp/stompjs'
@@ -644,7 +644,8 @@ const connectSubscriber = async (token: string) => {
       applySubscriberVolume()
       applyVideoQuality(selectedQuality.value)
     })
-    openviduSession.value.on('streamDestroyed', () => {
+    openviduSession.value.on('streamDestroyed', (event: StreamEvent) => {
+      event.preventDefault()
       openviduSubscriber.value = null
       clearViewerContainer()
     })

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { OpenVidu, type Publisher, type Session } from 'openvidu-browser'
+import { OpenVidu, type Publisher, type Session, type StreamEvent } from 'openvidu-browser'
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
 import { Client, type StompSubscription } from '@stomp/stompjs'
@@ -625,6 +625,12 @@ const resetOpenViduState = () => {
   }
 }
 
+const attachPublisherHandlers = (publisher: Publisher) => {
+  publisher.on('streamDestroyed', (event: StreamEvent) => {
+    event.preventDefault()
+  })
+}
+
 const disconnectOpenVidu = () => {
   if (openviduSession.value) {
     try {
@@ -682,6 +688,7 @@ const restartPublisher = async () => {
       publisherContainerRef.value,
       buildPublisherOptions(),
     )
+    attachPublisherHandlers(openviduPublisher.value)
     await openviduSession.value.publish(openviduPublisher.value as Publisher)
     applyPublisherVolume()
   } catch {
@@ -705,6 +712,7 @@ const connectPublisher = async (broadcastId: number, token: string) => {
       container,
       buildPublisherOptions(),
     )
+    attachPublisherHandlers(openviduPublisher.value)
     await openviduSession.value.publish(openviduPublisher.value as Publisher)
     openviduConnected.value = true
     applyPublisherVolume()


### PR DESCRIPTION
### Motivation
- The OpenVidu client emitted a `streamDestroyed` event that attempted DOM cleanup after the publisher container had already been cleared, causing `removeChild` on `null` errors in the logs. 
- The intent is to prevent OpenVidu's default cleanup handler from removing elements that the app has already removed during disconnect/unpublish. 

### Description
- Imported the `StreamEvent` type from `openvidu-browser` and added `attachPublisherHandlers` which calls `event.preventDefault()` for the `streamDestroyed` event. 
- Applied `attachPublisherHandlers` to publisher instances created in `restartPublisher` and `connectPublisher` so the default DOM cleanup is suppressed. 
- Kept existing disconnect logic and preserved clearing of `publisherContainerRef.innerHTML` in `resetOpenViduState`. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966460d139c832eaab3d36698567c49)