### PR TITLE
Handle SSE disconnects cleanly

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/common/exception/LiveExceptionHandler.java
+++ b/src/main/java/com/deskit/deskit/livehost/common/exception/LiveExceptionHandler.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import java.io.IOException;
+
 @Slf4j
 @RestControllerAdvice(basePackages = "com.deskit.deskit.livehost.controller")
 @Order(Ordered.HIGHEST_PRECEDENCE) // 혹시 deskit의 전역 핸들러가 있다면, 이게 먼저 실행되도록 우선순위 높임
@@ -41,6 +43,13 @@ public class LiveExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     // 3. 그 외 알 수 없는 에러 (내 영역 안에서 터진 것만)
+    @ExceptionHandler(IOException.class)
+    protected ResponseEntity<Void> handleIOException(IOException e) {
+        log.debug("[Live Error] Client disconnected: {}", e.getMessage());
+        return ResponseEntity.noContent().build();
+    }
+
+    // 4. 그 외 알 수 없는 에러 (내 영역 안에서 터진 것만)
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ApiResult<?>> handleException(Exception e) {
         log.error("[Live Error] Unknown Exception: ", e);

--- a/src/main/java/com/deskit/deskit/livehost/service/SseService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/SseService.java
@@ -128,8 +128,10 @@ public class SseService {
     private void sendToClient(SseEmitter emitter, String id, String name, Object data) {
         try {
             emitter.send(SseEmitter.event().id(id).name(name).data(data));
-        } catch (IOException e) {
+        } catch (IOException | IllegalStateException e) {
             emitters.remove(id);
+            emitter.complete();
+            log.debug("SSE connection closed: key={}, reason={}", id, e.getMessage());
         }
     }
 


### PR DESCRIPTION
### Motivation
- SSE sends were throwing `IOException`/`IllegalStateException` when clients disconnected, which bubbled up to the global handler and caused response conversion errors for `text/event-stream` responses.
- The stack trace showed `IOException` from socket write during `SseEmitter.send`, and the generic exception handler attempted to serialize an `ApiResult` into an SSE response, resulting in `HttpMessageNotWritableException`.
- The intent is to ensure disconnected SSE clients are cleaned up and that client disconnects do not trigger the generic error flow.

### Description
- Added an `@ExceptionHandler(IOException.class)` in `LiveExceptionHandler` that logs a client disconnect and returns `ResponseEntity.noContent()` to avoid trying to serialize an `ApiResult` into an SSE stream.
- Imported `java.io.IOException` and ensured the `IOException` handler is declared before the generic `Exception` handler so disconnects are handled specifically.
- Updated `SseService.sendToClient` to catch `IOException` and `IllegalStateException`, remove the emitter from the `emitters` map, call `emitter.complete()`, and emit a debug log with the key and reason.
- These changes prevent stale emitters from remaining in the map and avoid surfacing socket write errors as generic internal server errors.

### Testing
- No automated tests were executed for this change.
- Changes were committed and verified locally by inspecting the modified files; no runtime test was run against a live SSE client.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966554ae21c832eaa317da8bf43bc2b)