### PR TITLE
Limit SSE disconnect handling to SseService

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/SseService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/SseService.java
@@ -128,8 +128,10 @@ public class SseService {
     private void sendToClient(SseEmitter emitter, String id, String name, Object data) {
         try {
             emitter.send(SseEmitter.event().id(id).name(name).data(data));
-        } catch (IOException e) {
+        } catch (IOException | IllegalStateException e) {
             emitters.remove(id);
+            emitter.complete();
+            log.debug("SSE connection closed: key={}, reason={}", id, e.getMessage());
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent socket write errors from disconnected SSE clients being routed through the global exception advice and causing `HttpMessageNotWritableException` for `text/event-stream` responses.
- Ensure disconnected SSE emitters are cleaned up at the point of send so stale emitters do not remain in the `emitters` map.
- Avoid masking non-SSE `IOException` failures in the global `LiveExceptionHandler` by restricting disconnect handling to the SSE service.

### Description
- Updated `SseService.sendToClient` to catch both `IOException` and `IllegalStateException`, remove the emitter from the `emitters` map, call `emitter.complete()`, and log the closure with the key and reason.
- Removed the dedicated `@ExceptionHandler(IOException.class)` from `LiveExceptionHandler` so `IOException`s are no longer handled specially in the controller advice.
- Removed the now-unused `IOException` import from `LiveExceptionHandler`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966554ae21c832eaa317da8bf43bc2b)