### PR TITLE
Skip stale OpenVidu forceDisconnects and normalize seller media selection

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
@@ -148,13 +148,20 @@ public class OpenViduService {
 
     public void forceDisconnect(Long broadcastId, String connectionId) {
         String sessionId = sessionMap.get(broadcastId);
-        if (sessionId == null) {
+        if (sessionId == null || connectionId == null || connectionId.isBlank()) {
             return;
         }
 
         try {
             Session session = openVidu.getActiveSession(sessionId);
             if (session != null) {
+                session.fetch();
+                boolean exists = session.getConnections().stream()
+                        .anyMatch(connection -> connectionId.equals(connection.getConnectionId()));
+                if (!exists) {
+                    log.info("Skip force disconnect for unknown connection: {}", connectionId);
+                    return;
+                }
                 session.forceDisconnect(connectionId);
                 log.info("Force disconnected connection: {}", connectionId);
             }


### PR DESCRIPTION
### Motivation
- Prevent attempts to force-disconnect an unknown or blank connectionId against OpenVidu sessions to avoid errors and noisy logs.
- Ensure saved microphone and camera selections are validated against currently enumerated devices to avoid using stale device IDs.
- Provide a graceful fallback when microphone constraints fail during mic-meter initialization.
- Avoid unpublish calls when there is no active publisher stream to reduce exceptions.

### Description
- Backend: update `forceDisconnect` in `OpenViduService` to return early on null/blank `connectionId`, call `session.fetch()`, verify the connection exists via `session.getConnections()` before calling `session.forceDisconnect`, and log when skipping unknown connections.
- Frontend: add `normalizeMediaSelection` and update `loadMediaDevices` to normalize `selectedMic`/`selectedCamera` after device enumeration.
- Frontend: call `loadMediaDevices` from `ensurePublisherConnected` so device lists are fresh before building publisher options.
- Frontend: handle `OverconstrainedError` in `startMicMeter` by falling back to the default microphone (`selectedMic.value = '기본 마이크'`) and retrying initialization, and guard `unpublish` calls by checking `openviduPublisher.value?.stream?.streamId`.

### Testing
- No automated tests were executed for this change.
- (No automated test results to report.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665913de60832e8a5935434cb3e27c)