### PR TITLE
Revert session memberId exposure and prefer email in viewer id resolution

### DIFF
--- a/front/src/lib/live/viewer.ts
+++ b/front/src/lib/live/viewer.ts
@@ -41,6 +41,9 @@ export const resolveViewerId = (user: AuthUser | null): string | null => {
   if (directId !== null && directId !== undefined) {
     return String(directId)
   }
+  if (user?.email) {
+    return user.email
+  }
 
   const access =
     localStorage.getItem('access') ||


### PR DESCRIPTION
### Motivation
- Remove the recent exposure of `memberId` from session/profile responses to avoid touching auth types and surface area in the frontend.
- Preserve a path to improve viewer identification for broadcast-related flows without changing the `AuthUser` shape.
- Align client-side viewer identification with server-side sanction checks that often match on `loginId`/email.
- Keep changes minimal and local to viewer resolution to reduce risk to auth/session handling.

### Description
- Reverted the `memberId` addition in `MyPageResponse` and removed population of `memberId` in `MyPageService` so the DTO and service no longer expose `memberId`.
- Restored `front/src/lib/auth.ts` to the original `AuthUser` shape and did not add `memberId` to session hydration.
- Updated `front/src/lib/live/viewer.ts` so `resolveViewerId` will return `user.email` as an early fallback before token parsing or stored UUIDs.
- Left existing API usage (e.g. `joinBroadcast` header usage) unchanged so viewer header behavior is preserved while improving identification logic.

### Testing
- No automated tests were run for these changes.
- CI/build was not executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665e2c6ca4832eb99df6713a2147a5)