### PR TITLE
Handle join failures for sanctioned viewers (B007)

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -878,7 +878,9 @@ const requestJoinToken = async () => {
     streamToken.value = await joinBroadcast(broadcastId.value, viewerId.value)
     joinedBroadcastId.value = broadcastId.value
   } catch (error) {
-    const code = (error as { code?: string } | null)?.code
+    const code =
+      (error as { code?: string } | null)?.code ||
+      (error as { response?: { data?: { error?: { code?: string } } } } | null)?.response?.data?.error?.code
     if (code === 'B007') {
       alert('관리자/판매자에 의해 방송 방 입장이 금지되었습니다.')
       router.push({ name: 'live' }).catch(() => {})


### PR DESCRIPTION
### Motivation
- When a viewer is forcibly removed the backend blocks `joinBroadcast` with error code `B007`, which prevented issuing an OpenVidu token and left the client in a partially-entered state.
- The frontend previously only inspected thrown error `code` and missed `B007` embedded in Axios non-2xx responses' body.
- Users should see a clear alert and be redirected back to the broadcast list when they are blocked from entering a room.
- The change aims to avoid trying to connect to OpenVidu without a token after a sanctioned join attempt.

### Description
- Updated `requestJoinToken` in `front/src/pages/LiveDetail.vue` to check both the thrown error `code` and the nested Axios response path `response.data.error.code` for `B007`.
- When `B007` is detected the client now shows an alert `관리자/판매자에 의해 방송 방 입장이 금지되었습니다.` and navigates to the `live` list using `router.push`.
- All existing `joinInFlight` handling and successful `joinBroadcast` token flow are preserved and unchanged.
- The change is localized to `front/src/pages/LiveDetail.vue` and does not modify backend logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966746290c4832ea8bef6bfdcbaa6fa)