### PR TITLE
[FEAT] 상품 이미지 업로드(NCP Object Storage) API 및 등록/수정 1:1 크롭 연동

### DIFF
--- a/front/src/components/LiveImageCropModal.vue
+++ b/front/src/components/LiveImageCropModal.vue
@@ -1,11 +1,25 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch, withDefaults } from 'vue'
 
-const props = defineProps<{
-  modelValue: boolean
-  imageSrc: string
-  fileName: string
-}>()
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean
+    imageSrc: string
+    fileName: string
+    frameWidthRatio?: number
+    frameHeightRatio?: number
+    outputWidth?: number
+    outputHeight?: number
+    title?: string
+  }>(),
+  {
+    frameWidthRatio: 16,
+    frameHeightRatio: 9,
+    outputWidth: 1280,
+    outputHeight: 720,
+    title: '16:9 이미지 자르기',
+  },
+)
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void
@@ -27,17 +41,29 @@ const dragState = ref<{ active: boolean; startX: number; startY: number; originX
 })
 
 const frameRect = ref({ x: 0, y: 0, width: 0, height: 0 })
+const frameSize = ref({ width: 0, height: 0 })
 
 const isOpen = computed(() => props.modelValue)
 
 const close = () => emit('update:modelValue', false)
 
-const syncFrameRect = () => {
+const syncFrameRect = async () => {
   if (!frameRef.value || !containerRef.value || !canvasRef.value) return
-  const frameBox = frameRef.value.getBoundingClientRect()
   const containerBox = containerRef.value.getBoundingClientRect()
   canvasRef.value.width = containerBox.width
   canvasRef.value.height = containerBox.height
+  const ratio = props.frameWidthRatio / props.frameHeightRatio
+  const maxWidth = containerBox.width * 0.9
+  const maxHeight = containerBox.height * 0.9
+  let frameWidth = Math.min(maxWidth, 640)
+  let frameHeight = frameWidth / ratio
+  if (frameHeight > maxHeight) {
+    frameHeight = maxHeight
+    frameWidth = frameHeight * ratio
+  }
+  frameSize.value = { width: frameWidth, height: frameHeight }
+  await nextTick()
+  const frameBox = frameRef.value.getBoundingClientRect()
   frameRect.value = {
     x: frameBox.left - containerBox.left,
     y: frameBox.top - containerBox.top,
@@ -58,7 +84,7 @@ const loadImage = async () => {
   scale.value = 1
   offset.value = { x: 0, y: 0 }
   await nextTick()
-  syncFrameRect()
+  await syncFrameRect()
   drawPreview()
 }
 
@@ -123,8 +149,8 @@ const handleScaleInput = (value: number) => {
 const confirmCrop = () => {
   const img = imageElement.value
   if (!img) return
-  const outputWidth = 1280
-  const outputHeight = 720
+  const outputWidth = props.outputWidth
+  const outputHeight = props.outputHeight
   const outputCanvas = document.createElement('canvas')
   outputCanvas.width = outputWidth
   outputCanvas.height = outputHeight
@@ -175,14 +201,21 @@ onUnmounted(() => {
       <header class="ds-modal__head">
         <div>
           <p class="ds-modal__eyebrow">이미지 편집</p>
-          <h3 class="ds-modal__title">16:9 이미지 자르기</h3>
+          <h3 class="ds-modal__title">{{ title }}</h3>
         </div>
         <button type="button" class="ds-modal__close" aria-label="닫기" @click="close">×</button>
       </header>
 
       <div class="cropper" ref="containerRef">
         <canvas ref="canvasRef" class="cropper__canvas" width="640" height="420" @pointerdown="handlePointerDown"></canvas>
-        <div ref="frameRef" class="cropper__frame"></div>
+        <div
+          ref="frameRef"
+          class="cropper__frame"
+          :style="{
+            width: frameSize.width ? `${frameSize.width}px` : undefined,
+            height: frameSize.height ? `${frameSize.height}px` : undefined,
+          }"
+        ></div>
       </div>
 
       <div class="cropper__controls">
@@ -302,8 +335,6 @@ onUnmounted(() => {
   position: absolute;
   left: 50%;
   top: 50%;
-  width: min(100%, 640px);
-  aspect-ratio: 16 / 9;
   transform: translate(-50%, -50%);
   border: 2px solid rgba(255, 255, 255, 0.9);
   box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.55);

--- a/front/src/pages/seller/ProductEditInfo.vue
+++ b/front/src/pages/seller/ProductEditInfo.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import PageContainer from '../../components/PageContainer.vue'
 import PageHeader from '../../components/PageHeader.vue'
 import ProductBasicFields from '../../components/seller/ProductBasicFields.vue'
+import LiveImageCropModal from '../../components/LiveImageCropModal.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -19,6 +20,14 @@ const images = ref<string[]>(['', '', '', '', ''])
 const error = ref('')
 const status = ref<ProductStatus | null>(null)
 const isDeleting = ref(false)
+const imagesDirty = ref(false)
+const uploadings = ref<boolean[]>([false, false, false, false, false])
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+const cropperOpen = ref(false)
+const cropperSource = ref('')
+const cropperFileName = ref('')
+const cropperIndex = ref<number | null>(null)
+const cropperInputRef = ref<HTMLInputElement | null>(null)
 
 const statusLabelMap: Record<ProductStatus, string> = {
   DRAFT: '작성중',
@@ -34,6 +43,105 @@ const buildAuthHeaders = (): Record<string, string> => {
   const access = localStorage.getItem('access') || sessionStorage.getItem('access')
   if (!access) return {}
   return { Authorization: `Bearer ${access}` }
+}
+
+const setUploading = (index: number, value: boolean) => {
+  uploadings.value = uploadings.value.map((slot, idx) => (idx === index ? value : slot))
+}
+
+const resetCropperState = () => {
+  cropperSource.value = ''
+  cropperFileName.value = ''
+  cropperIndex.value = null
+  cropperInputRef.value = null
+}
+
+const openCropper = (file: File, index: number, input: HTMLInputElement) => {
+  const reader = new FileReader()
+  reader.onload = () => {
+    cropperSource.value = typeof reader.result === 'string' ? reader.result : ''
+    cropperFileName.value = file.name
+    cropperIndex.value = index
+    cropperInputRef.value = input
+    cropperOpen.value = true
+  }
+  reader.readAsDataURL(file)
+}
+
+const dataUrlToFile = (dataUrl: string, fileName: string) => {
+  const [header, base64] = dataUrl.split(',')
+  if (!header || !base64) return null
+  const mimeMatch = header.match(/data:(.*?);base64/)
+  const mimeType = mimeMatch?.[1] ?? 'image/jpeg'
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return new File([bytes], fileName, { type: mimeType })
+}
+
+const uploadImageFile = async (index: number, file: File) => {
+  error.value = ''
+  setUploading(index, true)
+  try {
+    const formData = new FormData()
+    formData.append('file', file)
+    const response = await fetch(`${apiBase}/api/seller/products/images/upload`, {
+      method: 'POST',
+      headers: {
+        ...buildAuthHeaders(),
+      },
+      credentials: 'include',
+      body: formData,
+    })
+    if (response.status === 401 || response.status === 403) {
+      error.value = '권한이 없습니다. 다시 로그인해주세요.'
+      return
+    }
+    if (response.status === 413) {
+      error.value = '파일 크기가 제한을 초과했습니다.'
+      return
+    }
+    if (!response.ok) {
+      error.value = '이미지 업로드에 실패했습니다.'
+      return
+    }
+    const data = (await response.json()) as { url?: string }
+    if (!data.url) {
+      error.value = '이미지 업로드에 실패했습니다.'
+      return
+    }
+    const next = [...images.value]
+    next[index] = data.url
+    images.value = next
+    imagesDirty.value = true
+  } catch {
+    error.value = '이미지 업로드에 실패했습니다.'
+  } finally {
+    setUploading(index, false)
+    if (cropperInputRef.value) {
+      cropperInputRef.value.value = ''
+    }
+  }
+}
+
+const handleCropConfirm = async (payload: { dataUrl: string; fileName: string }) => {
+  const index = cropperIndex.value
+  if (index === null) return
+  const file = dataUrlToFile(payload.dataUrl, payload.fileName)
+  if (!file) {
+    error.value = '이미지 업로드에 실패했습니다.'
+    cropperOpen.value = false
+    return
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    error.value = '파일 크기가 제한을 초과했습니다.'
+    cropperOpen.value = false
+    return
+  }
+  await uploadImageFile(index, file)
+  cropperOpen.value = false
 }
 
 const loadInitial = async () => {
@@ -59,42 +167,47 @@ const loadInitial = async () => {
       short_desc?: string
       price?: number
       stock_qty?: number
+      image_urls?: string[]
       status?: ProductStatus
     }
     name.value = data.product_name ?? ''
     shortDesc.value = data.short_desc ?? ''
     price.value = typeof data.price === 'number' ? data.price : 0
     stock.value = typeof data.stock_qty === 'number' ? data.stock_qty : 0
+    const imageUrls = Array.isArray(data.image_urls) ? data.image_urls.slice(0, 5) : []
+    images.value = Array.from({ length: 5 }, (_, index) => imageUrls[index] ?? '')
+    uploadings.value = [false, false, false, false, false]
+    imagesDirty.value = false
     status.value = data.status ?? null
   } catch {
     error.value = '상품 정보를 불러올 수 없습니다.'
   }
 }
 
-const setImageAt = (index: number, event: Event) => {
+const setImageAt = async (index: number, event: Event) => {
   const input = event.target as HTMLInputElement
   const file = input.files?.[0]
   if (!file) return
-  if (!file.type.startsWith('image/')) {
+  if (!file.type || !file.type.startsWith('image/')) {
     error.value = '이미지 파일만 업로드할 수 있습니다.'
     input.value = ''
     return
   }
-  const reader = new FileReader()
-  reader.onload = () => {
-    if (typeof reader.result === 'string') {
-      const next = [...images.value]
-      next[index] = reader.result
-      images.value = next
-    }
+  if (file.size > MAX_IMAGE_BYTES) {
+    error.value = '파일 크기가 제한을 초과했습니다.'
+    input.value = ''
+    return
   }
-  reader.readAsDataURL(file)
+
+  error.value = ''
+  openCropper(file, index, input)
 }
 
 const clearImageAt = (index: number) => {
   const next = [...images.value]
   next[index] = ''
   images.value = next
+  imagesDirty.value = true
 }
 
 const cancel = () => {
@@ -105,6 +218,10 @@ const handleDelete = async () => {
   const id = typeof route.params.id === 'string' ? route.params.id : ''
   if (!id) {
     error.value = '상품 정보를 확인할 수 없습니다.'
+    return
+  }
+  if (uploadings.value.some((slot) => slot)) {
+    error.value = '이미지 업로드가 완료될 때까지 기다려주세요.'
     return
   }
   if (!window.confirm('정말 삭제하시겠습니까?')) return
@@ -181,6 +298,10 @@ const handleSubmit = async () => {
     error.value = '수정할 수 없는 상품 상태입니다.'
     return
   }
+  if (uploadings.value.some((slot) => slot)) {
+    error.value = '이미지 업로드가 완료될 때까지 기다려주세요.'
+    return
+  }
 
   const id = typeof route.params.id === 'string' ? route.params.id : ''
   if (!id) {
@@ -197,6 +318,13 @@ const handleSubmit = async () => {
   } else if (canEditPartial.value) {
     payload.short_desc = shortDesc.value.trim()
     payload.price = price.value
+  }
+  if (imagesDirty.value) {
+    if (!images.value[0]) {
+      error.value = '썸네일 이미지를 등록해주세요.'
+      return
+    }
+    payload.image_urls = images.value.filter((url) => url)
   }
 
   try {
@@ -222,11 +350,31 @@ const handleSubmit = async () => {
 onMounted(() => {
   loadInitial()
 })
+
+watch(cropperOpen, (open, wasOpen) => {
+  if (!open && wasOpen) {
+    if (cropperInputRef.value) {
+      cropperInputRef.value.value = ''
+    }
+    resetCropperState()
+  }
+})
 </script>
 
 <template>
   <PageContainer>
     <PageHeader eyebrow="DESKIT" title="상품 수정 - 기본 정보" />
+    <LiveImageCropModal
+      v-model="cropperOpen"
+      :image-src="cropperSource"
+      :file-name="cropperFileName"
+      title="1:1 이미지 자르기"
+      :frame-width-ratio="1"
+      :frame-height-ratio="1"
+      :output-width="1024"
+      :output-height="1024"
+      @confirm="handleCropConfirm"
+    />
     <section class="create-card ds-surface">
       <div v-if="status" class="status-info">
         <span class="status-label">현재 상태: {{ statusLabelMap[status] }}</span>
@@ -252,8 +400,14 @@ onMounted(() => {
             <div class="image-slot__preview">
               <img v-if="img" :src="img" :alt="`상품 이미지 ${idx}`" />
               <label v-if="!img" class="btn ghost image-slot__upload">
-                업로드
-                <input type="file" accept="image/*" @change="setImageAt(idx, $event)" hidden />
+                {{ uploadings[idx] ? '업로드 중' : '업로드' }}
+                <input
+                  type="file"
+                  accept="image/*"
+                  :disabled="uploadings[idx]"
+                  @change="setImageAt(idx, $event)"
+                  hidden
+                />
               </label>
             </div>
             <div class="image-slot__actions">
@@ -267,7 +421,14 @@ onMounted(() => {
       <p v-if="error" class="error">{{ error }}</p>
       <div class="actions">
         <button type="button" class="btn" @click="cancel">취소</button>
-        <button type="button" class="btn danger" :disabled="isDeleting" @click="handleDelete">삭제</button>
+        <button
+          type="button"
+          class="btn danger"
+          :disabled="isDeleting || uploadings.some((slot) => slot)"
+          @click="handleDelete"
+        >
+          삭제
+        </button>
         <button type="button" class="btn primary" @click="handleSubmit">상세 수정</button>
       </div>
     </section>

--- a/src/main/java/com/deskit/deskit/livehost/common/enums/UploadType.java
+++ b/src/main/java/com/deskit/deskit/livehost/common/enums/UploadType.java
@@ -11,7 +11,10 @@ public enum UploadType {
     THUMBNAIL(5 * 1024 * 1024L, 16.0, 9.0, "방송 썸네일"),
 
     // 대기화면: 16:9 비율, 최대 7MB
-    WAIT_SCREEN(5 * 1024 * 1024L, 16.0, 9.0, "방송 대기화면");
+    WAIT_SCREEN(5 * 1024 * 1024L, 16.0, 9.0, "방송 대기화면"),
+
+    // 상품 이미지: 1:1 비율, 최대 5MB
+    PRODUCT_IMAGE(5 * 1024 * 1024L, 1.0, 1.0, "상품 이미지");
 
     private final long maxSizeBytes; // 최대 용량 (Byte)
     private final double widthRatio; // 가로 비율

--- a/src/main/java/com/deskit/deskit/livehost/common/exception/ErrorCode.java
+++ b/src/main/java/com/deskit/deskit/livehost/common/exception/ErrorCode.java
@@ -58,7 +58,7 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드에 실패했습니다."),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "F002", "지원하지 않는 파일 형식입니다. (jpg, png, gif만 가능)"),
     FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F003", "파일 삭제에 실패했습니다."),
-    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "F004", "파일 크기가 제한을 초과했습니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "F004", "파일 크기가 제한을 초과했습니다."),
     INVALID_IMAGE_RATIO(HttpStatus.BAD_REQUEST, "F005", "이미지 비율이 올바르지 않습니다."),
 
     // 11. 시스템 에러

--- a/src/main/java/com/deskit/deskit/livehost/service/AwsS3Service.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/AwsS3Service.java
@@ -180,6 +180,9 @@ public class AwsS3Service {
     }
 
     private void validateImageRatio(MultipartFile file, UploadType type) {
+        if (type.getWidthRatio() <= 0 || type.getHeightRatio() <= 0) {
+            return;
+        }
         try {
             BufferedImage image = ImageIO.read(file.getInputStream());
 

--- a/src/main/java/com/deskit/deskit/product/controller/ProductUploadExceptionHandler.java
+++ b/src/main/java/com/deskit/deskit/product/controller/ProductUploadExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.deskit.deskit.product.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+@RestControllerAdvice(basePackages = "com.deskit.deskit.product.controller")
+public class ProductUploadExceptionHandler {
+
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public ResponseEntity<String> handleMaxUploadSizeExceeded(MaxUploadSizeExceededException ex) {
+    return ResponseEntity
+      .status(HttpStatus.PAYLOAD_TOO_LARGE)
+      .body("파일 크기가 제한을 초과했습니다.");
+  }
+}

--- a/src/main/java/com/deskit/deskit/product/dto/ProductImageUploadResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductImageUploadResponse.java
@@ -1,0 +1,11 @@
+package com.deskit.deskit.product.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ProductImageUploadResponse(
+  @JsonProperty("url")
+  String url,
+
+  @JsonProperty("key")
+  String key
+) {}


### PR DESCRIPTION
## 📌 관련 이슈
- closes #151

## 📝 작업 내용
- 상품 이미지 업로드 API 구현: POST /api/seller/products/images/upload (multipart/form-data)
- NCP Object Storage 업로드 재사용(기존 livehost AwsS3Service) 및 응답 DTO(ProductImageUploadResponse)로 url/key 반환
- 업로드 타입 PRODUCT_IMAGE 추가(1:1 비율, 최대 5MB) 및 비율 검증 스킵 조건 보완
- 업로드 용량 초과(413) 메시지 일관화(파일 크기가 제한을 초과했습니다.)
- 상품 등록/수정 화면 이미지 플로우 개선
  - LiveImageCropModal 재사용하여 1:1 크롭(1024x1024) 후 업로드
  - 업로드 중 상태(uploading) 처리 및 저장/삭제 시 업로드 진행 중 차단
  - 등록 플로우에서 생성 후 PUT으로 image_urls 저장, 404/413 예외 메시지 처리
  - 수정 플로우에서 imagesDirty일 때만 image_urls 반영, 썸네일(슬롯0) 필수 검증

## 🧐 리뷰 포인트
- livehost AwsS3Service 재사용 구조가 product 도메인 요구사항에 무리 없는지(UploadType.PRODUCT_IMAGE 추가 방식)