### PR TITLE
[FEAT] 판매자 상품 수정/이미지 업로드·크롭(1:1)·삭제/교체 및 스토리지 키 연동

### DIFF
--- a/front/.env.example
+++ b/front/.env.example
@@ -5,4 +5,5 @@ VITE_API_BASE_URL=https://api.example.com
 VITE_USE_MOCK_API=true
 
 # API request timeout in milliseconds
-VITE_API_TIMEOUT_MS=10000
+VITE_API_TIMEOUT_MS=10000ch
+

--- a/front/src/api/products.ts
+++ b/front/src/api/products.ts
@@ -2,7 +2,6 @@ import { http } from './http'
 import { endpoints } from './endpoints'
 import { USE_MOCK_API } from './config'
 import { type DbProduct } from '../lib/products-data'
-import { deleteMockProduct, getAllMockProducts } from '../lib/mocks/sellerProducts'
 import { normalizeProduct, normalizeProducts } from './products-normalizer'
 import {
   fetchDetailTextJson,
@@ -13,7 +12,8 @@ import {
 } from './api-text-json'
 
 export const listProducts = async (): Promise<DbProduct[]> => {
-  if (USE_MOCK_API) {
+  if (import.meta.env.DEV && USE_MOCK_API) {
+    const { getAllMockProducts } = await import('../lib/mocks/sellerProducts')
     return getAllMockProducts()
   }
 
@@ -34,7 +34,8 @@ export const listProductsWithAuthGuard = async (): Promise<{
   products: DbProduct[]
   authRequired: boolean
 }> => {
-  if (USE_MOCK_API) {
+  if (import.meta.env.DEV && USE_MOCK_API) {
+    const { getAllMockProducts } = await import('../lib/mocks/sellerProducts')
     return { products: getAllMockProducts(), authRequired: false }
   }
 
@@ -60,7 +61,8 @@ export const listProductsWithAuthGuard = async (): Promise<{
 export const getProductDetail = async (
   id: string | number
 ): Promise<DbProduct | null> => {
-  if (USE_MOCK_API) {
+  if (import.meta.env.DEV && USE_MOCK_API) {
+    const { getAllMockProducts } = await import('../lib/mocks/sellerProducts')
     const products = getAllMockProducts()
     const found = products.find(
       (product) => String(product.product_id ?? product.id) === String(id)
@@ -77,7 +79,8 @@ export const getProductDetail = async (
 }
 
 export const deleteProduct = async (id: string | number): Promise<void> => {
-  if (USE_MOCK_API) {
+  if (import.meta.env.DEV && USE_MOCK_API) {
+    const { deleteMockProduct } = await import('../lib/mocks/sellerProducts')
     deleteMockProduct(String(id))
     return
   }

--- a/front/src/components/LiveImageCropModal.vue
+++ b/front/src/components/LiveImageCropModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, ref, watch, withDefaults } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 
 const props = withDefaults(
   defineProps<{

--- a/front/src/pages/MyPage.vue
+++ b/front/src/pages/MyPage.vue
@@ -29,7 +29,9 @@ const EMPTY_USER: UserInfo = {
 
 const router = useRouter()
 const user = ref<UserInfo | null>(null)
+const profileImageFailed = ref(false)
 const recommendedProducts = ref<DbProduct[]>([])
+const apiBase = (import.meta.env.VITE_API_BASE_URL || '').trim()
 const preferencePrompt =
   '지금 MBTI(직업군)를 입력하고 나에게 맞춘 데스크테리어 상품 추천을 받아보세요!'
 
@@ -695,4 +697,3 @@ onMounted(() => {
   }
 }
 </style>
-

--- a/front/src/pages/admin/AdminDashboard.vue
+++ b/front/src/pages/admin/AdminDashboard.vue
@@ -90,7 +90,6 @@ const maxVisitors = computed(() => Math.max(...visitorsChart.value.map((item) =>
 const maxRevenue = computed(() => Math.max(...revenueChart.value.map((item) => item.value), 1))
 
 const handleExport = () => {
-  console.log('[admin] export excel')
 }
 </script>
 

--- a/front/src/pages/admin/AdminProducts.vue
+++ b/front/src/pages/admin/AdminProducts.vue
@@ -3,7 +3,6 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import PageHeader from '../../components/PageHeader.vue'
 import { type DbProduct } from '../../lib/products-data'
 import { deleteProduct, listProducts } from '../../api/products'
-import { SELLER_PRODUCTS_EVENT } from '../../lib/mocks/sellerProducts'
 import { USE_MOCK_API } from '../../api/config'
 
 type ProductStatus = 'selling' | 'soldout' | 'hidden'
@@ -22,6 +21,7 @@ const baseProducts = ref<DbProduct[]>([])
 const isLoading = ref(false)
 const errorMessage = ref('')
 const deletingKey = ref<string | null>(null)
+const mockEventName = ref<string | null>(null)
 
 const statusLabelMap: Record<ProductStatus, string> = {
   selling: '판매중',
@@ -153,14 +153,16 @@ const handleDelete = async (product: any) => {
 onMounted(async () => {
   loadStatusMap()
   await refreshProducts()
-  if (USE_MOCK_API) {
+  if (import.meta.env.DEV && USE_MOCK_API) {
+    const { SELLER_PRODUCTS_EVENT } = await import('../../lib/mocks/sellerProducts')
+    mockEventName.value = SELLER_PRODUCTS_EVENT
     window.addEventListener(SELLER_PRODUCTS_EVENT, onProductsChanged)
   }
 })
 
 onBeforeUnmount(() => {
-  if (USE_MOCK_API) {
-    window.removeEventListener(SELLER_PRODUCTS_EVENT, onProductsChanged)
+  if (mockEventName.value) {
+    window.removeEventListener(mockEventName.value, onProductsChanged)
   }
 })
 </script>

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -977,7 +977,6 @@ const closeChat = () => {
 const openModeration = (msg: { user: string; kind?: string; memberLoginId?: string; connectionId?: string }) => {
   if (!isInteractive.value) return
   if (msg.user === 'SYSTEM' || msg.kind === 'system' || msg.user === '관리자') return
-  console.log('[admin chat] moderation open', msg.user)
   moderationTarget.value = { user: msg.user, memberLoginId: msg.memberLoginId, connectionId: msg.connectionId }
   moderationType.value = ''
   moderationReason.value = ''

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -358,7 +358,7 @@ const connectChat = () => {
         withCredentials: true,
       }),
     reconnectDelay: 5000,
-    debug: (str) => console.log('[STOMP]', str),
+    debug: () => {},
   })
   const access = getAccessToken()
   if (access) {

--- a/front/src/pages/seller/ProductEditInfo.vue
+++ b/front/src/pages/seller/ProductEditInfo.vue
@@ -17,6 +17,7 @@ const shortDesc = ref('')
 const price = ref(0)
 const stock = ref(0)
 const images = ref<string[]>(['', '', '', '', ''])
+const imageKeys = ref<string[]>(['', '', '', '', ''])
 const error = ref('')
 const status = ref<ProductStatus | null>(null)
 const isDeleting = ref(false)
@@ -107,7 +108,7 @@ const uploadImageFile = async (index: number, file: File) => {
       error.value = '이미지 업로드에 실패했습니다.'
       return
     }
-    const data = (await response.json()) as { url?: string }
+    const data = (await response.json()) as { url?: string; key?: string }
     if (!data.url) {
       error.value = '이미지 업로드에 실패했습니다.'
       return
@@ -115,6 +116,9 @@ const uploadImageFile = async (index: number, file: File) => {
     const next = [...images.value]
     next[index] = data.url
     images.value = next
+    const nextKeys = [...imageKeys.value]
+    nextKeys[index] = data.key ?? ''
+    imageKeys.value = nextKeys
     imagesDirty.value = true
   } catch {
     error.value = '이미지 업로드에 실패했습니다.'
@@ -168,6 +172,7 @@ const loadInitial = async () => {
       price?: number
       stock_qty?: number
       image_urls?: string[]
+      image_keys?: string[]
       status?: ProductStatus
     }
     name.value = data.product_name ?? ''
@@ -175,7 +180,9 @@ const loadInitial = async () => {
     price.value = typeof data.price === 'number' ? data.price : 0
     stock.value = typeof data.stock_qty === 'number' ? data.stock_qty : 0
     const imageUrls = Array.isArray(data.image_urls) ? data.image_urls.slice(0, 5) : []
+    const imageKeyValues = Array.isArray(data.image_keys) ? data.image_keys.slice(0, 5) : []
     images.value = Array.from({ length: 5 }, (_, index) => imageUrls[index] ?? '')
+    imageKeys.value = Array.from({ length: 5 }, (_, index) => imageKeyValues[index] ?? '')
     uploadings.value = [false, false, false, false, false]
     imagesDirty.value = false
     status.value = data.status ?? null
@@ -207,6 +214,9 @@ const clearImageAt = (index: number) => {
   const next = [...images.value]
   next[index] = ''
   images.value = next
+  const nextKeys = [...imageKeys.value]
+  nextKeys[index] = ''
+  imageKeys.value = nextKeys
   imagesDirty.value = true
 }
 
@@ -324,7 +334,8 @@ const handleSubmit = async () => {
       error.value = '썸네일 이미지를 등록해주세요.'
       return
     }
-    payload.image_urls = images.value.filter((url) => url)
+    payload.image_urls = images.value.slice(0, 5)
+    payload.image_keys = imageKeys.value.slice(0, 5)
   }
 
   try {

--- a/front/src/pages/seller/Products.vue
+++ b/front/src/pages/seller/Products.vue
@@ -214,7 +214,6 @@ onMounted(() => {
     <section v-else class="product-list">
       <article v-for="product in filteredProducts" :key="product.product_id" class="product-card ds-surface">
         <div class="thumb">
-          <!-- TODO: seller list API does not return thumbnail yet -->
           <div class="thumb__placeholder"></div>
         </div>
         <div class="product-main">

--- a/src/main/java/com/deskit/deskit/account/service/MyPageService.java
+++ b/src/main/java/com/deskit/deskit/account/service/MyPageService.java
@@ -51,18 +51,6 @@ public class MyPageService {
 			profileUrl = resolveProfileUrl(normalizedRole, loginId);
 		}
 
-		if ("ROLE_MEMBER".equals(normalizedRole) && !loginId.isEmpty()) {
-			Member member = memberRepository.findByLoginId(loginId);
-			if (member != null) {
-				if (member.getMbti() != null) {
-					mbti = member.getMbti().name();
-				}
-				if (member.getJobCategory() != null) {
-					job = mapJobCategory(member.getJobCategory());
-				}
-			}
-		}
-
 		return new MyPageResponse(
 				name,
 				email,

--- a/src/main/java/com/deskit/deskit/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/deskit/deskit/order/repository/OrderItemRepository.java
@@ -1,8 +1,11 @@
 package com.deskit.deskit.order.repository;
 
 import com.deskit.deskit.order.entity.OrderItem;
+import com.deskit.deskit.order.enums.OrderStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * OrderItem(주문 상품/라인 아이템) 조회/저장을 담당하는 Repository
@@ -20,4 +23,16 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
    *   - 그 안의 "id" 값을 조건으로 검색한다는 뜻 (order.id)
    */
   List<OrderItem> findByOrder_Id(Long orderId);
+
+  @Query("""
+      select (count(oi) > 0)
+      from OrderItem oi
+      join oi.order o
+      where oi.productId = :productId
+        and oi.deletedAt is null
+        and o.deletedAt is null
+        and o.status in :statuses
+      """)
+  boolean existsPaidOrderByProductId(@Param("productId") Long productId,
+                                     @Param("statuses") List<OrderStatus> statuses);
 }

--- a/src/main/java/com/deskit/deskit/product/dto/ProductBasicUpdateRequest.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductBasicUpdateRequest.java
@@ -23,5 +23,8 @@ public record ProductBasicUpdateRequest(
   String detailHtml,
 
   @JsonProperty("image_urls")
-  List<String> imageUrls
+  List<String> imageUrls,
+
+  @JsonProperty("image_keys")
+  List<String> imageKeys
 ) {}

--- a/src/main/java/com/deskit/deskit/product/dto/SellerProductDetailResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/SellerProductDetailResponse.java
@@ -26,12 +26,15 @@ public record SellerProductDetailResponse(
   @JsonProperty("image_urls")
   List<String> imageUrls,
 
+  @JsonProperty("image_keys")
+  List<String> imageKeys,
+
   @JsonProperty("status")
   Product.Status status
 ) {
-  public static SellerProductDetailResponse from(Product product, List<String> imageUrls) {
+  public static SellerProductDetailResponse from(Product product, List<String> imageUrls, List<String> imageKeys) {
     if (product == null) {
-      return new SellerProductDetailResponse(null, null, null, null, null, null, null, null);
+      return new SellerProductDetailResponse(null, null, null, null, null, null, null, null, null);
     }
     return new SellerProductDetailResponse(
       product.getId(),
@@ -41,6 +44,7 @@ public record SellerProductDetailResponse(
       product.getStockQty(),
       product.getDetailHtml(),
       imageUrls,
+      imageKeys,
       product.getStatus()
     );
   }

--- a/src/main/java/com/deskit/deskit/product/entity/ProductImage.java
+++ b/src/main/java/com/deskit/deskit/product/entity/ProductImage.java
@@ -35,6 +35,9 @@ public class ProductImage extends BaseEntity {
   @Column(name = "product_image_url", nullable = false, length = 500)
   private String productImageUrl;
 
+  @Column(name = "stored_file_name", length = 500)
+  private String storedFileName;
+
   @Enumerated(EnumType.STRING)
   @Column(name = "image_type", nullable = false)
   private ImageType imageType;
@@ -43,9 +46,14 @@ public class ProductImage extends BaseEntity {
   private Integer slotIndex;
 
   public static ProductImage create(Long productId, String productImageUrl, ImageType imageType, Integer slotIndex) {
+    return create(productId, productImageUrl, null, imageType, slotIndex);
+  }
+
+  public static ProductImage create(Long productId, String productImageUrl, String storedFileName, ImageType imageType, Integer slotIndex) {
     ProductImage image = new ProductImage();
     image.productId = productId;
     image.productImageUrl = productImageUrl;
+    image.storedFileName = storedFileName;
     image.imageType = imageType;
     image.slotIndex = slotIndex;
     return image;

--- a/src/main/java/com/deskit/deskit/product/repository/ProductRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductRepository.java
@@ -41,6 +41,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
    */
   Optional<Product> findByIdAndDeletedAtIsNull(Long id);
 
+  List<Product> findAllByIdInAndDeletedAtIsNull(List<Long> ids);
+
   Optional<Product> findByIdAndStatusAndDeletedAtIsNull(Long id, Product.Status status);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/deskit/deskit/product/service/ProductService.java
+++ b/src/main/java/com/deskit/deskit/product/service/ProductService.java
@@ -18,6 +18,9 @@ import com.deskit.deskit.product.repository.ProductRepository;
 import com.deskit.deskit.product.repository.ProductTagRepository;
 import com.deskit.deskit.product.repository.ProductTagRepository.ProductTagRow;
 import com.deskit.deskit.livehost.repository.BroadcastProductRepository;
+import com.deskit.deskit.livehost.service.AwsS3Service;
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.deskit.deskit.order.repository.OrderItemRepository;
 import com.deskit.deskit.tag.entity.TagCategory.TagCode;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -29,6 +32,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -40,16 +45,24 @@ public class ProductService {
   private final ProductTagRepository productTagRepository; // Product-Tag 매핑 조회용 JPA Repository
   private final ProductImageRepository productImageRepository;
   private final BroadcastProductRepository broadcastProductRepository;
+  private final OrderItemRepository orderItemRepository;
+  private final AwsS3Service awsS3Service;
+
+  private static final Logger log = LoggerFactory.getLogger(ProductService.class);
 
   // 생성자 주입: 테스트/대체 구현에 유리하고, final 필드와 잘 맞음
   public ProductService(ProductRepository productRepository,
                         ProductTagRepository productTagRepository,
                         ProductImageRepository productImageRepository,
-                        BroadcastProductRepository broadcastProductRepository) {
+                        BroadcastProductRepository broadcastProductRepository,
+                        OrderItemRepository orderItemRepository,
+                        AwsS3Service awsS3Service) {
     this.productRepository = productRepository;
     this.productTagRepository = productTagRepository;
     this.productImageRepository = productImageRepository;
     this.broadcastProductRepository = broadcastProductRepository;
+    this.orderItemRepository = orderItemRepository;
+    this.awsS3Service = awsS3Service;
   }
 
   // 상품 목록 조회: deleted_at IS NULL인 상품만 가져오고, 태그는 productIds로 한 번에 batch 조회 (N+1 방지)
@@ -284,6 +297,9 @@ public class ProductService {
         || request.price() != null
         || request.stockQty() != null;
     boolean hasDetail = request.detailHtml() != null;
+    if (request.imageKeys() != null && request.imageUrls() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "image_urls required when image_keys present");
+    }
     boolean hasImages = request.imageUrls() != null;
 
     if (!hasBasicFields && !hasDetail && !hasImages) {
@@ -304,6 +320,22 @@ public class ProductService {
       }
       if (request.stockQty() != null) {
         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "stock_qty not allowed");
+      }
+    }
+
+    boolean triesRestrictedUpdate =
+      (request.productName() != null && !Objects.equals(request.productName(), product.getProductName()))
+        || (request.shortDesc() != null && !Objects.equals(request.shortDesc(), product.getShortDesc()))
+        || (request.price() != null && !Objects.equals(request.price(), product.getPrice()))
+        || (request.detailHtml() != null && !Objects.equals(request.detailHtml(), product.getDetailHtml()));
+
+    if (triesRestrictedUpdate) {
+      boolean hasPaidOrders = orderItemRepository.existsPaidOrderByProductId(
+        productId,
+        List.of(OrderStatus.PAID, OrderStatus.COMPLETED)
+      );
+      if (hasPaidOrders) {
+        throw new ResponseStatusException(HttpStatus.CONFLICT, "주문이 존재하는 상품은 가격/정보를 수정할 수 없습니다.");
       }
     }
 
@@ -329,31 +361,85 @@ public class ProductService {
 
     if (hasImages) {
       List<String> imageUrls = request.imageUrls();
-      if (imageUrls.size() > 5) {
-        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "max 5 images per product");
+      List<String> imageKeys = request.imageKeys();
+      if (imageUrls.size() != 5) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "image_urls must be length 5");
       }
-      if (imageUrls.stream().anyMatch(url -> url == null || url.isBlank())) {
-        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid image_urls");
+      if (imageKeys != null && imageKeys.size() != 5) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "image_keys must be length 5");
+      }
+      if (imageKeys != null && imageUrls.size() != imageKeys.size()) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "image_urls and image_keys length mismatch");
       }
 
       List<ProductImage> existingImages =
         productImageRepository.findAllByProductIdAndDeletedAtIsNullOrderBySlotIndexAsc(productId);
-      if (!existingImages.isEmpty()) {
-        LocalDateTime now = LocalDateTime.now();
-        for (ProductImage image : existingImages) {
-          image.setDeletedAt(now);
+      Map<Integer, ProductImage> existingBySlot = existingImages.stream()
+        .filter(image -> image.getSlotIndex() != null)
+        .collect(Collectors.toMap(ProductImage::getSlotIndex, image -> image, (left, right) -> left));
+
+      LocalDateTime now = LocalDateTime.now();
+      List<ProductImage> toSoftDelete = new ArrayList<>();
+      List<ProductImage> toCreate = new ArrayList<>();
+
+      for (int index = 0; index < 5; index += 1) {
+        String desiredUrl = imageUrls.get(index);
+        if (desiredUrl != null && desiredUrl.isBlank()) {
+          desiredUrl = null;
         }
-        productImageRepository.saveAll(existingImages);
+        String desiredKey = null;
+        if (imageKeys != null) {
+          desiredKey = imageKeys.get(index);
+          if (desiredKey != null && desiredKey.isBlank()) {
+            desiredKey = null;
+          }
+        }
+        if (desiredUrl == null && desiredKey != null) {
+          throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "image_key cannot exist without image_url");
+        }
+
+        ProductImage existing = existingBySlot.get(index);
+        if (desiredUrl == null) {
+          if (existing != null) {
+            existing.setDeletedAt(now);
+            toSoftDelete.add(existing);
+            if (existing.getStoredFileName() != null && !existing.getStoredFileName().isBlank()) {
+              try {
+                awsS3Service.deleteFile(sellerId, existing.getStoredFileName());
+              } catch (RuntimeException ex) {
+                log.warn("Failed to delete product image from storage: productId={}, sellerId={}, key={}", productId, sellerId, existing.getStoredFileName(), ex);
+              }
+            }
+          }
+          continue;
+        }
+
+        if (existing != null) {
+          boolean sameUrl = desiredUrl.equals(existing.getProductImageUrl());
+          boolean sameKey = Objects.equals(desiredKey, existing.getStoredFileName());
+          if (sameUrl && sameKey) {
+            continue;
+          }
+          existing.setDeletedAt(now);
+          toSoftDelete.add(existing);
+          if (existing.getStoredFileName() != null && !existing.getStoredFileName().isBlank()) {
+            try {
+              awsS3Service.deleteFile(sellerId, existing.getStoredFileName());
+            } catch (RuntimeException ex) {
+              log.warn("Failed to delete product image from storage: productId={}, sellerId={}, key={}", productId, sellerId, existing.getStoredFileName(), ex);
+            }
+          }
+        }
+
+        ImageType imageType = index == 0 ? ImageType.THUMBNAIL : ImageType.GALLERY;
+        toCreate.add(ProductImage.create(productId, desiredUrl, desiredKey, imageType, index));
       }
 
-      if (!imageUrls.isEmpty()) {
-        List<ProductImage> nextImages = new ArrayList<>();
-        for (int index = 0; index < imageUrls.size(); index += 1) {
-          String imageUrl = imageUrls.get(index);
-          ImageType imageType = index == 0 ? ImageType.THUMBNAIL : ImageType.GALLERY;
-          nextImages.add(ProductImage.create(productId, imageUrl, imageType, index));
-        }
-        productImageRepository.saveAll(nextImages);
+      if (!toSoftDelete.isEmpty()) {
+        productImageRepository.saveAll(toSoftDelete);
+      }
+      if (!toCreate.isEmpty()) {
+        productImageRepository.saveAll(toCreate);
       }
     }
 
@@ -375,13 +461,16 @@ public class ProductService {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
     }
 
-    List<String> imageUrls = productImageRepository
-      .findAllByProductIdAndDeletedAtIsNullOrderBySlotIndexAsc(productId)
-      .stream()
+    List<ProductImage> images = productImageRepository
+      .findAllByProductIdAndDeletedAtIsNullOrderBySlotIndexAsc(productId);
+    List<String> imageUrls = images.stream()
       .map(ProductImage::getProductImageUrl)
       .collect(Collectors.toList());
+    List<String> imageKeys = images.stream()
+      .map(ProductImage::getStoredFileName)
+      .collect(Collectors.toList());
 
-    return SellerProductDetailResponse.from(product, imageUrls);
+    return SellerProductDetailResponse.from(product, imageUrls, imageKeys);
   }
   public void completeProductRegistration(Long sellerId, Long productId) {
     if (sellerId == null) {

--- a/src/main/resources/sql/livecommerce_create_table.sql
+++ b/src/main/resources/sql/livecommerce_create_table.sql
@@ -216,6 +216,7 @@ CREATE TABLE product_image
     product_image_id  BIGINT UNSIGNED              NOT NULL AUTO_INCREMENT COMMENT '상품 이미지 ID',
     product_id        BIGINT UNSIGNED              NOT NULL COMMENT '상품 ID(논리 FK: product.product_id)',
     product_image_url VARCHAR(500)                 NOT NULL COMMENT '이미지 URL(NCP Object Storage 등)',
+    stored_file_name  VARCHAR(500)                 NULL COMMENT 'NCP Object Storage 키',
     image_type        ENUM ('THUMBNAIL','GALLERY') NOT NULL COMMENT '이미지 타입(THUMBNAIL=대표 1칸, GALLERY=갤러리)',
     slot_index        TINYINT UNSIGNED             NOT NULL DEFAULT 0 COMMENT '슬롯 인덱스(정렬/고정용: THUMBNAIL=0, GALLERY=1~4 권장)',
     created_at        DATETIME                     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '등록 시각',


### PR DESCRIPTION
## 📌 관련 이슈
- closes #261 

## 📝 작업 내용
- 상품 이미지 업로드/에러 메시지(413 포함) UX 정리 및 프론트 처리 통일
- 상품 이미지 1:1 비율 정책 적용 + 크롭 모달(LiveImageCropModal) 재사용(상품 생성/수정)
- 상품 이미지 저장 시 url/key(스토리지 키) 5슬롯 계약으로 저장/조회 연동(image_urls, image_keys)
- 상품 이미지 삭제/교체 시 기존 key 기반 Object Storage 삭제(실패는 warn 로그 후 무시)
- 개발용 console.log/debug/info 및 불필요 주석 정리
- 로컬 환경에서 mock 미사용 설정(.env.local: VITE_USE_MOCK_API=false)
- 빌드 에러 수정(merge conflict marker 제거, MyPage.vue 누락 변수 선언)