### PR TITLE
[FEAT] 판매자 주문 관리(목록/상세) 추가 및 환불 취소 플로우 보강

### DIFF
--- a/docs/policy/order-policy.md
+++ b/docs/policy/order-policy.md
@@ -1,0 +1,73 @@
+# 주문 정책서
+
+## 정책 요약(핵심 규칙)
+- 주문 생성 시 회원/요청/아이템 검증을 통과해야 하며, 상품은 ON_SALE 상태 + 재고 충분해야 한다 (근거: `OrderService.createOrder`)
+- 주문 금액은 실시간 판매가(라이브 가격) 우선 적용 후 합산하며, 배송비는 50,000원 미만이면 3,000원 (근거: `OrderService.createOrder`#L94-L126)
+- 결제 확정 시 Toss 확인 로직에서 주문 금액 변동이 있으면 주문을 취소 처리하고 409로 응답한다 (근거: `TossPaymentService`#L94-L113, #L250-L276)
+- 주문 취소 요청은 상태에 따라 CANCEL_REQUESTED 또는 REFUND_REQUESTED로 전이하며, PAID 취소는 즉시 환불 승인(REFUNDED)까지 진행된다 (근거: `Order.requestCancel`, `OrderService.requestCancel`)
+
+## 상태/전이 표
+| 트리거 | 현재 상태 | 다음 상태 | 조건/비고 |
+|---|---|---|---|
+| 주문 생성 | (없음) | CREATED | 최초 생성 (근거: `OrderService.createOrder`)
+| 결제 확정(Toss) | CREATED | PAID | 금액 일치 + 현재가 검증 통과 (근거: `TossPaymentService.updateOrderPaid`, `Order.markPaid`)
+| 취소 요청 | CREATED | CANCEL_REQUESTED | 사용자가 취소 요청 (근거: `Order.requestCancel`)
+| 취소 요청 | PAID | REFUND_REQUESTED | 결제 완료 주문 환불 요청 (근거: `Order.requestCancel`)
+| 환불 승인 | REFUND_REQUESTED | REFUNDED | `Order.approveRefund` 실행 (근거: `OrderService.requestCancel`)
+| 취소 승인 | CANCEL_REQUESTED | CANCELLED | `Order.approveCancel` 필요 (현재 일반 취소 흐름에서는 호출되지 않음) (근거: `Order.approveCancel`, `OrderService.requestCancel`)
+| 가격 변동 취소 | CREATED | CANCELLED | 결제 확인 시 가격 변동이면 `requestCancel` + `approveCancel` 수행 (근거: `TossPaymentService.cancelOrderDueToPriceChange`)
+| 환불 거절 | REFUND_REQUESTED | REFUND_REJECTED | 별도 호출 필요(현재 공개 API 없음) (근거: `Order.rejectRefund`)
+
+## 주요 제약
+### 생성 요청 제약
+- 필수 필드: items(1개 이상), receiver(<=20), postcode(5자리), addr_detail(<=255) (근거: `CreateOrderRequest`)
+- 아이템: product_id 필수, quantity > 0 (근거: `CreateOrderItemRequest`)
+- 상품 상태/재고 검증
+  - `findByIdForUpdateAndStatus(..., ON_SALE)`로 ON_SALE만 허용
+  - 재고 부족 시 409 `insufficient stock` (근거: `OrderService.createOrder`#L94-L108)
+
+### 금액 계산 규칙
+- 단가: 라이브 방송가가 있으면 우선, 없으면 상품 가격 (근거: `OrderService.resolveCurrentPrice`)
+- 배송비: 총 상품 금액 50,000원 미만이면 3,000원 (근거: `OrderService.createOrder`#L115-L123)
+- 총 결제 금액: `total_product_amount - discount_fee + shipping_fee` (근거: `OrderService.createOrder`#L115-L126)
+
+### 취소/환불 규칙
+- CREATED 상태 취소 요청은 CANCEL_REQUESTED까지만 전이됨 (승인 로직은 별도 필요) (근거: `OrderService.requestCancel`#L209-L242)
+- PAID 상태 취소 요청은 Toss 결제 취소 후 즉시 REFUNDED로 전이 (근거: `OrderService.requestCancel`#L235-L242)
+
+## API 엔드포인트 기준 동작
+- POST `/api/orders`
+  - 정상: 200 + `order_id`, `order_number`, `status`, `order_amount`
+  - 오류: 400(member_id/items/receiver/postcode/addr_detail), 404(member/product), 409(insufficient stock) (근거: `OrderService.createOrder`)
+- GET `/api/orders`
+  - 본인 주문 요약 리스트 (근거: `OrderController.getMyOrders`)
+- GET `/api/orders/{orderId}`
+  - 본인 주문 상세 + 아이템 (근거: `OrderService.getMyOrderDetail`)
+- PATCH `/api/orders/{orderId}/cancel`
+  - 주문 취소 요청, 상태에 따라 CANCEL_REQUESTED 또는 REFUND_REQUESTED/REFUNDED (근거: `OrderService.requestCancel`)
+
+## DB 스키마 근거
+- `order` 테이블: status ENUM (CREATED/PAID/CANCEL_REQUESTED/CANCELLED/COMPLETED/REFUND_REQUESTED/REFUND_REJECTED/REFUNDED), order_amount/total_product_amount/shipping_fee/discount_fee (근거: `livecommerce_create_table.sql`#L306-L336)
+- `order_item` 테이블: 상품 스냅샷(product_name/unit_price/quantity/subtotal_price) + deleted_at (근거: `livecommerce_create_table.sql`#L337-L356)
+
+## 프론트 플로우/가드
+- 주문 생성 시 프론트는 product_id/quantity만 전송하고, quantity > 0인 아이템만 포함 (근거: `front/src/pages/Checkout.vue`#L502-L509)
+- 배송 정보(수령인/우편번호/상세주소) 조합 후 `addr_detail`로 전송 (근거: `Checkout.vue`#L513-L527)
+- 결제 전 단계에서 가격 재동기화가 수행되며, 가격 변경 감지 시 결제 진행을 중단함 (근거: `Checkout.vue`#L479-L498, #L500-L512)
+
+## 확인 필요
+- `Order` 엔티티는 `BaseEntity`를 상속하지만, 스키마(`order` 테이블)에 `deleted_at` 컬럼이 없음. 실제 운영 DB/마이그레이션에 `deleted_at`이 존재하는지 확인 필요 (근거: `BaseEntity.java`, `livecommerce_create_table.sql`#L306-L336)
+- 일반 취소 흐름에서 CANCEL_REQUESTED -> CANCELLED 승인 로직이 공개 API에 존재하지 않음. 운영 정책상 자동 승인 여부 확인 필요 (근거: `OrderService.requestCancel`, `Order.approveCancel`)
+
+## Evidence map
+- Backend 핵심
+  - `src/main/java/com/deskit/deskit/order/service/OrderService.java`
+  - `src/main/java/com/deskit/deskit/order/entity/Order.java`
+  - `src/main/java/com/deskit/deskit/order/entity/OrderItem.java`
+  - `src/main/java/com/deskit/deskit/order/enums/OrderStatus.java`
+  - `src/main/java/com/deskit/deskit/order/controller/OrderController.java`
+  - `src/main/java/com/deskit/deskit/order/dto/*.java`
+  - `src/main/java/com/deskit/deskit/order/payment/service/TossPaymentService.java`
+  - `src/main/resources/sql/livecommerce_create_table.sql`
+- Frontend 핵심
+  - `front/src/pages/Checkout.vue`

--- a/docs/policy/product-policy.md
+++ b/docs/policy/product-policy.md
@@ -1,0 +1,103 @@
+# 상품 정책서
+
+## 정책 요약(핵심 규칙)
+- 상품 상태 전이는 `Product.Status.canTransitionTo`에 의해 제한된다. 예: DRAFT -> READY, READY -> ON_SALE/HIDDEN 등 (근거: `src/main/java/com/deskit/deskit/product/entity/Product.java`#L23-L54)
+- 판매자 상품 기본 정보 수정(PUT `/api/seller/products/{id}`)은 상태 및 주문 존재 여부에 따라 제한된다. ON_SALE 상태에서는 `product_name`, `stock_qty` 수정 불가 (근거: `src/main/java/com/deskit/deskit/product/service/ProductService.java`#L309-L323)
+- 결제 완료 주문(PAID/COMPLETED)이 존재하는 상품은 가격/정보(상품명, 한 줄 설명, 가격, 상세HTML) 변경이 409로 차단된다 (근거: `src/main/java/com/deskit/deskit/product/service/ProductService.java`#L326-L339)
+- 상품 이미지 업데이트는 5 슬롯 고정이며, `image_urls` 길이 5 필수, `image_keys`는 선택이지만 존재 시 길이 5/정합성(키만 존재 불가) 강제 (근거: `src/main/java/com/deskit/deskit/product/service/ProductService.java`#L362-L399)
+- 상품 이미지 업로드는 확장자/용량/비율 검사: jpg/jpeg/png, 5MB, 1:1 비율. 컨트롤러는 content-type `image/*` 추가 검사 (근거: `AwsS3Service`, `UploadType`, `SellerProductController`)
+
+## 상태/전이 표
+| 현재 상태 | 허용 전이 | 불가/금지 전이 | 조건/비고 |
+|---|---|---|---|
+| DRAFT | READY, DELETED | 그 외 | 등록 완료 전 상태 (근거: `Product.Status.canTransitionTo`) |
+| READY | ON_SALE, HIDDEN | 그 외 | 판매 준비 완료 상태 |
+| ON_SALE | SOLD_OUT, PAUSED, HIDDEN | READY/DELETED 등 | 판매중 상태 |
+| SOLD_OUT | ON_SALE, HIDDEN | 그 외 | 재고 부족 상태 |
+| PAUSED | ON_SALE, HIDDEN | 그 외 | 일시 중지 |
+| HIDDEN | READY, DELETED | 그 외 | 숨김 상태 |
+| LIMITED_SALE | 없음 | 모든 전이 | 파생 상태(ON_SALE + 재고 임박), 직접 전이 금지 (근거: `Product.java`#L30-L53, #L179-L188) |
+| DELETED | 없음 | 모든 전이 | 논리 삭제 상태 |
+
+## 주요 제약
+### 필드 제약/검증
+- 생성(POST `/api/seller/products`)
+  - `product_name`, `short_desc` 필수, `price >= 0`, `stock_qty >= 0`, `cost_price >= 0` (근거: `ProductCreateRequest`, `ProductService.createProduct`)
+  - `detail_html`는 null이면 빈 문자열로 보정 (근거: `ProductService.createProduct`)
+- 기본 수정(PUT `/api/seller/products/{id}`)
+  - 요청에 수정 필드가 하나도 없으면 400 (근거: `ProductService.updateProductBasicInfo`#L294-L307)
+  - 허용 상태: DRAFT/READY/PAUSED/ON_SALE (근거: `ProductService`#L309-L315)
+  - ON_SALE 상태에서 `product_name`, `stock_qty` 수정 불가 (근거: `ProductService`#L317-L323)
+  - 결제 주문 존재 시 가격/정보 수정 차단: `product_name`, `short_desc`, `price`, `detail_html` 변경 시 409 (근거: `ProductService`#L326-L339)
+- 상세 수정(PATCH `/api/seller/products/{id}/detail`)
+  - `detail_html` 필수 (근거: `ProductDetailUpdateRequest`, `ProductService.updateProductDetailHtml`)
+- 상태 변경(PATCH `/api/seller/products/{id}/status`)
+  - `status` 필수, 전이 규칙 위반 시 400 `invalid status transition` (근거: `SellerProductStatusUpdateRequest`, `Product.changeStatus`)
+
+### 이미지 정책
+- 업로드 엔드포인트: POST `/api/seller/products/images/upload`
+  - content-type `image/*` 필수 (근거: `SellerProductController.uploadProductImageFile`)
+  - 허용 확장자: jpg/jpeg/png (근거: `AwsS3Service`#L32-L58)
+  - 최대 용량: 5MB (UploadType.PRODUCT_IMAGE) + 전역 멀티파트 10MB (근거: `UploadType`, `application.properties`)
+  - 비율: 1:1, 허용 오차 ±0.05 (근거: `UploadType`#L12-L19, `AwsS3Service.validateImageRatio`)
+- 저장 정책
+  - 이미지 슬롯 5개 고정, slotIndex 0=THUMBNAIL, 1~4=GALLERY (근거: `ProductService` 이미지 업데이트 루프, `ProductImage`)
+  - `image_urls` 길이 5 필수, `image_keys`는 선택이지만 존재 시 길이 5/정합성 필수 (근거: `ProductService`#L362-L399)
+  - 슬롯 단위 교체/삭제: 동일 URL+KEY는 유지, 다르면 기존 소프트 삭제 후 신규 생성 (근거: `ProductService`#L401-L456)
+  - 저장 시 기존 객체 키가 있으면 Object Storage delete 시도(실패 시 warn 로그) (근거: `ProductService`#L403-L452)
+
+### 태그 정책
+- 판매자 태그 목록: GET `/api/seller/tags` (seller 권한 필요, ACTIVE만 허용) (근거: `TagController`)
+- 상품 태그 갱신: PUT `/api/seller/products/{id}/tags`
+  - `tag_ids` 필수, 유효한 태그만 허용, 중복 제거 후 재매핑 (근거: `ProductTagService`)
+
+## API 엔드포인트 기준 동작
+### Seller API
+- POST `/api/seller/products` : 상품 생성
+  - 오류: 400(product_name/short_desc/price/stock_qty), 403(seller), 404(seller not found) (근거: `ProductService.createProduct`, `SellerProductController.resolveSellerId`)
+- PUT `/api/seller/products/{id}` : 기본 정보/이미지 업데이트
+  - 오류: 400(request/status not allowed/이미지 길이), 403(forbidden), 404(product not found), 409(주문 존재 시 정보 수정 불가) (근거: `ProductService.updateProductBasicInfo`)
+- PATCH `/api/seller/products/{id}/detail` : 상세 HTML 업데이트
+- PATCH `/api/seller/products/{id}/status` : 상태 변경
+- PATCH `/api/seller/products/{id}/complete` : 등록 완료(DRAFT -> READY), detail_html 필수 (근거: `ProductService.completeProductRegistration`)
+- DELETE `/api/seller/products/{id}` : 소프트 삭제(삭제 시각만 설정) (근거: `ProductService.softDeleteProduct`)
+- POST `/api/seller/products/images/upload` : 이미지 업로드, 응답 `{url, key}` (근거: `ProductImageUploadResponse`)
+
+### Public API
+- GET `/api/products` : ON_SALE 상품만 조회 (근거: `ProductService.getProducts`)
+- GET `/api/products/{id}` : ON_SALE 단건 조회 (근거: `ProductService.getProduct`)
+
+## DB 스키마 근거
+- `product` 테이블: status ENUM, detail_html LONGTEXT, soft delete 컬럼 `deleted_at` (근거: `src/main/resources/sql/livecommerce_create_table.sql`#L186-L213)
+- `product_image` 테이블: `product_image_url`, `stored_file_name`, `image_type`, `slot_index`, unique 키 `(product_id, image_type, slot_index)` (근거: `livecommerce_create_table.sql`#L214-L228)
+- `product_tag` 테이블: 복합 PK(product_id, tag_id) + deleted_at (근거: `livecommerce_create_table.sql`#L230-L238)
+
+## 프론트 플로우/가드
+- 상품 등록 기본 정보 페이지
+  - 썸네일(slot 0) 필수, 업로드 중이면 진행 차단 (근거: `front/src/pages/seller/ProductCreateInfo.vue`#L205-L221)
+  - 이미지 업로드 전 1:1 크롭 모달 사용, 5MB 초과 시 차단 (근거: `ProductCreateInfo.vue`#L90-L177, `LiveImageCropModal.vue`)
+  - 등록 후 이미지 저장: PUT `/api/seller/products/{id}`에 `image_urls`/`image_keys` 길이 5 전송 (근거: `ProductCreateInfo.vue`#L242-L290)
+- 상품 수정 기본 정보 페이지
+  - 이미지 슬롯 5개 고정, 업로드 중이면 저장/삭제 차단 (근거: `front/src/pages/seller/ProductEditInfo.vue`#L18-L38, #L233-L311)
+  - 이미지 변경 시 `image_urls`/`image_keys` 길이 5 전송, 썸네일 누락 시 저장 차단 (근거: `ProductEditInfo.vue`#L311-L351)
+
+## 확인 필요
+- 프론트 `apiBase` 구성에 따라 `/api` prefix 여부가 다름. 예: `ProductCreateInfo.vue`는 `${apiBase}/seller/products`로 호출 (근거: `ProductCreateInfo.vue`#L223-L238). 실제 VITE_API_BASE_URL 값에 `/api`가 포함되는지 확인 필요.
+- `Product.Status.DELETED`는 상태 전이 규칙에 존재하지만, 실제 삭제는 `deleted_at`만 설정됨. 상태 필드가 DELETED로 세팅되는 경로가 없는지 확인 필요 (근거: `ProductService.softDeleteProduct`, `Product.Status.canTransitionTo`).
+
+## Evidence map
+- Backend 핵심
+  - `src/main/java/com/deskit/deskit/product/service/ProductService.java`
+  - `src/main/java/com/deskit/deskit/product/entity/Product.java`
+  - `src/main/java/com/deskit/deskit/product/entity/ProductImage.java`
+  - `src/main/java/com/deskit/deskit/product/dto/*.java`
+  - `src/main/java/com/deskit/deskit/product/controller/SellerProductController.java`
+  - `src/main/java/com/deskit/deskit/tag/controller/TagController.java`
+  - `src/main/java/com/deskit/deskit/livehost/service/AwsS3Service.java`
+  - `src/main/java/com/deskit/deskit/livehost/common/enums/UploadType.java`
+  - `src/main/java/com/deskit/deskit/livehost/common/exception/ErrorCode.java`
+  - `src/main/resources/sql/livecommerce_create_table.sql`
+- Frontend 핵심
+  - `front/src/pages/seller/ProductCreateInfo.vue`
+  - `front/src/pages/seller/ProductEditInfo.vue`
+  - `front/src/components/LiveImageCropModal.vue`

--- a/front/src/api/orders.ts
+++ b/front/src/api/orders.ts
@@ -4,8 +4,6 @@ import type {
   CreateOrderRequest,
   CreateOrderResponse,
   OrderDetailResponse,
-  OrderStatusUpdateRequest,
-  OrderStatusUpdateResponse,
   OrderSummaryResponse,
 } from './types/orders'
 
@@ -29,18 +27,6 @@ export const getMyOrders = async (): Promise<OrderSummaryResponse[]> => {
 
 export const getMyOrderDetail = async (orderId: number): Promise<OrderDetailResponse> => {
   const response = await http.get<OrderDetailResponse>(endpoints.orderDetail(orderId), withCredentials)
-  return response.data
-}
-
-export const updateOrderStatus = async (
-  orderId: number,
-  request: OrderStatusUpdateRequest,
-): Promise<OrderStatusUpdateResponse> => {
-  const response = await http.patch<OrderStatusUpdateResponse>(
-    endpoints.orderStatus(orderId),
-    request,
-    withCredentials,
-  )
   return response.data
 }
 

--- a/front/src/api/sellerOrders.ts
+++ b/front/src/api/sellerOrders.ts
@@ -1,0 +1,68 @@
+import { http } from './http'
+import type { OrderItemResponse } from './types/orders'
+
+const withCredentials = { withCredentials: true }
+
+export type SellerOrderSummaryResponse = {
+  order_id: number
+  order_number: string
+  status: string
+  order_amount: number
+  created_at: string
+  paid_at?: string
+  cancelled_at?: string
+  refunded_at?: string
+  item_count?: number
+  first_product_name?: string
+}
+
+export type SellerOrderDetailResponse = {
+  order_id: number
+  order_number: string
+  status: string
+  order_amount: number
+  created_at: string
+  paid_at?: string
+  cancelled_at?: string
+  refunded_at?: string
+  items: OrderItemResponse[]
+}
+
+export type PageResponse<T> = {
+  content: T[]
+  totalElements: number
+  totalPages: number
+  number: number
+  size: number
+  first: boolean
+  last: boolean
+}
+
+export const getSellerOrders = async (params: {
+  status?: string | null
+  page?: number
+  size?: number
+}): Promise<PageResponse<SellerOrderSummaryResponse>> => {
+  const response = await http.get<PageResponse<SellerOrderSummaryResponse>>(
+    '/api/seller/orders',
+    {
+      ...withCredentials,
+      params: {
+        status: params.status || undefined,
+        page: params.page ?? 0,
+        size: params.size ?? 10,
+      },
+    },
+  )
+  return response.data
+}
+
+export const getSellerOrderDetail = async (
+  orderId: number,
+): Promise<SellerOrderDetailResponse> => {
+  const response = await http.get<SellerOrderDetailResponse>(
+    `/api/seller/orders/${orderId}`,
+    withCredentials,
+  )
+  return response.data
+}

--- a/front/src/api/types/orders.ts
+++ b/front/src/api/types/orders.ts
@@ -1,4 +1,12 @@
-export type OrderStatus = 'CREATED' | 'PAID' | 'CANCELLED' | 'COMPLETED'
+export type OrderStatus =
+  | 'CREATED'
+  | 'PAID'
+  | 'CANCEL_REQUESTED'
+  | 'CANCELLED'
+  | 'REFUND_REQUESTED'
+  | 'REFUND_REJECTED'
+  | 'REFUNDED'
+  | 'COMPLETED'
 
 export interface CreateOrderItemRequest {
   product_id: number
@@ -31,6 +39,7 @@ export interface OrderSummaryResponse {
 }
 
 export interface OrderItemResponse {
+  order_item_id?: number
   product_id: number
   product_name?: string
   quantity: number
@@ -45,13 +54,4 @@ export interface OrderDetailResponse {
   order_amount: number
   created_at: string
   items: OrderItemResponse[]
-}
-
-export interface OrderStatusUpdateRequest {
-  status: OrderStatus
-}
-
-export interface OrderStatusUpdateResponse {
-  order_id: number
-  status: OrderStatus
 }

--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -35,6 +35,7 @@ const sellerTabs = [
     ],
   },
   {label: '상품관리', to: '/seller/products'},
+  {label: '주문관리', to: '/seller/orders'},
 ]
 
 const adminTabs = [

--- a/front/src/pages/seller/SellerOrderDetail.vue
+++ b/front/src/pages/seller/SellerOrderDetail.vue
@@ -1,0 +1,281 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import PageHeader from '../../components/PageHeader.vue'
+import { getSellerOrderDetail } from '../../api/sellerOrders'
+import type { SellerOrderDetailResponse } from '../../api/sellerOrders'
+
+const route = useRoute()
+const router = useRouter()
+
+const order = ref<SellerOrderDetailResponse | null>(null)
+const errorMessage = ref('')
+const isLoading = ref(false)
+
+const statusLabel = (status?: string) => {
+  const map: Record<string, string> = {
+    CREATED: '주문 생성',
+    PAID: '결제 완료',
+    CANCEL_REQUESTED: '취소 요청',
+    CANCELLED: '취소 완료',
+    REFUND_REQUESTED: '환불 요청',
+    REFUND_REJECTED: '환불 거절',
+    REFUNDED: '환불 완료',
+  }
+  return map[status ?? ''] ?? '알 수 없음'
+}
+
+const formatDateTime = (value?: string) => {
+  if (!value) return '-'
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return '-'
+  const yy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mi = String(d.getMinutes()).padStart(2, '0')
+  return `${yy}.${mm}.${dd} ${hh}:${mi}`
+}
+
+const formatPrice = (value?: number) => `${(value ?? 0).toLocaleString('ko-KR')}원`
+
+const load = async () => {
+  const raw = route.params.orderId
+  const numericId = Number(raw)
+  if (!Number.isFinite(numericId) || numericId <= 0) {
+    errorMessage.value = '주문 정보를 확인할 수 없습니다.'
+    return
+  }
+  isLoading.value = true
+  errorMessage.value = ''
+  try {
+    order.value = await getSellerOrderDetail(numericId)
+  } catch (error: any) {
+    const status = error?.response?.status
+    if (status === 403) {
+      errorMessage.value = '권한이 없습니다.'
+    } else if (status === 404) {
+      errorMessage.value = '주문을 찾을 수 없습니다.'
+    } else {
+      errorMessage.value = '주문 정보를 불러오지 못했습니다.'
+    }
+    order.value = null
+  } finally {
+    isLoading.value = false
+  }
+}
+
+watch(
+  () => route.params.orderId,
+  () => {
+    order.value = null
+    errorMessage.value = ''
+    load()
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <section class="seller-order-detail">
+    <PageHeader eyebrow="DESKIT" title="주문 상세" />
+
+    <div v-if="errorMessage" class="empty">
+      {{ errorMessage }}
+    </div>
+    <div v-else-if="isLoading" class="empty">불러오는 중...</div>
+    <div v-else-if="!order" class="empty">주문 정보가 없습니다.</div>
+    <div v-else class="detail">
+      <header class="card">
+        <div class="header-row">
+          <div>
+            <p class="label">주문번호</p>
+            <p class="value mono">{{ order.order_number }}</p>
+          </div>
+          <div>
+            <p class="label">상태</p>
+            <p class="value status">{{ statusLabel(order.status) }}</p>
+          </div>
+          <div>
+            <p class="label">총금액</p>
+            <p class="value">{{ formatPrice(order.order_amount) }}</p>
+          </div>
+        </div>
+        <div class="meta">
+          <div>
+            <span class="label">주문일</span>
+            <span class="value">{{ formatDateTime(order.created_at) }}</span>
+          </div>
+          <div>
+            <span class="label">결제일</span>
+            <span class="value">{{ formatDateTime(order.paid_at) }}</span>
+          </div>
+          <div>
+            <span class="label">취소일</span>
+            <span class="value">{{ formatDateTime(order.cancelled_at) }}</span>
+          </div>
+          <div>
+            <span class="label">환불일</span>
+            <span class="value">{{ formatDateTime(order.refunded_at) }}</span>
+          </div>
+        </div>
+      </header>
+
+      <section class="card">
+        <h3 class="section-title">주문 상품</h3>
+        <div v-if="!order.items?.length" class="empty-row">상품 정보가 없습니다.</div>
+        <div v-else class="items">
+          <div class="row header">
+            <span>상품명</span>
+            <span>수량</span>
+            <span>단가</span>
+            <span>합계</span>
+          </div>
+          <div
+            v-for="(item, index) in order.items"
+            :key="item.order_item_id ?? `${item.product_id}-${index}`"
+            class="row data"
+          >
+            <span>{{ item.product_name ?? `상품 #${item.product_id}` }}</span>
+            <span>{{ item.quantity ?? 0 }}</span>
+            <span>{{ formatPrice(item.unit_price ?? 0) }}</span>
+            <span>
+              {{
+                formatPrice(
+                  item.subtotal_price ?? (item.unit_price ?? 0) * (item.quantity ?? 0),
+                )
+              }}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <div class="actions">
+        <button type="button" class="btn ghost" @click="router.push('/seller/orders')">
+          목록으로 돌아가기
+        </button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.seller-order-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.card {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 16px;
+  background: var(--surface);
+}
+
+.header-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.label {
+  font-size: 12px;
+  color: var(--text-muted, #6b7280);
+}
+
+.value {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.status {
+  color: var(--primary-color, #111827);
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+}
+
+.meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 14px;
+  font-size: 13px;
+}
+
+.meta .value {
+  font-weight: 500;
+  margin-left: 6px;
+}
+
+.section-title {
+  font-size: 16px;
+  margin-bottom: 12px;
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 2fr 0.7fr 1fr 1fr;
+  gap: 12px;
+  align-items: center;
+}
+
+.row.header {
+  font-size: 13px;
+  color: var(--text-muted, #6b7280);
+}
+
+.row.data {
+  padding: 10px 0;
+  border-top: 1px solid var(--border-color);
+}
+
+.empty,
+.empty-row {
+  padding: 24px 12px;
+  text-align: center;
+  border: 1px dashed var(--border-color);
+  border-radius: 12px;
+  color: var(--text-muted, #6b7280);
+}
+
+.empty-row {
+  margin-top: 8px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn {
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 8px 12px;
+  background: transparent;
+  cursor: pointer;
+}
+
+@media (max-width: 768px) {
+  .header-row {
+    grid-template-columns: 1fr;
+  }
+
+  .row {
+    grid-template-columns: 1.6fr 0.6fr 0.8fr;
+  }
+
+  .row span:nth-child(4) {
+    display: none;
+  }
+}
+</style>

--- a/front/src/pages/seller/SellerOrders.vue
+++ b/front/src/pages/seller/SellerOrders.vue
@@ -1,0 +1,310 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import PageHeader from '../../components/PageHeader.vue'
+import { getSellerOrders } from '../../api/sellerOrders'
+import type { SellerOrderSummaryResponse } from '../../api/sellerOrders'
+
+type StatusFilter = '' | 'PAID' | 'CANCEL_REQUESTED' | 'CANCELLED'
+
+const route = useRoute()
+const router = useRouter()
+
+const orders = ref<SellerOrderSummaryResponse[]>([])
+const errorMessage = ref('')
+const isLoading = ref(false)
+const statusFilter = ref<StatusFilter>('')
+const page = ref(0)
+const size = ref(10)
+const totalPages = ref(0)
+const totalElements = ref(0)
+
+const statusLabel = (status?: string) => {
+  const map: Record<string, string> = {
+    CREATED: '주문 생성',
+    PAID: '결제 완료',
+    CANCEL_REQUESTED: '취소 요청',
+    CANCELLED: '취소 완료',
+  }
+  return map[status ?? ''] ?? '알 수 없음'
+}
+
+const formatDate = (value?: string) => {
+  if (!value) return '-'
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return '-'
+  const yy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${yy}.${mm}.${dd}`
+}
+
+const formatPrice = (value?: number) => `${(value ?? 0).toLocaleString('ko-KR')}원`
+
+const summaryText = (order: SellerOrderSummaryResponse) => {
+  const name = order.first_product_name || '상품'
+  const count = order.item_count ?? 0
+  if (count <= 1) return name
+  return `${name} 외 ${count - 1}건`
+}
+
+const load = async () => {
+  isLoading.value = true
+  errorMessage.value = ''
+  try {
+    const response = await getSellerOrders({
+      status: statusFilter.value || null,
+      page: page.value,
+      size: size.value,
+    })
+    orders.value = response.content || []
+    totalPages.value = response.totalPages ?? 0
+    totalElements.value = response.totalElements ?? 0
+  } catch (error: any) {
+    const status = error?.response?.status
+    if (status === 403) {
+      errorMessage.value = '권한이 없습니다.'
+    } else {
+      errorMessage.value = '주문 목록을 불러오지 못했습니다.'
+    }
+    orders.value = []
+    totalPages.value = 0
+    totalElements.value = 0
+  } finally {
+    isLoading.value = false
+  }
+}
+
+const syncFromQuery = () => {
+  const queryPage = Number(route.query.page ?? 0)
+  const querySize = Number(route.query.size ?? 10)
+  const queryStatus = String(route.query.status ?? '')
+  page.value = Number.isFinite(queryPage) && queryPage >= 0 ? queryPage : 0
+  size.value = Number.isFinite(querySize) && querySize > 0 ? querySize : 10
+  statusFilter.value = (queryStatus || '') as StatusFilter
+}
+
+const updateQuery = () => {
+  router.replace({
+    query: {
+      ...route.query,
+      page: String(page.value),
+      size: String(size.value),
+      status: statusFilter.value || undefined,
+    },
+  })
+}
+
+const canGoPrev = computed(() => page.value > 0)
+const canGoNext = computed(() => page.value + 1 < totalPages.value)
+
+const goPrev = () => {
+  if (!canGoPrev.value) return
+  page.value -= 1
+  updateQuery()
+}
+
+const goNext = () => {
+  if (!canGoNext.value) return
+  page.value += 1
+  updateQuery()
+}
+
+const handleFilterChange = () => {
+  page.value = 0
+  updateQuery()
+}
+
+const openDetail = (orderId?: number) => {
+  if (!orderId) return
+  router.push(`/seller/orders/${orderId}`).catch(() => {})
+}
+
+onMounted(() => {
+  syncFromQuery()
+  load()
+})
+
+watch(
+  () => route.query,
+  () => {
+    syncFromQuery()
+    load()
+  },
+)
+</script>
+
+<template>
+  <section class="seller-orders">
+    <PageHeader eyebrow="DESKIT" title="주문 내역" />
+
+    <div class="toolbar">
+      <label class="filter">
+        <span>상태</span>
+        <select v-model="statusFilter" @change="handleFilterChange">
+          <option value="">전체</option>
+          <option value="PAID">결제 완료</option>
+          <option value="CANCEL_REQUESTED">취소 요청</option>
+          <option value="CANCELLED">취소 완료</option>
+        </select>
+      </label>
+      <span class="count">총 {{ totalElements }}건</span>
+    </div>
+
+    <div v-if="errorMessage" class="empty">
+      {{ errorMessage }}
+    </div>
+    <div v-else-if="isLoading" class="empty">불러오는 중...</div>
+    <div v-else-if="!orders.length" class="empty">주문 내역이 없습니다.</div>
+    <div v-else class="table">
+      <div class="row header">
+        <span>주문번호</span>
+        <span>상품</span>
+        <span>상태</span>
+        <span>금액</span>
+        <span>주문일</span>
+      </div>
+      <button
+        v-for="order in orders"
+        :key="order.order_id"
+        type="button"
+        class="row data"
+        @click="openDetail(order.order_id)"
+      >
+        <span class="mono">{{ order.order_number }}</span>
+        <span>{{ summaryText(order) }}</span>
+        <span class="status">{{ statusLabel(order.status) }}</span>
+        <span>{{ formatPrice(order.order_amount) }}</span>
+        <span>{{ formatDate(order.created_at) }}</span>
+      </button>
+    </div>
+
+    <div class="pagination">
+      <button type="button" class="btn ghost" :disabled="!canGoPrev" @click="goPrev">이전</button>
+      <span class="page">{{ page + 1 }} / {{ totalPages || 1 }}</span>
+      <button type="button" class="btn ghost" :disabled="!canGoNext" @click="goNext">다음</button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.seller-orders {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.filter select {
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 8px 10px;
+  background: var(--surface);
+}
+
+.count {
+  font-size: 14px;
+  color: var(--text-muted, #6b7280);
+}
+
+.empty {
+  padding: 32px 12px;
+  text-align: center;
+  border: 1px dashed var(--border-color);
+  border-radius: 12px;
+  color: var(--text-muted, #6b7280);
+}
+
+.table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1.4fr 2fr 1fr 1fr 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 16px;
+}
+
+.row.header {
+  background: var(--surface);
+  font-size: 13px;
+  color: var(--text-muted, #6b7280);
+}
+
+.row.data {
+  background: transparent;
+  border: none;
+  border-top: 1px solid var(--border-color);
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.row.data:hover {
+  background: rgba(17, 24, 39, 0.04);
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+}
+
+.status {
+  font-weight: 600;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.btn {
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 8px 12px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.page {
+  font-size: 14px;
+  color: var(--text-muted, #6b7280);
+}
+
+@media (max-width: 768px) {
+  .row {
+    grid-template-columns: 1.2fr 1.6fr 1fr;
+  }
+
+  .row span:nth-child(4),
+  .row span:nth-child(5) {
+    display: none;
+  }
+}
+</style>

--- a/front/src/router/index.ts
+++ b/front/src/router/index.ts
@@ -195,6 +195,16 @@ const routes: RouteRecordRaw[] = [
         name: 'seller-products',
         component: () => import('../pages/seller/Products.vue'),
       },
+      {
+        path: 'orders',
+        name: 'seller-orders',
+        component: () => import('../pages/seller/SellerOrders.vue'),
+      },
+      {
+        path: 'orders/:orderId',
+        name: 'seller-order-detail',
+        component: () => import('../pages/seller/SellerOrderDetail.vue'),
+      },
     ],
   },
   {

--- a/src/main/java/com/deskit/deskit/order/controller/SellerOrderController.java
+++ b/src/main/java/com/deskit/deskit/order/controller/SellerOrderController.java
@@ -1,0 +1,97 @@
+package com.deskit.deskit.order.controller;
+
+import com.deskit.deskit.account.entity.Seller;
+import com.deskit.deskit.account.enums.SellerStatus;
+import com.deskit.deskit.account.oauth.CustomOAuth2User;
+import com.deskit.deskit.account.repository.SellerRepository;
+import com.deskit.deskit.order.dto.SellerOrderDetailResponse;
+import com.deskit.deskit.order.dto.SellerOrderSummaryResponse;
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.deskit.deskit.order.service.SellerOrderService;
+import java.util.Objects;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/seller/orders")
+public class SellerOrderController {
+
+  private final SellerOrderService sellerOrderService;
+  private final SellerRepository sellerRepository;
+
+  public SellerOrderController(
+    SellerOrderService sellerOrderService,
+    SellerRepository sellerRepository
+  ) {
+    this.sellerOrderService = sellerOrderService;
+    this.sellerRepository = sellerRepository;
+  }
+
+  @GetMapping
+  public ResponseEntity<Page<SellerOrderSummaryResponse>> getSellerOrders(
+    @AuthenticationPrincipal CustomOAuth2User user,
+    @RequestParam(name = "status", required = false) OrderStatus status,
+    @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+  ) {
+    Long sellerId = resolveSellerId(user);
+    return ResponseEntity.ok(sellerOrderService.getSellerOrders(sellerId, status, pageable));
+  }
+
+  @GetMapping("/{orderId}")
+  public ResponseEntity<SellerOrderDetailResponse> getSellerOrderDetail(
+    @AuthenticationPrincipal CustomOAuth2User user,
+    @PathVariable("orderId") Long orderId
+  ) {
+    Long sellerId = resolveSellerId(user);
+    return ResponseEntity.ok(sellerOrderService.getSellerOrderDetail(sellerId, orderId));
+  }
+
+  private Long resolveSellerId(CustomOAuth2User user) {
+    if (user == null) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+    }
+
+    boolean isSeller = user.getAuthorities().stream()
+      .anyMatch(authority -> authority != null &&
+        authority.getAuthority() != null &&
+        authority.getAuthority().startsWith("ROLE_SELLER"));
+    if (!isSeller) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "seller role required");
+    }
+
+    String loginId = normalize(user.getUsername());
+    String email = normalize(user.getEmail());
+    Seller seller = loginId == null ? null : sellerRepository.findByLoginId(loginId);
+    if (seller == null && email != null && !Objects.equals(loginId, email)) {
+      seller = sellerRepository.findByLoginId(email);
+    }
+
+    if (seller == null || seller.getSellerId() == null) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "seller not found");
+    }
+    if (seller.getStatus() != SellerStatus.ACTIVE) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "seller inactive");
+    }
+
+    return seller.getSellerId();
+  }
+
+  private String normalize(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/src/main/java/com/deskit/deskit/order/dto/OrderItemResponse.java
+++ b/src/main/java/com/deskit/deskit/order/dto/OrderItemResponse.java
@@ -4,6 +4,9 @@ import com.deskit.deskit.order.entity.OrderItem;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record OrderItemResponse(
+  @JsonProperty("order_item_id")
+  Long orderItemId,
+
   @JsonProperty("product_id")
   Long productId,
 
@@ -21,9 +24,10 @@ public record OrderItemResponse(
 ) {
   public static OrderItemResponse from(OrderItem item) {
     if (item == null) {
-      return new OrderItemResponse(null, null, null, null, null);
+      return new OrderItemResponse(null, null, null, null, null, null);
     }
     return new OrderItemResponse(
+      item.getId(),
       item.getProductId(),
       item.getProductName(),
       item.getQuantity(),

--- a/src/main/java/com/deskit/deskit/order/dto/SellerOrderDetailResponse.java
+++ b/src/main/java/com/deskit/deskit/order/dto/SellerOrderDetailResponse.java
@@ -1,0 +1,53 @@
+package com.deskit.deskit.order.dto;
+
+import com.deskit.deskit.order.entity.Order;
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record SellerOrderDetailResponse(
+  @JsonProperty("order_id")
+  Long orderId,
+
+  @JsonProperty("order_number")
+  String orderNumber,
+
+  @JsonProperty("status")
+  OrderStatus status,
+
+  @JsonProperty("order_amount")
+  Integer orderAmount,
+
+  @JsonProperty("created_at")
+  LocalDateTime createdAt,
+
+  @JsonProperty("paid_at")
+  LocalDateTime paidAt,
+
+  @JsonProperty("cancelled_at")
+  LocalDateTime cancelledAt,
+
+  @JsonProperty("refunded_at")
+  LocalDateTime refundedAt,
+
+  @JsonProperty("items")
+  List<OrderItemResponse> items
+) {
+  public static SellerOrderDetailResponse from(Order order, List<OrderItemResponse> items) {
+    if (order == null) {
+      return new SellerOrderDetailResponse(null, null, null, null, null, null, null, null, items);
+    }
+    return new SellerOrderDetailResponse(
+      order.getId(),
+      order.getOrderNumber(),
+      order.getStatus(),
+      order.getOrderAmount(),
+      order.getCreatedAt(),
+      order.getPaidAt(),
+      order.getCancelledAt(),
+      order.getRefundedAt(),
+      items
+    );
+  }
+}

--- a/src/main/java/com/deskit/deskit/order/dto/SellerOrderSummaryResponse.java
+++ b/src/main/java/com/deskit/deskit/order/dto/SellerOrderSummaryResponse.java
@@ -1,0 +1,62 @@
+package com.deskit.deskit.order.dto;
+
+import com.deskit.deskit.order.entity.Order;
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+
+public record SellerOrderSummaryResponse(
+  @JsonProperty("order_id")
+  Long orderId,
+
+  @JsonProperty("order_number")
+  String orderNumber,
+
+  @JsonProperty("status")
+  OrderStatus status,
+
+  @JsonProperty("order_amount")
+  Integer orderAmount,
+
+  @JsonProperty("created_at")
+  LocalDateTime createdAt,
+
+  @JsonProperty("paid_at")
+  LocalDateTime paidAt,
+
+  @JsonProperty("cancelled_at")
+  LocalDateTime cancelledAt,
+
+  @JsonProperty("refunded_at")
+  LocalDateTime refundedAt,
+
+  @JsonProperty("item_count")
+  Integer itemCount,
+
+  @JsonProperty("first_product_name")
+  String firstProductName
+) {
+  public static SellerOrderSummaryResponse from(
+    Order order,
+    Integer itemCount,
+    String firstProductName
+  ) {
+    if (order == null) {
+      return new SellerOrderSummaryResponse(
+        null, null, null, null, null, null, null, null, itemCount, firstProductName
+      );
+    }
+    return new SellerOrderSummaryResponse(
+      order.getId(),
+      order.getOrderNumber(),
+      order.getStatus(),
+      order.getOrderAmount(),
+      order.getCreatedAt(),
+      order.getPaidAt(),
+      order.getCancelledAt(),
+      order.getRefundedAt(),
+      itemCount,
+      firstProductName
+    );
+  }
+}

--- a/src/main/java/com/deskit/deskit/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/deskit/deskit/order/repository/OrderItemRepository.java
@@ -24,6 +24,12 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
    */
   List<OrderItem> findByOrder_Id(Long orderId);
 
+  List<OrderItem> findByOrder_IdAndSellerIdAndDeletedAtIsNull(Long orderId, Long sellerId);
+
+  List<OrderItem> findByOrder_IdInAndSellerIdAndDeletedAtIsNullOrderByIdAsc(List<Long> orderIds, Long sellerId);
+
+  boolean existsByOrder_IdAndSellerIdAndDeletedAtIsNull(Long orderId, Long sellerId);
+
   @Query("""
       select (count(oi) > 0)
       from OrderItem oi

--- a/src/main/java/com/deskit/deskit/order/service/SellerOrderService.java
+++ b/src/main/java/com/deskit/deskit/order/service/SellerOrderService.java
@@ -1,0 +1,102 @@
+package com.deskit.deskit.order.service;
+
+import com.deskit.deskit.order.dto.OrderItemResponse;
+import com.deskit.deskit.order.dto.SellerOrderDetailResponse;
+import com.deskit.deskit.order.dto.SellerOrderSummaryResponse;
+import com.deskit.deskit.order.entity.Order;
+import com.deskit.deskit.order.entity.OrderItem;
+import com.deskit.deskit.order.enums.OrderStatus;
+import com.deskit.deskit.order.repository.OrderItemRepository;
+import com.deskit.deskit.order.repository.OrderRepository;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@Transactional(readOnly = true)
+public class SellerOrderService {
+
+  private final OrderRepository orderRepository;
+  private final OrderItemRepository orderItemRepository;
+
+  public SellerOrderService(
+    OrderRepository orderRepository,
+    OrderItemRepository orderItemRepository
+  ) {
+    this.orderRepository = orderRepository;
+    this.orderItemRepository = orderItemRepository;
+  }
+
+  public Page<SellerOrderSummaryResponse> getSellerOrders(
+    Long sellerId,
+    OrderStatus status,
+    Pageable pageable
+  ) {
+    if (sellerId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "seller_id required");
+    }
+
+    Page<Order> orders = orderRepository.findSellerOrders(sellerId, status, pageable);
+    List<Order> content = orders.getContent();
+    if (content.isEmpty()) {
+      return orders.map(order -> SellerOrderSummaryResponse.from(order, 0, null));
+    }
+
+    List<Long> orderIds = content.stream()
+      .map(Order::getId)
+      .filter(id -> id != null)
+      .toList();
+    if (orderIds.isEmpty()) {
+      return orders.map(order -> SellerOrderSummaryResponse.from(order, 0, null));
+    }
+
+    List<OrderItem> items =
+      orderItemRepository.findByOrder_IdInAndSellerIdAndDeletedAtIsNullOrderByIdAsc(orderIds, sellerId);
+    Map<Long, List<OrderItem>> itemsByOrderId = new HashMap<>();
+    for (OrderItem item : items) {
+      Long orderId = item.getOrder() == null ? null : item.getOrder().getId();
+      if (orderId == null) {
+        continue;
+      }
+      itemsByOrderId.computeIfAbsent(orderId, key -> new java.util.ArrayList<>()).add(item);
+    }
+
+    return orders.map(order -> {
+      List<OrderItem> orderItems = itemsByOrderId.getOrDefault(order.getId(), Collections.emptyList());
+      int itemCount = orderItems.size();
+      String firstProductName = orderItems.isEmpty() ? null : orderItems.get(0).getProductName();
+      return SellerOrderSummaryResponse.from(order, itemCount, firstProductName);
+    });
+  }
+
+  public SellerOrderDetailResponse getSellerOrderDetail(Long sellerId, Long orderId) {
+    if (sellerId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "seller_id required");
+    }
+    if (orderId == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "order_id required");
+    }
+
+    if (!orderItemRepository.existsByOrder_IdAndSellerIdAndDeletedAtIsNull(orderId, sellerId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "order not found");
+    }
+
+    Order order = orderRepository.findByIdAndDeletedAtIsNull(orderId)
+      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "order not found"));
+
+    List<OrderItemResponse> items = orderItemRepository
+      .findByOrder_IdAndSellerIdAndDeletedAtIsNull(orderId, sellerId)
+      .stream()
+      .map(OrderItemResponse::from)
+      .toList();
+
+    return SellerOrderDetailResponse.from(order, items);
+  }
+}

--- a/src/main/resources/sql/livecommerce_create_table.sql
+++ b/src/main/resources/sql/livecommerce_create_table.sql
@@ -173,9 +173,9 @@ CREATE TABLE tag
 
 CREATE TABLE forbidden_word
 (
-    word_id     INT UNSIGNED NOT NULL AUTO_INCREMENT,
-    word        VARCHAR(50)  NOT NULL COMMENT '금지어',
-    created_at  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    word_id    INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    word       VARCHAR(50)  NOT NULL COMMENT '금지어',
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (word_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='금지어';
@@ -451,7 +451,7 @@ CREATE TABLE live_chat
 (
     message_id    BIGINT UNSIGNED                                  NOT NULL AUTO_INCREMENT,
     broadcast_id  BIGINT UNSIGNED                                  NOT NULL,
-    member_email VARCHAR(255)                                      NOT NULL,
+    member_email  VARCHAR(255)                                     NOT NULL,
     msg_type      ENUM ('TALK','ENTER','EXIT','PURCHASE','NOTICE') NOT NULL COMMENT '채팅 메시지 유형',
     content       VARCHAR(500)                                     NOT NULL,
     raw_content   VARCHAR(500)                                     NOT NULL,
@@ -741,7 +741,8 @@ ALTER TABLE order_item
 -- [Broadcast Relations]
 ALTER TABLE broadcast
     ADD CONSTRAINT FK_broadcast_seller FOREIGN KEY (seller_id) REFERENCES seller (seller_id);
--- ALTER TABLE broadcast ADD CONSTRAINT FK_broadcast_tag_cat FOREIGN KEY (tag_category_id) REFERENCES tag_category (tag_category_id); 
+ALTER TABLE broadcast
+    ADD CONSTRAINT FK_broadcast_tag_cat FOREIGN KEY (tag_category_id) REFERENCES tag_category (tag_category_id);
 
 ALTER TABLE broadcast_product
     ADD CONSTRAINT FK_bp_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
@@ -758,12 +759,9 @@ ALTER TABLE broadcast_result
 -- [Live Interaction Relations]
 ALTER TABLE view_history
     ADD CONSTRAINT FK_vh_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
-# ALTER TABLE view_history ADD CONSTRAINT FK_vh_member FOREIGN KEY (member_id) REFERENCES member (member_id);
 
 ALTER TABLE live_chat
     ADD CONSTRAINT FK_lc_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);
-ALTER TABLE live_chat
-    ADD CONSTRAINT FK_lc_member FOREIGN KEY (member_id) REFERENCES member (member_id);
 
 ALTER TABLE sanction
     ADD CONSTRAINT FK_sanction_broadcast FOREIGN KEY (broadcast_id) REFERENCES broadcast (broadcast_id);


### PR DESCRIPTION
## 📌 관련 이슈
- closes #381 

## 📝 작업 내용
- 판매자 주문 조회 API/서비스 추가: 목록(배치 조회로 N+1 방지) + 상세(소프트 삭제 주문 404)
- 판매자 주문 관리 프론트 추가: 라우팅/헤더 메뉴/목록 페이지/상세 페이지
- 주문 아이템 응답에 order_item_id 추가로 프론트 렌더링 key 안정화
- 환불(Toss cancel) 실패 시 REFUND_REQUESTED를 별도 REQUIRES_NEW 트랜잭션으로 선저장하고, 실패 시 502 반환 및 환불 승인/매출 리프레시 중단
- 판매자 목록 기본 정렬 최신순(createdAt DESC) + 배치 아이템 조회 정렬(id ASC)로 first_product_name 결정 안정화