### PR TITLE
feat: 상품 상세 API에 thumbnail_url 노출

### DIFF
--- a/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
@@ -50,6 +50,9 @@ public class ProductResponse {
   @JsonProperty("tagsFlat")
   private final List<String> tagsFlat;
 
+  @JsonProperty("thumbnail_url")
+  private final String thumbnailUrl;
+
   /**
    * 생성자에서 null-safe 처리:
    * - tags/tagsFlat이 null로 들어오면 빈 값으로 치환해서 응답 안정성 확보
@@ -58,6 +61,13 @@ public class ProductResponse {
                          String detailHtml, Integer price, Integer costPrice,
                          Product.Status status, Integer stockQty, Integer safetyStock,
                          ProductTags tags, List<String> tagsFlat) {
+    this(productId, sellerId, name, shortDesc, detailHtml, price, costPrice, status, stockQty, safetyStock, tags, tagsFlat, null);
+  }
+
+  public ProductResponse(Long productId, Long sellerId, String name, String shortDesc,
+                         String detailHtml, Integer price, Integer costPrice,
+                         Product.Status status, Integer stockQty, Integer safetyStock,
+                         ProductTags tags, List<String> tagsFlat, String thumbnailUrl) {
     this.productId = productId;
     this.sellerId = sellerId;
     this.name = name;
@@ -70,6 +80,7 @@ public class ProductResponse {
     this.safetyStock = safetyStock;
     this.tags = tags == null ? ProductTags.empty() : tags;
     this.tagsFlat = tagsFlat == null ? Collections.emptyList() : tagsFlat;
+    this.thumbnailUrl = thumbnailUrl;
   }
 
   /**
@@ -100,6 +111,30 @@ public class ProductResponse {
       status = Product.Status.LIMITED_SALE;
     }
     return fromWithOverrides(product, tags, tagsFlat, priceOverride, null, status);
+  }
+
+  public static ProductResponse fromWithPriceAndThumbnail(Product product, ProductTags tags, List<String> tagsFlat,
+                                                          Integer priceOverride, String thumbnailUrl) {
+    Product.Status status = product.getStatus();
+    if (product.isLimitedSale()) {
+      status = Product.Status.LIMITED_SALE;
+    }
+    Integer resolvedPrice = priceOverride != null ? priceOverride : product.getPrice();
+    return new ProductResponse(
+            product.getId(),
+            product.getSellerId(),
+            product.getProductName(),
+            product.getShortDesc(),
+            product.getDetailHtml(),
+            resolvedPrice,
+            product.getCostPrice(),
+            status,
+            product.getStockQty(),
+            product.getSafetyStock(),
+            tags,
+            tagsFlat,
+            thumbnailUrl
+    );
   }
 
   private static ProductResponse fromWithOverrides(Product product, ProductTags tags, List<String> tagsFlat,

--- a/src/main/java/com/deskit/deskit/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductImageRepository.java
@@ -3,6 +3,7 @@ package com.deskit.deskit.product.repository;
 import com.deskit.deskit.product.entity.ProductImage;
 import com.deskit.deskit.product.entity.ProductImage.ImageType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
@@ -10,6 +11,12 @@ public interface ProductImageRepository extends JpaRepository<ProductImage, Long
   long countByProductIdAndDeletedAtIsNull(Long productId);
 
   boolean existsByProductIdAndImageTypeAndSlotIndexAndDeletedAtIsNull(
+    Long productId,
+    ImageType imageType,
+    Integer slotIndex
+  );
+
+  Optional<ProductImage> findFirstByProductIdAndImageTypeAndSlotIndexAndDeletedAtIsNullOrderByIdAsc(
     Long productId,
     ImageType imageType,
     Integer slotIndex

--- a/src/main/java/com/deskit/deskit/product/service/ProductService.java
+++ b/src/main/java/com/deskit/deskit/product/service/ProductService.java
@@ -122,7 +122,11 @@ public class ProductService {
     Integer priceOverride = broadcastProductRepository.findLiveBpPriceByProductId(id).stream()
             .findFirst()
             .orElse(null);
-    return Optional.of(ProductResponse.fromWithPrice(product.get(), tags, tagsFlat, priceOverride));
+    String thumbnailUrl = productImageRepository
+      .findFirstByProductIdAndImageTypeAndSlotIndexAndDeletedAtIsNullOrderByIdAsc(id, ImageType.THUMBNAIL, 0)
+      .map(ProductImage::getProductImageUrl)
+      .orElse(null);
+    return Optional.of(ProductResponse.fromWithPriceAndThumbnail(product.get(), tags, tagsFlat, priceOverride, thumbnailUrl));
   }
 
   public List<SellerProductListResponse> getSellerProducts(Long sellerId) {


### PR DESCRIPTION
## 📌 관련 이슈
- closes #424 

## 📝 작업 내용
- 상품 상세 API(/api/products/{id}) 응답에 `thumbnail_url` 필드 추가
- product_image 테이블에서 THUMBNAIL(slot_index=0) 조회 후 `product_image_url`을 `thumbnail_url`로 매핑