### PR TITLE
[FIX] 홈/상품목록/방송상품 이미지 썸네일 응답 추가

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
+++ b/src/main/java/com/deskit/deskit/livehost/dto/response/BroadcastProductResponse.java
@@ -34,6 +34,11 @@ public class BroadcastProductResponse {
     }
 
     public static BroadcastProductResponse fromEntity(BroadcastProduct bp, Integer remainingQuantity, Integer originalCostPrice) {
+        return fromEntityWithImageUrl(bp, remainingQuantity, originalCostPrice, null);
+    }
+
+    public static BroadcastProductResponse fromEntityWithImageUrl(BroadcastProduct bp, Integer remainingQuantity,
+                                                                  Integer originalCostPrice, String imageUrl) {
         Product p = bp.getProduct();
         int remaining = remainingQuantity != null ? remainingQuantity : bp.getBpQuantity();
 
@@ -41,7 +46,7 @@ public class BroadcastProductResponse {
                 .bpId(bp.getBpId())
                 .productId(p.getId())
                 .name(p.getProductName())
-//                .imageUrl(p.getProductThumbUrl())   // 추후 ProductImage 구현되면 추가 예정
+                .imageUrl(imageUrl)
                 .originalPrice(p.getCostPrice())
                 .originalCostPrice(originalCostPrice)
                 .stockQty(remaining)

--- a/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/ProductResponse.java
@@ -53,6 +53,9 @@ public class ProductResponse {
   @JsonProperty("thumbnail_url")
   private final String thumbnailUrl;
 
+  @JsonProperty("product_images")
+  private final List<ProductImageResponse> productImages;
+
   /**
    * 생성자에서 null-safe 처리:
    * - tags/tagsFlat이 null로 들어오면 빈 값으로 치환해서 응답 안정성 확보
@@ -61,13 +64,14 @@ public class ProductResponse {
                          String detailHtml, Integer price, Integer costPrice,
                          Product.Status status, Integer stockQty, Integer safetyStock,
                          ProductTags tags, List<String> tagsFlat) {
-    this(productId, sellerId, name, shortDesc, detailHtml, price, costPrice, status, stockQty, safetyStock, tags, tagsFlat, null);
+    this(productId, sellerId, name, shortDesc, detailHtml, price, costPrice, status, stockQty, safetyStock, tags, tagsFlat, null, null);
   }
 
   public ProductResponse(Long productId, Long sellerId, String name, String shortDesc,
                          String detailHtml, Integer price, Integer costPrice,
                          Product.Status status, Integer stockQty, Integer safetyStock,
-                         ProductTags tags, List<String> tagsFlat, String thumbnailUrl) {
+                         ProductTags tags, List<String> tagsFlat, String thumbnailUrl,
+                         List<ProductImageResponse> productImages) {
     this.productId = productId;
     this.sellerId = sellerId;
     this.name = name;
@@ -81,6 +85,7 @@ public class ProductResponse {
     this.tags = tags == null ? ProductTags.empty() : tags;
     this.tagsFlat = tagsFlat == null ? Collections.emptyList() : tagsFlat;
     this.thumbnailUrl = thumbnailUrl;
+    this.productImages = productImages == null ? Collections.emptyList() : productImages;
   }
 
   /**
@@ -114,7 +119,8 @@ public class ProductResponse {
   }
 
   public static ProductResponse fromWithPriceAndThumbnail(Product product, ProductTags tags, List<String> tagsFlat,
-                                                          Integer priceOverride, String thumbnailUrl) {
+                                                          Integer priceOverride, String thumbnailUrl,
+                                                          List<ProductImageResponse> productImages) {
     Product.Status status = product.getStatus();
     if (product.isLimitedSale()) {
       status = Product.Status.LIMITED_SALE;
@@ -133,7 +139,8 @@ public class ProductResponse {
             product.getSafetyStock(),
             tags,
             tagsFlat,
-            thumbnailUrl
+            thumbnailUrl,
+            productImages
     );
   }
 

--- a/src/main/java/com/deskit/deskit/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/deskit/deskit/product/repository/ProductImageRepository.java
@@ -22,5 +22,11 @@ public interface ProductImageRepository extends JpaRepository<ProductImage, Long
     Integer slotIndex
   );
 
+  List<ProductImage> findAllByProductIdInAndImageTypeAndSlotIndexAndDeletedAtIsNullOrderByProductIdAscIdAsc(
+    List<Long> productIds,
+    ImageType imageType,
+    Integer slotIndex
+  );
+
   List<ProductImage> findAllByProductIdAndDeletedAtIsNullOrderBySlotIndexAsc(Long productId);
 }

--- a/src/main/java/com/deskit/deskit/product/service/ProductService.java
+++ b/src/main/java/com/deskit/deskit/product/service/ProductService.java
@@ -4,6 +4,7 @@ import com.deskit.deskit.product.dto.ProductCreateRequest;
 import com.deskit.deskit.product.dto.ProductCreateResponse;
 import com.deskit.deskit.product.dto.ProductBasicUpdateRequest;
 import com.deskit.deskit.product.dto.ProductDetailUpdateRequest;
+import com.deskit.deskit.product.dto.ProductImageResponse;
 import com.deskit.deskit.product.dto.ProductResponse;
 import com.deskit.deskit.product.dto.ProductResponse.ProductTags;
 import com.deskit.deskit.product.dto.SellerProductListResponse;
@@ -78,6 +79,16 @@ public class ProductService {
             .map(Product::getId)
             .collect(Collectors.toList());
 
+    Map<Long, String> thumbnailUrls = productImageRepository
+      .findAllByProductIdInAndImageTypeAndSlotIndexAndDeletedAtIsNullOrderByProductIdAscIdAsc(
+        productIds, ImageType.THUMBNAIL, 0
+      ).stream()
+      .collect(Collectors.toMap(
+        ProductImage::getProductId,
+        ProductImage::getProductImageUrl,
+        (left, right) -> left
+      ));
+
     Map<Long, Integer> livePrices = broadcastProductRepository.findLiveBpPrices(productIds).stream()
             .collect(Collectors.toMap(
                     BroadcastProductRepository.LivePriceRow::getProductId,
@@ -98,7 +109,10 @@ public class ProductService {
               ProductTags tags = bundle == null ? ProductTags.empty() : bundle.getTags();
               List<String> tagsFlat = bundle == null ? Collections.emptyList() : bundle.getTagsFlat();
               Integer priceOverride = livePrices.get(product.getId());
-              return ProductResponse.fromWithPrice(product, tags, tagsFlat, priceOverride);
+              String thumbnailUrl = thumbnailUrls.get(product.getId());
+              return ProductResponse.fromWithPriceAndThumbnail(
+                product, tags, tagsFlat, priceOverride, thumbnailUrl, null
+              );
             })
             .collect(Collectors.toList());
   }
@@ -126,7 +140,14 @@ public class ProductService {
       .findFirstByProductIdAndImageTypeAndSlotIndexAndDeletedAtIsNullOrderByIdAsc(id, ImageType.THUMBNAIL, 0)
       .map(ProductImage::getProductImageUrl)
       .orElse(null);
-    return Optional.of(ProductResponse.fromWithPriceAndThumbnail(product.get(), tags, tagsFlat, priceOverride, thumbnailUrl));
+    List<ProductImageResponse> productImages = productImageRepository
+      .findAllByProductIdAndDeletedAtIsNullOrderBySlotIndexAsc(id).stream()
+      .filter(image -> image.getImageType() == ImageType.GALLERY)
+      .map(ProductImageResponse::from)
+      .collect(Collectors.toList());
+    return Optional.of(ProductResponse.fromWithPriceAndThumbnail(
+      product.get(), tags, tagsFlat, priceOverride, thumbnailUrl, productImages
+    ));
   }
 
   public List<SellerProductListResponse> getSellerProducts(Long sellerId) {


### PR DESCRIPTION
## 📌 관련 이슈
- closes #429 

## 📝 작업 내용
- 상품 목록(/api/products) 응답에 thumbnail_url 배치 매핑 추가 (N+1 방지)
- 방송 상품(/api/broadcasts/{id}/products) 응답 imageUrl에 썸네일 매핑 추가