### PR TITLE
feat: 채팅 구조 개선

### DIFF
--- a/src/main/java/com/deskit/deskit/directchat/controller/DirectChatController.java
+++ b/src/main/java/com/deskit/deskit/directchat/controller/DirectChatController.java
@@ -43,4 +43,9 @@ public class DirectChatController {
     ) {
         return directChatService.saveMessage(chatId, request);
     }
+
+    @PostMapping("/{chatId}/close")
+    public void closeChat(@PathVariable Long chatId) {
+        directChatService.closeChat(chatId);
+    }
 }

--- a/src/main/java/com/deskit/deskit/directchat/service/DirectChatService.java
+++ b/src/main/java/com/deskit/deskit/directchat/service/DirectChatService.java
@@ -18,6 +18,7 @@ import com.deskit.deskit.directchat.dto.DirectChatMessageResponse;
 import com.deskit.deskit.directchat.dto.DirectChatSummaryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +33,7 @@ public class DirectChatService {
     private final ChatHandoffRepository chatHandoffRepository;
     private final MemberRepository memberRepository;
     private final SellerRepository sellerRepository;
+    private final SimpMessagingTemplate messagingTemplate;
 
     @Transactional(readOnly = true)
     public List<DirectChatSummaryResponse> getEscalatedChats() {
@@ -160,6 +162,15 @@ public class DirectChatService {
         closeMessage.setType(MessageType.SYSTEM);
         closeMessage.setContent("상담이 종료되었습니다.");
         chatRepository.save(closeMessage);
+
+        DirectChatMessageResponse response = DirectChatMessageResponse.builder()
+                .messageId(closeMessage.getMessageId())
+                .chatId(closeMessage.getChatId())
+                .sender(resolveSender(closeMessage.getType()))
+                .content(closeMessage.getContent())
+                .createdAt(closeMessage.getCreatedAt())
+                .build();
+        messagingTemplate.convertAndSend("/topic/direct-chats/" + chatId, response);
 
         chatHandoffRepository.findTopByChatIdOrderByCreatedAtDesc(chatId)
                 .ifPresent(handoff -> {


### PR DESCRIPTION
## 📌 관련 이슈

- closes #433 

## 📝 작업 내용

- 관리자-회원 채팅을 실시간(STOMP) + 비실시간(REST) 구조로 변경

## 🧐 리뷰 포인트

- 관리자 이관 및 채팅
