### PR TITLE
Revert access token unification changes

### DIFF
--- a/front/src/api/http.ts
+++ b/front/src/api/http.ts
@@ -36,7 +36,11 @@ http.interceptors.request.use((config: InternalAxiosRequestConfig) => {
     config.baseURL = baseURL.replace(/\/api$/, '')
   }
 
-  const token = localStorage.getItem('access_token')
+  const token =
+    localStorage.getItem('access_token') ||
+    sessionStorage.getItem('access_token') ||
+    localStorage.getItem('access') ||
+    sessionStorage.getItem('access')
 
   const method = (config.method ?? 'get').toLowerCase()
   const rawUrl = config.url ?? ''


### PR DESCRIPTION
### Motivation
- The unified access token helper impacted many files and increased risk, so revert to a smaller-scope change to reduce surface area. 
- Preserve a targeted fix so the `Authorization` header is still populated by checking legacy keys and `sessionStorage` when present.

### Description
- Reverted the large access-token unification and removed the helper `front/src/lib/accessToken.ts`, restoring the previous code paths. 
- Kept and applied a focused update to the Axios request interceptor in `front/src/api/http.ts` to read the token from `localStorage` or `sessionStorage` and from either `access_token` or legacy `access` keys, and to inject the `Authorization` header for non-public APIs. 
- Restored other files modified by the broader unification back to their prior state.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690a5869b4832a978000cf3e934ea4)