### PR TITLE
Fix SockJS base URL for live chat

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -31,7 +31,7 @@ const route = useRoute()
 const router = useRouter()
 const { now } = useNow(1000)
 const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
-const apiRoot = apiBase.replace(/\/api\/?$/, '')
+const wsBase = apiBase.replace(/\/+$/, '')
 const sseSource = ref<EventSource | null>(null)
 const sseConnected = ref(false)
 const sseRetryCount = ref(0)
@@ -986,7 +986,7 @@ const connectChat = () => {
   }
   const client = new Client({
     webSocketFactory: () =>
-        new SockJS(`${apiRoot}/ws`, undefined, {
+        new SockJS(`${wsBase}/ws`, undefined, {
         withCredentials: true,
       }),
     reconnectDelay: 5000,

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -24,7 +24,7 @@ import { resolveViewerId } from '../../../lib/live/viewer'
 const route = useRoute()
 const router = useRouter()
 const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
-const apiRoot = apiBase.replace(/\/api\/?$/, '')
+const wsBase = apiBase.replace(/\/+$/, '')
 
 // --- Types ---
 type AdminDetail = {
@@ -338,7 +338,7 @@ const fetchRecentMessages = async () => {
 const connectChat = () => {
   if (!broadcastId.value || stompClient.value?.active) return
   const client = new Client({
-    webSocketFactory: () => new SockJS(`${apiRoot}/ws`, undefined, { withCredentials: true }),
+    webSocketFactory: () => new SockJS(`${wsBase}/ws`, undefined, { withCredentials: true }),
     reconnectDelay: 5000,
   })
 

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -173,7 +173,7 @@ const recordingStartRequested = ref(false)
 const endRequested = ref(false)
 const endRequestTimer = ref<number | null>(null)
 const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
-const apiRoot = apiBase.replace(/\/api\/?$/, '')
+const wsBase = apiBase.replace(/\/+$/, '')
 const viewerId = ref<string | null>(resolveViewerId(getAuthUser()))
 const joinedBroadcastId = ref<number | null>(null)
 const joinedViewerId = ref<string | null>(null)
@@ -356,7 +356,7 @@ const connectChat = () => {
 
   const client = new Client({
     webSocketFactory: () =>
-        new SockJS(`${apiRoot}/ws`, undefined, {
+        new SockJS(`${wsBase}/ws`, undefined, {
         withCredentials: true,
       }),
     reconnectDelay: 5000,


### PR DESCRIPTION
### Motivation
- WebSocket connections to `/ws/info` were returning 404 during live broadcasts because the front-end was normalizing `VITE_API_BASE_URL` by removing an `/api` suffix, producing an incorrect base URL for SockJS. 
- The intent is to preserve the backend path (including `/api` when present) and only remove trailing slashes so SockJS reaches the correct `/ws` endpoint.

### Description
- Introduce `wsBase = apiBase.replace(/\/+$/,'')` and stop using the previous `apiRoot` normalization that stripped `/api` in `front/src/pages/LiveDetail.vue`. 
- Apply the same `wsBase` change and update the `SockJS` instantiation to use ```${wsBase}/ws``` in `front/src/pages/admin/live/LiveDetail.vue`. 
- Apply the same `wsBase` change and update the `SockJS` instantiation to use ```${wsBase}/ws``` in `front/src/pages/seller/LiveStream.vue`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969489fd7f8832a96b3643f2ec2bcff)