### PR TITLE
Fix websocket base URL resolution for live chat

### DIFF
--- a/front/src/lib/ws.ts
+++ b/front/src/lib/ws.ts
@@ -1,0 +1,18 @@
+export const resolveWsBase = (apiBase?: string) => {
+  const trimmed = (apiBase ?? '').trim()
+  const origin = typeof window !== 'undefined' ? window.location.origin : ''
+  const base = trimmed || origin
+
+  if (!base) {
+    return ''
+  }
+
+  try {
+    const url = new URL(base, origin || 'http://localhost')
+    const normalizedPath = url.pathname.replace(/\/api\/?$/, '').replace(/\/$/, '')
+    url.pathname = normalizedPath || '/'
+    return url.toString().replace(/\/$/, '')
+  } catch {
+    return base.replace(/\/api\/?$/, '').replace(/\/+$/, '')
+  }
+}

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -12,6 +12,7 @@ import { useNow } from '../lib/live/useNow'
 import { getAuthUser, hydrateSessionUser } from '../lib/auth'
 import { resolveViewerId } from '../lib/live/viewer'
 import { createImageErrorHandler } from '../lib/images/productImages'
+import { resolveWsBase } from '../lib/ws'
 import {
   fetchBroadcastLikeStatus,
   fetchBroadcastProducts,
@@ -31,7 +32,7 @@ const route = useRoute()
 const router = useRouter()
 const { now } = useNow(1000)
 const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
-const wsBase = apiBase.replace(/\/+$/, '')
+const wsBase = resolveWsBase(apiBase)
 const sseSource = ref<EventSource | null>(null)
 const sseConnected = ref(false)
 const sseRetryCount = ref(0)

--- a/front/src/pages/admin/live/LiveDetail.vue
+++ b/front/src/pages/admin/live/LiveDetail.vue
@@ -19,12 +19,13 @@ import { useNow } from '../../../lib/live/useNow'
 import { computeLifecycleStatus, getBroadcastStatusLabel, getScheduledEndMs, normalizeBroadcastStatus } from '../../../lib/broadcastStatus'
 import { getAuthUser } from '../../../lib/auth'
 import { createImageErrorHandler } from '../../../lib/images/productImages'
+import { resolveWsBase } from '../../../lib/ws'
 import { resolveViewerId } from '../../../lib/live/viewer'
 
 const route = useRoute()
 const router = useRouter()
 const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
-const wsBase = apiBase.replace(/\/+$/, '')
+const wsBase = resolveWsBase(apiBase)
 
 // --- Types ---
 type AdminDetail = {

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -34,6 +34,7 @@ import { getAuthUser } from '../../lib/auth'
 import { resolveViewerId } from '../../lib/live/viewer'
 import { computeLifecycleStatus, getScheduledEndMs, normalizeBroadcastStatus, type BroadcastStatus } from '../../lib/broadcastStatus'
 import { createImageErrorHandler } from '../../lib/images/productImages'
+import { resolveWsBase } from '../../lib/ws'
 
 type StreamProduct = {
   id: string
@@ -173,7 +174,7 @@ const recordingStartRequested = ref(false)
 const endRequested = ref(false)
 const endRequestTimer = ref<number | null>(null)
 const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
-const wsBase = apiBase.replace(/\/+$/, '')
+const wsBase = resolveWsBase(apiBase)
 const viewerId = ref<string | null>(resolveViewerId(getAuthUser()))
 const joinedBroadcastId = ref<number | null>(null)
 const joinedViewerId = ref<string | null>(null)


### PR DESCRIPTION
### Motivation
- Clients using an API base that includes `/api` were triggering SockJS to request `GET /api/ws/info` and receiving `404`, causing repeated WebSocket connection failures. 
- The intent is to ensure STOMP/SockJS connections target the backend `/ws`/`/ws-live` endpoints regardless of how `VITE_API_BASE_URL` is configured.

### Description
- Added a small helper `resolveWsBase` in `front/src/lib/ws.ts` to normalize the API base by stripping a trailing `/api` and trimming paths, and to return a stable base URL for websockets. 
- Switched websocket base resolution to use `resolveWsBase(apiBase)` in `front/src/pages/seller/LiveStream.vue`, `front/src/pages/LiveDetail.vue`, and `front/src/pages/admin/live/LiveDetail.vue` so SockJS is instantiated with the corrected base (e.g. `
new SockJS(`${wsBase}/ws`, ...)`).
- This ensures the client will call the expected websocket endpoints (`/ws` or `/ws-live`) instead of `/<api>/ws/info` when `VITE_API_BASE_URL` includes `/api`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696952cd6fe4832a9c97fd4aff768bf1)