### PR TITLE
[FEAT] 상품 이미지 썸네일 고정 및 공통 프레임 적용

### DIFF
--- a/front/src/components/ProductCard.vue
+++ b/front/src/components/ProductCard.vue
@@ -24,8 +24,8 @@ const discountRate = computed(() => {
 <template>
   <RouterLink :to="`/products/${props.id}`" class="card-link">
     <article class="card">
-      <div class="thumb">
-        <img :src="props.imageUrl" :alt="props.name" />
+      <div class="thumb ds-thumb-frame ds-thumb-16x10">
+        <img class="ds-thumb-img" :src="props.imageUrl" :alt="props.name" />
         <span v-if="discountRate > 0" class="badge">-{{ discountRate }}%</span>
       </div>
       <div class="body">

--- a/front/src/components/ProductListCard.vue
+++ b/front/src/components/ProductListCard.vue
@@ -21,8 +21,8 @@ const discountRate = computed(() => {
 
 <template>
   <RouterLink :to="`/products/${props.id}`" class="card">
-    <div class="thumb">
-      <img :src="props.imageUrl" :alt="props.name" />
+    <div class="thumb ds-thumb-frame ds-thumb-square">
+      <img class="ds-thumb-img" :src="props.imageUrl" :alt="props.name" />
       <span v-if="discountRate > 0" class="badge">-{{ discountRate }}%</span>
     </div>
     <div class="body">
@@ -56,16 +56,19 @@ const discountRate = computed(() => {
 }
 
 .thumb {
-  aspect-ratio: 16 / 10;
+  aspect-ratio: 1 / 1;
   background: var(--surface-weak);
   position: relative;
+  width: 100%;
+  overflow: hidden;
 }
 
 .thumb img {
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
-  display: block;
+  object-position: center;
 }
 
 .body {

--- a/front/src/pages/Cart.vue
+++ b/front/src/pages/Cart.vue
@@ -254,7 +254,9 @@ onBeforeUnmount(() => {
               </label>
 
               <div class="cart-item__main">
-                <img :src="item.imageUrl" :alt="item.name" class="cart-item__thumb" />
+                <div class="cart-item__thumb ds-thumb-frame ds-thumb-square">
+                  <img class="ds-thumb-img" :src="item.imageUrl" :alt="item.name" />
+                </div>
                 <div class="cart-item__info">
                   <h3 class="cart-title">{{ item.name }}</h3>
                   <div class="cart-pricing">
@@ -472,7 +474,6 @@ onBeforeUnmount(() => {
   width: 96px;
   height: 96px;
   border-radius: 12px;
-  object-fit: cover;
 }
 
 .cart-item__info {

--- a/front/src/pages/Live.vue
+++ b/front/src/pages/Live.vue
@@ -595,7 +595,9 @@ onMounted(() => {
             @click="handleRowClick(item)"
             @keydown="(e) => handleRowKeydown(e, item)"
           >
-            <img class="thumb" :src="item.thumbnailUrl" :alt="item.title" @error="handleImageError" />
+            <div class="thumb ds-thumb-frame ds-thumb-16x10">
+              <img class="ds-thumb-img" :src="item.thumbnailUrl" :alt="item.title" @error="handleImageError" />
+            </div>
             <div class="meta">
               <div class="meta__title-row">
                 <h4 class="meta__title">{{ item.title }}</h4>
@@ -797,7 +799,6 @@ onMounted(() => {
   width: 180px;
   height: 140px;
   border-radius: 16px;
-  object-fit: cover;
 }
 
 .meta {

--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -1597,7 +1597,9 @@ onBeforeUnmount(() => {
             @click="handleProductClick(product.id)"
           >
             <span v-if="product.isPinned" class="product-card__pin">PIN</span>
-            <img class="product-card__thumb" :src="product.imageUrl" :alt="product.name" @error="handleImageError" />
+            <div class="product-card__thumb ds-thumb-frame ds-thumb-square">
+              <img class="ds-thumb-img" :src="product.imageUrl" :alt="product.name" @error="handleImageError" />
+            </div>
             <div class="product-card__info">
               <p class="product-card__name">{{ product.name }}</p>
               <p class="product-card__price">
@@ -1735,7 +1737,6 @@ onBeforeUnmount(() => {
   width: 64px;
   height: 64px;
   border-radius: 10px;
-  object-fit: cover;
 }
 
 .product-card__info {

--- a/front/src/pages/MyPage.vue
+++ b/front/src/pages/MyPage.vue
@@ -228,8 +228,8 @@ onMounted(() => {
             class="product-card"
             :to="`/products/${item.product_id}`"
           >
-            <div class="thumb">
-              <img :src="item.imageUrl" :alt="item.name" />
+            <div class="thumb ds-thumb-frame ds-thumb-square">
+              <img class="ds-thumb-img" :src="item.imageUrl" :alt="item.name" />
             </div>
             <div class="product-body">
               <p class="product-name">{{ item.name }}</p>

--- a/front/src/pages/OrderHistory.vue
+++ b/front/src/pages/OrderHistory.vue
@@ -370,8 +370,8 @@ onMounted(() => {
         <div class="card-grid">
           <div class="info">
             <div class="info__row header">
-              <div class="thumb" :class="{ 'thumb--empty': !thumbOf(order) }">
-                <img v-if="thumbOf(order)" :src="thumbOf(order)" :alt="order.items[0]?.name || '상품'" />
+              <div class="thumb ds-thumb-frame ds-thumb-square" :class="{ 'thumb--empty': !thumbOf(order) }">
+                <img v-if="thumbOf(order)" class="ds-thumb-img" :src="thumbOf(order)" :alt="order.items[0]?.name || '상품'" />
                 <span v-else class="thumb__ph">DESKIT</span>
               </div>
               <div class="header-block">

--- a/front/src/pages/ProductDetail.vue
+++ b/front/src/pages/ProductDetail.vue
@@ -281,7 +281,7 @@ onBeforeUnmount(() => {
               :class="{ active: idx === selectedImageIndex }"
               @click="selectedImageIndex = idx"
           >
-            <img :src="img || placeholderImage" :alt="`${product.name} 썸네일 ${idx + 1}`" @error="handleImageError" />
+            <img class="ds-thumb-img" :src="img || placeholderImage" :alt="`${product.name} 썸네일 ${idx + 1}`" @error="handleImageError" />
           </button>
         </div>
         <div class="main-image">

--- a/front/src/pages/Vod.vue
+++ b/front/src/pages/Vod.vue
@@ -486,7 +486,9 @@ watch(isLoggedIn, (next) => {
             :class="{ 'product-card--sold-out': product.isSoldOut }"
             @click="handleProductClick(product.id)"
           >
-            <img class="product-card__thumb" :src="product.imageUrl" :alt="product.name" @error="handleImageError" />
+            <div class="product-card__thumb ds-thumb-frame ds-thumb-square">
+              <img class="ds-thumb-img" :src="product.imageUrl" :alt="product.name" @error="handleImageError" />
+            </div>
             <div class="product-card__info">
               <p class="product-card__name">{{ product.name }}</p>
               <p class="product-card__price">{{ formatPrice(product.price) }}</p>
@@ -595,7 +597,6 @@ watch(isLoggedIn, (next) => {
   width: 64px;
   height: 64px;
   border-radius: 10px;
-  object-fit: cover;
 }
 
 .product-card__info {

--- a/front/src/pages/admin/AdminProducts.vue
+++ b/front/src/pages/admin/AdminProducts.vue
@@ -211,9 +211,10 @@ onBeforeUnmount(() => {
     <section v-else class="product-list">
       <article v-for="item in keyedProducts" :key="item.key">
         <div class="product-card ds-surface">
-          <div class="thumb">
+          <div class="thumb ds-thumb-frame">
             <img
               v-if="item.product.imageUrl"
+              class="ds-thumb-img"
               :src="item.product.imageUrl"
               :alt="item.product.name"
             />

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -1836,8 +1836,8 @@ const toggleFullscreen = async () => {
             :class="{ 'is-pinned': pinnedProductId === item.id, 'is-soldout': item.status === '품절' }"
           >
             <span v-if="pinnedProductId === item.id" class="pin-badge">PIN</span>
-            <div class="panel-thumb">
-              <img :src="item.thumb" :alt="item.title" loading="lazy" @error="handleImageError" />
+            <div class="panel-thumb ds-thumb-frame ds-thumb-square">
+              <img class="ds-thumb-img" :src="item.thumb" :alt="item.title" loading="lazy" @error="handleImageError" />
             </div>
             <div class="panel-meta">
               <p class="panel-title">{{ item.title }}</p>

--- a/front/src/style.css
+++ b/front/src/style.css
@@ -50,6 +50,29 @@
   box-shadow: var(--shadow-card);
 }
 
+.ds-thumb-frame {
+  width: 100%;
+  overflow: hidden;
+  background: var(--surface-weak);
+  position: relative;
+}
+
+.ds-thumb-square {
+  aspect-ratio: 1 / 1;
+}
+
+.ds-thumb-16x10 {
+  aspect-ratio: 16 / 10;
+}
+
+.ds-thumb-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
 @media (max-width: 640px) {
   .ds-container {
     padding: 0 16px;


### PR DESCRIPTION
## 📌 관련 이슈
- closes #434 

## 📝 작업 내용
- 상품 이미지 비율/크기에 관계없이 카드 높이가 흔들리지 않도록 공통 썸네일 프레임 CSS(.ds-thumb-*) 추가 및 적용
- 리스트/카드/장바구니/주문내역/마이페이지/라이브·VOD 등 이미지 노출 영역을 공통 프레임으로 감싸고 `object-fit: cover`로 크롭 고정
- 이미지 로딩 실패 시 placeholder로 1회만 fallback 되도록 공통 이미지 에러 핸들러 기반 유지