### PR TITLE
FIX: 상품 배경색 화이트로 변경

### DIFF
--- a/front/src/style.css
+++ b/front/src/style.css
@@ -53,7 +53,7 @@
 .ds-thumb-frame {
   width: 100%;
   overflow: hidden;
-  background: var(--surface-weak);
+  background: #fff;
   position: relative;
 }
 


### PR DESCRIPTION
## 📌 관련 이슈
- closes #507 

## 📝 작업 내용
- 썸네일 프레임(.ds-thumb-frame) 기본 배경색을 surface-weak → #fff로 변경
- 투명/배경 없는 상품 이미지가 카드에서 어색하게 보이던 문제 개선

## 📸 스크린샷 (선택)
- 상품 목록(/products) 카드 썸네일 비교 캡처 (변경 전/후)

## 🧐 리뷰 포인트
- ds-thumb-frame 적용 영역(상품 카드/장바구니/주문내역/라이브/VOD 등)에서 배경 흰색이 톤앤매너에 문제 없는지

## ✅ 체크리스트
- [ ] 빌드가 오류 없이 실행되는지 확인했나요?
- [ ] 포맷팅(코드 스타일)을 준수했나요?
- [ ] 불필요한 로그나 주석은 제거했나요?