### PR TITLE
[FEAT] 상품 이미지 프레임 배경 흰색 통일 및 썸네일 프레임 공통화

### DIFF
--- a/front/src/components/ProductCard.vue
+++ b/front/src/components/ProductCard.vue
@@ -67,17 +67,8 @@ const discountRate = computed(() => {
 
 .thumb {
   position: relative;
-  aspect-ratio: 16 / 10;
-  background: var(--surface-weak);
   width: 100%;
   overflow: hidden;
-}
-
-.thumb img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
 }
 
 .badge {

--- a/front/src/components/ProductListCard.vue
+++ b/front/src/components/ProductListCard.vue
@@ -57,18 +57,9 @@ const discountRate = computed(() => {
 
 .thumb {
   aspect-ratio: 1 / 1;
-  background: var(--surface-weak);
   position: relative;
   width: 100%;
   overflow: hidden;
-}
-
-.thumb img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center;
 }
 
 .body {

--- a/front/src/pages/MyPage.vue
+++ b/front/src/pages/MyPage.vue
@@ -572,17 +572,9 @@ onMounted(() => {
 
 .thumb {
   width: 100%;
-  aspect-ratio: 4 / 3;
-  background: var(--surface-weak);
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.thumb img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
 }
 
 .product-body {

--- a/front/src/pages/OrderHistory.vue
+++ b/front/src/pages/OrderHistory.vue
@@ -710,18 +710,10 @@ onMounted(() => {
   border-radius: 14px;
   overflow: hidden;
   border: 1px solid var(--border-color);
-  background: var(--surface-weak);
   display: flex;
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-}
-
-.thumb img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
 }
 
 .thumb__ph {
@@ -731,9 +723,6 @@ onMounted(() => {
   letter-spacing: 0.06em;
 }
 
-.thumb--empty {
-  background: linear-gradient(135deg, var(--surface-weak), var(--surface));
-}
 
 .items-list {
   margin-top: 8px;

--- a/front/src/pages/ProductDetail.vue
+++ b/front/src/pages/ProductDetail.vue
@@ -274,18 +274,18 @@ onBeforeUnmount(() => {
       <div class="media">
         <div class="thumbs" v-if="imageList.length">
           <button
-              v-for="(img, idx) in imageList"
-              :key="`${img ?? ''}-${idx}`"
-              type="button"
-              class="thumb-btn"
-              :class="{ active: idx === selectedImageIndex }"
-              @click="selectedImageIndex = idx"
+            v-for="(img, idx) in imageList"
+            :key="`${img ?? ''}-${idx}`"
+            type="button"
+            class="thumb-btn ds-thumb-frame ds-thumb-square"
+            :class="{ active: idx === selectedImageIndex }"
+            @click="selectedImageIndex = idx"
           >
             <img class="ds-thumb-img" :src="img || placeholderImage" :alt="`${product.name} 썸네일 ${idx + 1}`" @error="handleImageError" />
           </button>
         </div>
-        <div class="main-image">
-          <img :src="selectedImage" :alt="product.name" @error="handleImageError" />
+        <div class="main-image ds-thumb-frame">
+          <img class="ds-thumb-img" :src="selectedImage" :alt="product.name" @error="handleImageError" />
         </div>
       </div>
 
@@ -417,7 +417,7 @@ onBeforeUnmount(() => {
 .main-image {
   flex: 1;
   min-height: 260px;
-  background: var(--surface-weak);
+  background: #fff;
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);

--- a/front/src/pages/admin/AdminProducts.vue
+++ b/front/src/pages/admin/AdminProducts.vue
@@ -211,7 +211,7 @@ onBeforeUnmount(() => {
     <section v-else class="product-list">
       <article v-for="item in keyedProducts" :key="item.key">
         <div class="product-card ds-surface">
-          <div class="thumb ds-thumb-frame">
+          <div class="thumb ds-thumb-frame ds-thumb-16x10">
             <img
               v-if="item.product.imageUrl"
               class="ds-thumb-img"
@@ -314,20 +314,12 @@ input[type='search'] {
   height: 110px;
   border-radius: 12px;
   overflow: hidden;
-  background: var(--surface-weak);
-}
-
-.thumb img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
 }
 
 .thumb__placeholder {
   width: 100%;
   height: 100%;
-  background: linear-gradient(135deg, #1f2937, #0f172a);
+  background: #fff;
 }
 
 .product-main {

--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -2353,14 +2353,7 @@ const toggleFullscreen = async () => {
   height: 64px;
   border-radius: 12px;
   overflow: hidden;
-  background: linear-gradient(135deg, #1f2937, #0f172a);
-}
-
-.panel-thumb img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
+  background: #fff;
 }
 
 .panel-meta {


### PR DESCRIPTION
## 📝 작업 내용
- 상품 이미지 프레임 배경색을 흰색(#fff)으로 통일 (ds-thumb-frame 기반)
- 페이지별로 중복/상충하던 thumb background 및 img object-fit 스타일 제거 → 전역 유틸(ds-thumb-*)로 일원화
- 상품상세 썸네일 버튼에 ds-thumb-square 적용해 썸네일 프레임 일관성 유지
- AdminProducts 썸네일에 ds-thumb-16x10 적용 및 placeholder 배경 흰색 처리
- LiveStream 패널 썸네일 배경 그라데이션 제거 → 흰색으로 통일
