### PR TITLE
[FIX] 헤더 ‘셋업’ 링크 클릭 불가 이슈 수정 (모바일 메뉴 outside-click 로직 보완)

### DIFF
--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -7,6 +7,7 @@ const route = useRoute()
 const router = useRouter()
 const isScrolled = ref(false)
 const isMenuOpen = ref(false)
+const headerRef = ref<HTMLElement | null>(null)
 const panelRef = ref<HTMLElement | null>(null)
 const isLoggedIn = ref(false)
 const memberCategory = ref<string | null>(null)
@@ -83,8 +84,10 @@ const handleScroll = () => {
 }
 
 const handleDocumentClick = (event: MouseEvent) => {
-  const target = event.target as Node
-  if (isMenuOpen.value && panelRef.value && panelRef.value.contains(target)) return
+  if (!isMenuOpen.value) return
+  const path = event.composedPath()
+  if (panelRef.value && path.includes(panelRef.value)) return
+  if (headerRef.value && path.includes(headerRef.value)) return
   closeMenu()
 }
 
@@ -185,7 +188,7 @@ const handleLogout = async () => {
 </script>
 
 <template>
-  <header class="header" :class="{ 'header--scrolled': isScrolled }">
+  <header ref="headerRef" class="header" :class="{ 'header--scrolled': isScrolled }">
     <div class="container">
       <div class="left">
         <RouterLink :to="logoTo" class="brand">


### PR DESCRIPTION
## 📌 관련 이슈
- closes #511 

## 📝 작업 내용
- 모바일 메뉴 오픈 상태에서 header 영역 클릭을 outside click으로 오인해 네비게이션이 끊기는 문제 수정
- document click 핸들러를 메뉴 오픈 상태에서만 동작하도록 제한
- event.composedPath()를 사용해 header/nav 내부 클릭은 무시하도록 처리

## 📸 스크린샷 (선택)

## 🧐 리뷰 포인트
- composedPath() 사용이 브라우저 호환성/이벤트 전파 측면에서 안전한지 확인 부탁드립니다.
- 모바일 메뉴 닫힘/링크 이동 UX가 기존 동작과 충돌 없는지 확인 부탁드립니다.

## ✅ 체크리스트
- [ ] 빌드가 오류 없이 실행되는지 확인했나요?
- [ ] 포맷팅(코드 스타일)을 준수했나요?
- [ ] 불필요한 로그나 주석은 제거했나요?