### PR TITLE
[FIX] 셋업 이미지 URL S3 키 절대경로 변환 지원

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/AwsS3Service.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/AwsS3Service.java
@@ -78,6 +78,18 @@ public class AwsS3Service {
         }
     }
 
+    public String buildPublicUrl(String key) {
+        if (key == null || key.isBlank()) {
+            return null;
+        }
+        String trimmedKey = key.startsWith("/") ? key.substring(1) : key;
+        if (endpoint != null && !endpoint.isBlank()) {
+            String base = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+            return base + "/" + bucket + "/" + trimmedKey;
+        }
+        return amazonS3.getUrl(bucket, trimmedKey).toString();
+    }
+
     public void deleteFile(Long sellerId, String storedFileName) {
         String expectedPrefix = "seller_" + sellerId + "/";
         if (!storedFileName.startsWith(expectedPrefix)) {

--- a/src/main/java/com/deskit/deskit/setup/dto/SetupResponse.java
+++ b/src/main/java/com/deskit/deskit/setup/dto/SetupResponse.java
@@ -73,27 +73,37 @@ public class SetupResponse {
    * - 엔티티 필드명(setupName 등)과 응답 필드명(name 등)을 여기서 매핑
    */
   public static SetupResponse from(Setup setup, SetupTags tags, List<String> tagsFlat) {
+    return from(setup, tags, tagsFlat, setup.getSetupImageUrl());
+  }
+
+  public static SetupResponse from(Setup setup, SetupTags tags, List<String> tagsFlat,
+                                   List<Long> productIds) {
+    return from(setup, tags, tagsFlat, productIds, setup.getSetupImageUrl());
+  }
+
+  public static SetupResponse from(Setup setup, SetupTags tags, List<String> tagsFlat,
+                                   String setupImageUrl) {
     return new SetupResponse(
             setup.getId(),
             setup.getSellerId(),
             setup.getSetupName(),      // 엔티티 setupName -> 응답 name
             setup.getShortDesc(),
             setup.getTipText(),
-            setup.getSetupImageUrl(),
+            setupImageUrl,
             tags,
             tagsFlat
     );
   }
 
   public static SetupResponse from(Setup setup, SetupTags tags, List<String> tagsFlat,
-                                   List<Long> productIds) {
+                                   List<Long> productIds, String setupImageUrl) {
     return new SetupResponse(
             setup.getId(),
             setup.getSellerId(),
             setup.getSetupName(),      // 엔티티 setupName -> 응답 name
             setup.getShortDesc(),
             setup.getTipText(),
-            setup.getSetupImageUrl(),
+            setupImageUrl,
             productIds,
             tags,
             tagsFlat


### PR DESCRIPTION
## 📌 관련 이슈
- closes #515 

## 📝 작업 내용
- AwsS3Service에 스토리지 key → 공개 URL 변환(buildPublicUrl) 유틸 추가
- SetupService에서 setup_image_url이 URL이 아닌 경우 DTO 생성 시점에 S3 공개 URL로 resolve 처리
- SetupResponse에 setup_image_url을 외부 주입할 수 있는 from 오버로드 추가(기존 JSON 필드명 유지)
