### PR TITLE
chat permission alert logic changed

### DIFF
--- a/front/src/pages/LiveDetail.vue
+++ b/front/src/pages/LiveDetail.vue
@@ -730,10 +730,10 @@ const notifyViewerSanction = (type: 'MUTE' | 'OUT', actorLabel?: string) => {
   router.push({ name: 'live' }).catch(() => {})
 }
 
-watch(hasChatPermission, (next, prev) => {
-  if (!next) {
+watch([hasChatPermission, lifecycleStatus], ([nextPermission, nextStatus], [prevPermission]) => {
+  if (!nextPermission) {
     input.value = ''
-    if (prev && viewerSanctionType.value !== 'MUTE') {
+    if (prevPermission && viewerSanctionType.value !== 'MUTE' && nextStatus === 'ON_AIR') {
       notifyViewerSanction('MUTE')
     }
   }


### PR DESCRIPTION
## 📌 관련 이슈

- closes #

## 📝 작업 내용

- 채팅 금지 알림이 방송 STOPPED 상태일 때 전역으로 알림이 가서, STOPPED 상태일 때는 제재 알림이 뜨지 않도록 수정

## ✅ 체크리스트

- [ ] 빌드가 오류 없이 실행되는지 확인했나요?
