### PR TITLE
fix: 셋업 API 필드 정규화로 이미지/텍스트 매핑 복구

### DIFF
--- a/front/src/api/setups.ts
+++ b/front/src/api/setups.ts
@@ -8,7 +8,7 @@ import {
 } from './api-text-json'
 
 const normalizeSetup = (raw: any): SetupWithProducts => {
-  const productIdsRaw = raw?.product_ids ?? raw?.productIds
+  const productIdsRaw = raw?.product_ids ?? raw?.productIds ?? raw?.productIdsRaw
   const setupProducts = raw?.setup_products ?? raw?.setupProducts
   const products = raw?.products
   const collectIds = (items: any[]) =>
@@ -33,10 +33,15 @@ const normalizeSetup = (raw: any): SetupWithProducts => {
   const uniqueProductIds = Array.from(new Set(product_ids))
   const tags = Array.isArray(raw?.tags) ? raw.tags : []
   return {
-    setup_id: raw?.setup_id ?? raw?.id ?? 0,
-    title: raw?.title ?? raw?.name ?? '',
-    short_desc: raw?.short_desc ?? raw?.description ?? '',
-    imageUrl: raw?.imageUrl ?? raw?.image_url ?? '/placeholder-setup.jpg',
+    setup_id: raw?.setup_id ?? raw?.setupId ?? raw?.id ?? 0,
+    title: raw?.title ?? raw?.setupName ?? raw?.setup_name ?? raw?.setup_title ?? raw?.name ?? '',
+    short_desc: raw?.short_desc ?? raw?.shortDesc ?? raw?.description ?? raw?.shortDescription ?? '',
+    imageUrl:
+      raw?.imageUrl ??
+      raw?.image_url ??
+      raw?.setupImageUrl ??
+      raw?.setup_image_url ??
+      '/placeholder-setup.jpg',
     product_ids: uniqueProductIds,
     tags,
     tip: raw?.tip_text ?? raw?.tipText ?? raw?.tip ?? '',


### PR DESCRIPTION
## 📝 작업 내용
- 셋업 리스트/상세에서 이미지가 안 보이던 문제를 해결하기 위해, setup API 응답의 snake_case/camelCase 필드를 프론트 정규화 로직에서 모두 지원하도록 확장했습니다.
- 페이지 컴포넌트 수정 없이 `front/src/api/setups.ts`의 normalize 단계에서만 흡수해 기존 렌더링 코드는 유지했습니다.