### PR TITLE
[FIX] 셋업 이미지 URL 경로 해석/정규화 적용 (S3 key 지원)

### DIFF
--- a/front/src/api/home.ts
+++ b/front/src/api/home.ts
@@ -1,6 +1,7 @@
 import { http } from './http'
 import { endpoints } from './endpoints'
 import { fetchListTextJsonWithRetry } from './api-text-json'
+import { resolveSetupImageUrl } from './setups'
 
 export type HomePopularProduct = {
   product_id: number
@@ -31,5 +32,8 @@ export const listPopularSetups = async (limit = 6): Promise<HomePopularSetup[]> 
     params: { limit },
     validateStatus: (status) => (status >= 200 && status < 300) || status === 304,
   })
-  return payload as HomePopularSetup[]
+  return (payload as HomePopularSetup[]).map((item) => ({
+    ...item,
+    image_url: resolveSetupImageUrl(item.image_url ?? undefined),
+  }))
 }

--- a/front/src/api/setups.ts
+++ b/front/src/api/setups.ts
@@ -7,6 +7,28 @@ import {
   isPlainObject,
 } from './api-text-json'
 
+const storageBase = (() => {
+  const base = import.meta.env.VITE_STORAGE_BASE_URL ?? 'https://kr.object.ncloudstorage.com/live-commerce-bucket/'
+  return base.endsWith('/') ? base : `${base}/`
+})()
+
+export const resolveSetupImageUrl = (rawValue?: string) => {
+  const value = (rawValue ?? '').trim()
+  if (!value) return '/placeholder-setup.jpg'
+  if (value.startsWith('http://') || value.startsWith('https://')) return value
+  if (value.startsWith('/live-commerce-bucket/')) {
+    return storageBase + value.replace(/^\/live-commerce-bucket\/+/, '')
+  }
+  if (value.startsWith('live-commerce-bucket/')) {
+    return storageBase + value.replace(/^live-commerce-bucket\/+/, '')
+  }
+  if (value.startsWith('seller_')) {
+    return storageBase + value
+  }
+  if (value.startsWith('/')) return value
+  return value
+}
+
 const normalizeSetup = (raw: any): SetupWithProducts => {
   const productIdsRaw = raw?.product_ids ?? raw?.productIds ?? raw?.productIdsRaw
   const setupProducts = raw?.setup_products ?? raw?.setupProducts
@@ -36,12 +58,9 @@ const normalizeSetup = (raw: any): SetupWithProducts => {
     setup_id: raw?.setup_id ?? raw?.setupId ?? raw?.id ?? 0,
     title: raw?.title ?? raw?.setupName ?? raw?.setup_name ?? raw?.setup_title ?? raw?.name ?? '',
     short_desc: raw?.short_desc ?? raw?.shortDesc ?? raw?.description ?? raw?.shortDescription ?? '',
-    imageUrl:
-      raw?.imageUrl ??
-      raw?.image_url ??
-      raw?.setupImageUrl ??
-      raw?.setup_image_url ??
-      '/placeholder-setup.jpg',
+    imageUrl: resolveSetupImageUrl(
+      raw?.imageUrl ?? raw?.image_url ?? raw?.setupImageUrl ?? raw?.setup_image_url
+    ),
     product_ids: uniqueProductIds,
     tags,
     tip: raw?.tip_text ?? raw?.tipText ?? raw?.tip ?? '',

--- a/front/src/pages/Home.vue
+++ b/front/src/pages/Home.vue
@@ -38,12 +38,15 @@ const buildProductItems = (items: Awaited<ReturnType<typeof listPopularProducts>
   }))
 
 const buildSetupItems = (items: Awaited<ReturnType<typeof listPopularSetups>>) =>
-  items.map((item) => ({
-    id: String(item.setup_id),
-    title: item.name ?? '',
-    description: item.short_desc ?? '',
-    imageUrl: item.image_url || '/placeholder-setup.jpg',
-  }))
+  items.map((item) => {
+    const raw = item as any
+    return {
+      id: String(raw.setup_id ?? raw.setupId ?? raw.id ?? ''),
+      title: raw.setup_name ?? raw.setupName ?? raw.name ?? raw.title ?? '',
+      description: raw.short_desc ?? raw.shortDesc ?? raw.description ?? '',
+      imageUrl: raw.setup_image_url ?? raw.setupImageUrl ?? raw.image_url ?? raw.imageUrl ?? '/placeholder-setup.jpg',
+    }
+  })
 
 const loadPopulars = async () => {
   popularProductsLoading.value = true


### PR DESCRIPTION
## 📝 작업 내용
- Setup API 응답 필드(snake_case/camelCase) 정규화 범위 확장 및 타입 정리
  - setup_id/setupId/id
  - setup_name/setupName/name/title
  - short_desc/shortDesc/description
  - setup_image_url/setupImageUrl/image_url/imageUrl
- 셋업 이미지 URL 해석 로직 추가
  - DB에 `seller_...` 형태 key 저장 시 `VITE_STORAGE_BASE_URL` 기준으로 절대 URL로 변환
  - `/live-commerce-bucket/...` prefix 케이스도 동일하게 정규화
  - 값이 없으면 `/placeholder-setup.jpg` fallback 유지
- Home 인기 셋업 API에서도 동일한 이미지 URL 해석 적용 (Home.vue에 산재한 처리 제거/중앙화)