### PR TITLE
[FEAT] 판매자 상품관리 썸네일 이미지 로딩 지원

### DIFF
--- a/front/src/lib/images/productImages.ts
+++ b/front/src/lib/images/productImages.ts
@@ -55,6 +55,22 @@ export const resolvePrimaryImage = (raw: any): string => {
   return list[0] ?? PLACEHOLDER_IMAGE
 }
 
+export const resolveProductImageUrlFromRaw = (raw: any): string => {
+  const primary = resolvePrimaryImage(raw) || PLACEHOLDER_IMAGE
+  if (primary.startsWith('http://') || primary.startsWith('https://')) return primary
+  if (primary.startsWith('/live-commerce-bucket/')) {
+    return `${getStorageBaseUrl()}${primary.replace(/^\/+live-commerce-bucket\/+/, '')}`
+  }
+  if (primary.startsWith('live-commerce-bucket/')) {
+    return `${getStorageBaseUrl()}${primary.replace(/^live-commerce-bucket\/+/, '')}`
+  }
+  if (primary.startsWith('seller_')) {
+    return `${getStorageBaseUrl()}${primary.replace(/^\/+/, '')}`
+  }
+  if (primary.startsWith('/')) return primary
+  return primary || PLACEHOLDER_IMAGE
+}
+
 const warnedImageSources = new Set<string>()
 
 export const createImageErrorHandler = () => {


### PR DESCRIPTION
## 📌 관련 이슈
- closes #528 

## 📝 작업 내용
- 판매자 상품관리(/seller/products)에서 상품 썸네일이 object storage URL로 정규화되도록 공용 resolver 추가
- Products.vue에서 placeholder div 대신 img 렌더링 + onerror 핸들링 적용
