### PR TITLE
 [FIX] 판매자 상품 목록에 썸네일 URL 제공

### DIFF
--- a/front/src/lib/images/productImages.ts
+++ b/front/src/lib/images/productImages.ts
@@ -11,8 +11,12 @@ export const extractImageUrl = (image: any): string => {
   const direct =
     image?.product_image_url ??
     image?.productImageUrl ??
+    image?.product_thumbnail_url ??
+    image?.productThumbnailUrl ??
     image?.image_url ??
     image?.imageUrl ??
+    image?.thumb_url ??
+    image?.thumbUrl ??
     image?.thumbnail_url ??
     image?.thumbnailUrl
   if (direct) return direct

--- a/src/main/java/com/deskit/deskit/product/dto/SellerProductListResponse.java
+++ b/src/main/java/com/deskit/deskit/product/dto/SellerProductListResponse.java
@@ -21,11 +21,14 @@ public record SellerProductListResponse(
   Integer stockQty,
 
   @JsonProperty("created_at")
-  LocalDateTime createdAt
+  LocalDateTime createdAt,
+
+  @JsonProperty("thumbnail_url")
+  String thumbnailUrl
 ) {
-  public static SellerProductListResponse from(Product product) {
+  public static SellerProductListResponse from(Product product, String thumbnailUrl) {
     if (product == null) {
-      return new SellerProductListResponse(null, null, null, null, null, null);
+      return new SellerProductListResponse(null, null, null, null, null, null, null);
     }
     Product.Status displayStatus =
       product.isLimitedSale() ? Product.Status.LIMITED_SALE : product.getStatus();
@@ -35,7 +38,8 @@ public record SellerProductListResponse(
       product.getPrice(),
       displayStatus,
       product.getStockQty(),
-      product.getCreatedAt()
+      product.getCreatedAt(),
+      thumbnailUrl
     );
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closes #531 

## 📝 작업 내용
- 판매자 상품 목록 API 응답(SellerProductListResponse)에 `thumbnail_url` 필드 추가
- ProductService.getSellerProducts에서 product_image 테이블의 THUMBNAIL(slot 0) 이미지를 조회해 `thumbnail_url`로 주입
- S3 키 형태(`seller_...`)인 경우 AwsS3Service.buildPublicUrl로 절대 URL로 resolve (http/https, / 경로는 그대로 통과)