### PR TITLE
Fix seller live stream product thumbnail resolution

### DIFF
--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -33,7 +33,7 @@ import { useNow } from '../../lib/live/useNow'
 import { getAuthUser } from '../../lib/auth'
 import { resolveViewerId } from '../../lib/live/viewer'
 import { computeLifecycleStatus, getScheduledEndMs, normalizeBroadcastStatus, type BroadcastStatus } from '../../lib/broadcastStatus'
-import { createImageErrorHandler } from '../../lib/images/productImages'
+import { createImageErrorHandler, resolveProductImageUrlFromRaw } from '../../lib/images/productImages'
 // import { resolveWsBase } from '../../lib/ws'
 import SockJS from 'sockjs-client/dist/sockjs'
 import { resolveSockJsUrl } from '../../lib/ws'
@@ -480,7 +480,7 @@ const mapStreamProduct = (product: NonNullable<BroadcastDetailResponse['products
     sale: formatPrice(product.bpPrice),
     sold,
     stock: stockQty,
-    thumb: product.imageUrl ?? '',
+    thumb: resolveProductImageUrlFromRaw(product),
     pinned: product.pinned,
   }
 }


### PR DESCRIPTION
### Motivation

- Seller live stream product thumbnails in the 상품 관리 panel could be empty or incorrect because raw product image fields were used directly instead of the shared resolver that handles storage paths and fallbacks.

### Description

- Import `resolveProductImageUrlFromRaw` from `front/src/lib/images/productImages` in `LiveStream.vue`.
- Replace `thumb: product.imageUrl ?? ''` with `thumb: resolveProductImageUrlFromRaw(product)` in the `mapStreamProduct` mapper so thumbnails use the centralized URL resolution and placeholder logic.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696df5698048832aaff180fd67299030)