### PR TITLE
Record only publisher stream and default viewer role to SUBSCRIBER

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
@@ -88,13 +88,17 @@ public class OpenViduService {
             session = openVidu.getActiveSession(sessionId);
         }
 
-        OpenViduRole role = OpenViduRole.PUBLISHER;
+        OpenViduRole role = OpenViduRole.SUBSCRIBER;
         if (params != null && params.containsKey("role")) {
             String requestedRole = String.valueOf(params.get("role"));
             if ("HOST".equalsIgnoreCase(requestedRole)) {
                 role = OpenViduRole.PUBLISHER;
-            } else {
-                role = OpenViduRole.valueOf(requestedRole.toUpperCase());
+            } else if ("PUBLISHER".equalsIgnoreCase(requestedRole)) {
+                role = OpenViduRole.PUBLISHER;
+            } else if ("MODERATOR".equalsIgnoreCase(requestedRole)) {
+                role = OpenViduRole.MODERATOR;
+            } else if ("SUBSCRIBER".equalsIgnoreCase(requestedRole)) {
+                role = OpenViduRole.SUBSCRIBER;
             }
         }
 
@@ -129,7 +133,7 @@ public class OpenViduService {
 
     private RecordingProperties buildRecordingProperties() {
         return new RecordingProperties.Builder()
-                .outputMode(Recording.OutputMode.COMPOSED) // 방송 화면 그대로(하나의 비디오) 녹화
+                .outputMode(Recording.OutputMode.INDIVIDUAL) // 판매자(퍼블리셔) 스트림만 별도 파일로 녹화
                 .hasAudio(true)
                 .hasVideo(true)
                 .build();


### PR DESCRIPTION
### Motivation
- Ensure viewer tokens default to `SUBSCRIBER` so only the host/seller can publish and avoid unexpected role strings causing runtime issues.
- Capture only the seller (publisher) camera and audio during recording rather than the entire composed broadcast.

### Description
- Changed the default role in `createToken` to `OpenViduRole.SUBSCRIBER` and replaced the `valueOf` lookup with explicit handling for `HOST`, `PUBLISHER`, `MODERATOR`, and `SUBSCRIBER` in `src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java`.
- Switched OpenVidu recording `outputMode` from `Recording.OutputMode.COMPOSED` to `Recording.OutputMode.INDIVIDUAL` in `buildRecordingProperties()` so publisher streams are recorded as separate files.
- Preserved audio/video flags by keeping `hasAudio(true)` and `hasVideo(true)` in the recording properties.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dfe3a9e9c832aa29fc91bab6e28ba)