### PR TITLE
Record composed BEST_FIT layout for seller and keep SUBSCRIBER as default role

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
@@ -8,6 +8,7 @@ import io.openvidu.java.client.OpenViduHttpException;
 import io.openvidu.java.client.OpenViduJavaClientException;
 import io.openvidu.java.client.OpenViduRole;
 import io.openvidu.java.client.Recording;
+import io.openvidu.java.client.RecordingLayout;
 import io.openvidu.java.client.RecordingMode;
 import io.openvidu.java.client.RecordingProperties;
 import io.openvidu.java.client.Session;
@@ -88,13 +89,17 @@ public class OpenViduService {
             session = openVidu.getActiveSession(sessionId);
         }
 
-        OpenViduRole role = OpenViduRole.PUBLISHER;
+        OpenViduRole role = OpenViduRole.SUBSCRIBER;
         if (params != null && params.containsKey("role")) {
             String requestedRole = String.valueOf(params.get("role"));
             if ("HOST".equalsIgnoreCase(requestedRole)) {
                 role = OpenViduRole.PUBLISHER;
-            } else {
-                role = OpenViduRole.valueOf(requestedRole.toUpperCase());
+            } else if ("PUBLISHER".equalsIgnoreCase(requestedRole)) {
+                role = OpenViduRole.PUBLISHER;
+            } else if ("MODERATOR".equalsIgnoreCase(requestedRole)) {
+                role = OpenViduRole.MODERATOR;
+            } else if ("SUBSCRIBER".equalsIgnoreCase(requestedRole)) {
+                role = OpenViduRole.SUBSCRIBER;
             }
         }
 
@@ -129,7 +134,8 @@ public class OpenViduService {
 
     private RecordingProperties buildRecordingProperties() {
         return new RecordingProperties.Builder()
-                .outputMode(Recording.OutputMode.COMPOSED) // 방송 화면 그대로(하나의 비디오) 녹화
+                .outputMode(Recording.OutputMode.COMPOSED) // 판매자(퍼블리셔) 스트림만 보이도록 단일 파일로 녹화
+                .recordingLayout(RecordingLayout.BEST_FIT)
                 .hasAudio(true)
                 .hasVideo(true)
                 .build();


### PR DESCRIPTION
### Motivation
- Ensure viewer tokens default to `SUBSCRIBER` to prevent unintended publishing and apply a composed recording layout that highlights the seller in a single output file.

### Description
- Set the default connection `role` to `OpenViduRole.SUBSCRIBER` and replace `valueOf` lookup with explicit handling for `HOST`, `PUBLISHER`, `MODERATOR`, and `SUBSCRIBER` in `OpenViduService`.
- Switch recording `outputMode` back to `Recording.OutputMode.COMPOSED` and add `.recordingLayout(RecordingLayout.BEST_FIT)` to produce a single composed video with a fixed BEST_FIT layout.
- Add the `RecordingLayout` import and keep `hasAudio(true)` and `hasVideo(true)` in the recording properties.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dfe3a9e9c832aa29fc91bab6e28ba)