### PR TITLE
Switch OpenVidu VOD pipeline to INDIVIDUAL recordings and add ZIP-based extraction

### DIFF
--- a/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
+++ b/src/main/java/com/deskit/deskit/livehost/service/OpenViduService.java
@@ -8,7 +8,6 @@ import io.openvidu.java.client.OpenViduHttpException;
 import io.openvidu.java.client.OpenViduJavaClientException;
 import io.openvidu.java.client.OpenViduRole;
 import io.openvidu.java.client.Recording;
-import io.openvidu.java.client.RecordingLayout;
 import io.openvidu.java.client.RecordingMode;
 import io.openvidu.java.client.RecordingProperties;
 import io.openvidu.java.client.Session;
@@ -134,8 +133,7 @@ public class OpenViduService {
 
     private RecordingProperties buildRecordingProperties() {
         return new RecordingProperties.Builder()
-                .outputMode(Recording.OutputMode.COMPOSED) // 판매자(퍼블리셔) 스트림만 보이도록 단일 파일로 녹화
-                .recordingLayout(RecordingLayout.BEST_FIT)
+                .outputMode(Recording.OutputMode.INDIVIDUAL) // 퍼블리셔 스트림을 개별 파일로 저장
                 .hasAudio(true)
                 .hasVideo(true)
                 .build();


### PR DESCRIPTION
### Motivation
- Record per-publisher streams instead of a single composed file so individual-stream outputs are available for processing (`INDIVIDUAL` recording mode). 
- Support OpenVidu's individual-recording ZIP outputs by extracting the best MP4 and uploading it to object storage, while keeping a fallback for legacy single MP4 recordings.

### Description
- Change recording mode in `OpenViduService` to use `Recording.OutputMode.INDIVIDUAL` and remove the unused `RecordingLayout` import.
- In `BroadcastService` update `uploadVodWithRetry` to attempt uploading from a recording ZIP first (`.zip`) and fall back to the single MP4 (`.mp4`) URL when ZIP extraction fails.
- Add `uploadFromIndividualZip` which streams the ZIP, extracts MP4 entries to temporary files, picks the largest MP4, uploads it via `s3Service.uploadVodStream`, and cleans up temp files.
- Add `uploadFromSingleMp4` and `openAuthorizedConnection` helper methods and related imports (`ZipInputStream`, `ZipEntry`, `StandardCopyOption`) to centralize OpenVidu auth handling and reduce duplication.

### Testing
- No automated tests were executed as part of this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e0c739e6c832aa5419d54e98cfe68)