### PR TITLE
Start recording after tracksReady (remove streamCreated trigger)

### DIFF
--- a/front/src/pages/seller/LiveStream.vue
+++ b/front/src/pages/seller/LiveStream.vue
@@ -712,7 +712,6 @@ const resetOpenViduState = () => {
 const attachPublisherHandlers = (publisher: Publisher, broadcastId?: number) => {
   publisher.on('streamCreated', () => {
     if (!broadcastId) return
-    void requestStartRecording(broadcastId)
   })
   publisher.on('streamDestroyed', (event: StreamEvent) => {
     event.preventDefault()


### PR DESCRIPTION
### Motivation
- Prevent starting recording immediately on `streamCreated` so recording only begins after publisher media tracks are ready (e.g. via `waitForPublisherTracks`).

### Description
- Removed the `void requestStartRecording(broadcastId)` call from `attachPublisherHandlers` so `publisher.on('streamCreated', ...)` no longer triggers recording.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e12862830832ab2b640adfe4d8290)